### PR TITLE
Fix past matches sorting and voting disable logic

### DIFF
--- a/apps/api/src/routes/matches.ts
+++ b/apps/api/src/routes/matches.ts
@@ -35,6 +35,7 @@ app.get(
 
     const result = await getMatchService().getAllMatches({
       status,
+      sortDirection: type === "past" ? "desc" : "asc",
       limit,
       offset,
       userId, // Pass userId to get user's signup status

--- a/apps/mobile-web/app/stats-voting.tsx
+++ b/apps/mobile-web/app/stats-voting.tsx
@@ -47,8 +47,11 @@ interface VotingCriteria {
   description: string | null;
 }
 
+// UserMatchVotes from @repo/shared/domain — re-declared here because
+// this file uses @ts-nocheck and can't rely on cross-package type resolution.
 interface UserVotes {
-  hasVoted: boolean;
+  matchId: string;
+  voterUserId: string;
   votes: Array<{
     criteriaId: string;
     votedForUserId: string;
@@ -283,7 +286,7 @@ export default function StatsVotingScreen() {
     }));
   };
 
-  const hasVoted = userVotesData?.hasVoted || false;
+  const hasVoted = (userVotesData?.votes?.length ?? 0) > 0;
   const hasSubmittedStats = !!getMyStats(matchStatsData);
 
   // Lock form only when both applicable parts are done:

--- a/apps/mobile-web/app/stats-voting.tsx
+++ b/apps/mobile-web/app/stats-voting.tsx
@@ -408,7 +408,7 @@ export default function StatsVotingScreen() {
             </Card>
 
             {/* Already voted banner */}
-            {!!selectedMatchId && isLocked && (
+            {!!selectedMatchId && hasVoted && (
               <XStack
                 backgroundColor="$green3"
                 padding="$3"

--- a/packages/shared/src/domain/types.ts
+++ b/packages/shared/src/domain/types.ts
@@ -313,6 +313,7 @@ export interface MatchFilters {
   locationId?: string;
   dateFrom?: string;
   dateTo?: string;
+  sortDirection?: "asc" | "desc";
 }
 
 export interface SignupFilters {

--- a/packages/shared/src/repositories/turso-repositories.ts
+++ b/packages/shared/src/repositories/turso-repositories.ts
@@ -472,9 +472,12 @@ export class TursoMatchRepository implements MatchRepository {
         "locations.court_count as location_court_count",
         "locations.created_at as location_created_at",
         "locations.updated_at as location_updated_at",
-      ])
-      .orderBy("matches.date", "asc")
-      .orderBy("matches.time", "asc");
+      ]);
+
+    const sortDir = filters?.sortDirection ?? "asc";
+    dataQuery = dataQuery
+      .orderBy("matches.date", sortDir)
+      .orderBy("matches.time", sortDir);
 
     // Apply pagination
     if (filters?.limit) {


### PR DESCRIPTION
## Summary
- **Past matches sorted newest-first**: Added `sortDirection` to `MatchFilters` and pass `"desc"` from the API when fetching past matches. Previously hardcoded as ASC.
- **Voting controls now properly disabled after voting**: The client expected a `hasVoted` boolean field from the API that was never returned (`UserMatchVotes` has no such field). Changed to derive `hasVoted` from `votes.length > 0`, which correctly disables dropdowns and hides the submit button.
