### PR TITLE
Fix auth navigation links and add forgot password flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# Screenshots
+screenshots/
+
 # Dependencies
 node_modules/
 .pnp

--- a/apps/api/app.json
+++ b/apps/api/app.json
@@ -1,5 +1,0 @@
-{
-  "ios": {
-    "bundleIdentifier": "com.pepegrillo.api"
-  }
-}

--- a/apps/api/app.json
+++ b/apps/api/app.json
@@ -1,0 +1,5 @@
+{
+  "ios": {
+    "bundleIdentifier": "com.pepegrillo.api"
+  }
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,7 +24,9 @@
     "hono": "^4.12.8",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "expo": "~55.0.11",
+    "react-native": "0.83.4"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260316.1",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,9 +24,7 @@
     "hono": "^4.12.8",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "zod": "^4.3.6",
-    "expo": "~55.0.11",
-    "react-native": "0.83.4"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260316.1",

--- a/apps/api/src/routes/phone-auth.ts
+++ b/apps/api/src/routes/phone-auth.ts
@@ -206,6 +206,241 @@ app.post("/reset-password", zValidator("json", resetPasswordSchema), async (c) =
   }
 });
 
+/**
+ * Forgot password: generate a 6-digit reset code and store it in the verification table.
+ * The code must be relayed to the user by the admin via WhatsApp.
+ * Always returns success to prevent user enumeration.
+ */
+const forgotPasswordSchema = z.object({
+  phoneNumber: z.string().optional(),
+  email: z.string().email().optional(),
+}).refine((data) => data.phoneNumber || data.email, {
+  message: "Either phoneNumber or email is required",
+});
+
+function generateResetCode(): string {
+  const digits = "0123456789";
+  let code = "";
+  const array = new Uint8Array(6);
+  crypto.getRandomValues(array);
+  for (let i = 0; i < 6; i++) {
+    code += digits[array[i] % 10];
+  }
+  return code;
+}
+
+app.post("/forgot-password", zValidator("json", forgotPasswordSchema), async (c) => {
+  const { phoneNumber, email } = c.req.valid("json");
+  const identifier = phoneNumber || email!;
+
+  try {
+    const db = getDatabase();
+
+    // Look up user (silent success if not found)
+    let query = db.selectFrom("user").select("id");
+    if (phoneNumber) {
+      query = query.where("phoneNumber", "=", phoneNumber);
+    } else if (email) {
+      query = query.where("email", "=", email);
+    }
+    const user = await query.executeTakeFirst();
+
+    if (user) {
+      const code = generateResetCode();
+      const now = Date.now();
+      const expiresAt = now + 15 * 60 * 1000; // 15 minutes
+      const verificationId = `forgot:${identifier}`;
+
+      // Delete any existing reset code for this identifier
+      await db
+        .deleteFrom("verification")
+        .where("identifier", "=", verificationId)
+        .execute();
+
+      // Insert new reset code
+      await db
+        .insertInto("verification")
+        .values({
+          id: crypto.randomUUID(),
+          identifier: verificationId,
+          value: `${code}:0`, // code:attempts
+          expiresAt,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .execute();
+
+      console.log(`[AUTH] Password reset code generated for ${identifier}`);
+    }
+
+    // Always return success to prevent enumeration
+    return c.json({ success: true });
+  } catch (error) {
+    console.error("forgot-password error:", error);
+    return c.json({ success: true }); // Still return success
+  }
+});
+
+/**
+ * Verify reset code and set new password.
+ * Rate-limited to 3 attempts per code.
+ */
+const verifyResetSchema = z.object({
+  phoneNumber: z.string().optional(),
+  email: z.string().email().optional(),
+  code: z.string().length(6, "Code must be 6 digits"),
+  newPassword: z.string().min(8, "Password must be at least 8 characters"),
+}).refine((data) => data.phoneNumber || data.email, {
+  message: "Either phoneNumber or email is required",
+});
+
+app.post("/verify-reset", zValidator("json", verifyResetSchema), async (c) => {
+  const { phoneNumber, email, code, newPassword } = c.req.valid("json");
+  const identifier = phoneNumber || email!;
+  const verificationId = `forgot:${identifier}`;
+
+  try {
+    const db = getDatabase();
+
+    // Find the verification entry
+    const verification = await db
+      .selectFrom("verification")
+      .select(["id", "value", "expiresAt"])
+      .where("identifier", "=", verificationId)
+      .executeTakeFirst();
+
+    if (!verification) {
+      return c.json({ error: "Invalid or expired reset code" }, 400);
+    }
+
+    // Check expiry
+    if (verification.expiresAt < Date.now()) {
+      await db.deleteFrom("verification").where("id", "=", verification.id).execute();
+      return c.json({ error: "Reset code has expired. Please request a new one." }, 400);
+    }
+
+    // Check attempts
+    const [storedCode, attemptsStr] = verification.value.split(":");
+    const attempts = parseInt(attemptsStr || "0");
+    if (attempts >= 3) {
+      await db.deleteFrom("verification").where("id", "=", verification.id).execute();
+      return c.json({ error: "Too many attempts. Please request a new code." }, 400);
+    }
+
+    // Verify code
+    if (code !== storedCode) {
+      // Increment attempts
+      await db
+        .updateTable("verification")
+        .set({ value: `${storedCode}:${attempts + 1}`, updatedAt: Date.now() })
+        .where("id", "=", verification.id)
+        .execute();
+      return c.json({ error: "Invalid reset code" }, 400);
+    }
+
+    // Find user
+    let userQuery = db.selectFrom("user").select("id");
+    if (phoneNumber) {
+      userQuery = userQuery.where("phoneNumber", "=", phoneNumber);
+    } else if (email) {
+      userQuery = userQuery.where("email", "=", email);
+    }
+    const user = await userQuery.executeTakeFirst();
+
+    if (!user) {
+      return c.json({ error: "Unable to reset password" }, 400);
+    }
+
+    // Get credential account
+    const account = await db
+      .selectFrom("account")
+      .select(["id"])
+      .where("userId", "=", user.id)
+      .where("providerId", "=", "credential")
+      .executeTakeFirst();
+
+    if (!account) {
+      return c.json({ error: "Unable to reset password" }, 400);
+    }
+
+    // Hash and update password
+    const newHash = await hashPassword(newPassword);
+    await db
+      .updateTable("account")
+      .set({ password: newHash })
+      .where("id", "=", account.id)
+      .execute();
+
+    // Clean up verification entry
+    await db.deleteFrom("verification").where("id", "=", verification.id).execute();
+
+    console.log(`[AUTH] Password reset successful for ${identifier}`);
+    return c.json({ success: true });
+  } catch (error) {
+    console.error("verify-reset error:", error);
+    return c.json({ error: "Unable to reset password" }, 500);
+  }
+});
+
+/**
+ * Admin-only: list pending password reset codes.
+ * Used by the admin to look up codes when users request resets via WhatsApp.
+ */
+app.get("/admin/reset-codes", async (c) => {
+  try {
+    // This route is under /api/phone-auth/ which is in the public allowlist,
+    // so the global auth middleware doesn't run. Manually verify the session.
+    const session = await auth.api.getSession({
+      headers: c.req.raw.headers,
+    });
+    if (!session?.user || (session.user as any).role !== "admin") {
+      return c.json({ error: "Forbidden" }, 403);
+    }
+
+    const db = getDatabase();
+    const codes = await db
+      .selectFrom("verification")
+      .select(["identifier", "value", "expiresAt"])
+      .where("identifier", "like", "forgot:%")
+      .execute();
+
+    const result = codes
+      .filter((v) => v.expiresAt > Date.now()) // Only non-expired
+      .map((v) => {
+        const [code] = v.value.split(":");
+        const userIdentifier = v.identifier.replace("forgot:", "");
+        return {
+          identifier: userIdentifier,
+          code,
+          expiresAt: new Date(v.expiresAt).toISOString(),
+        };
+      });
+
+    return c.json({ codes: result });
+  } catch (error) {
+    console.error("admin/reset-codes error:", error);
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+});
+
+/**
+ * Public endpoint to get the organizer's WhatsApp number.
+ * Used by the forgot-password screen (which is shown to unauthenticated users).
+ */
+app.get("/organizer-contact", async (c) => {
+  try {
+    const db = getDatabase();
+    const settings = await db
+      .selectFrom("settings")
+      .select(["organizer_whatsapp"])
+      .executeTakeFirst();
+
+    return c.json({ whatsapp: settings?.organizer_whatsapp || null });
+  } catch {
+    return c.json({ whatsapp: null });
+  }
+});
+
 // Named export for worker.ts (Cloudflare Workers)
 export { app as phoneAuthRoute };
 

--- a/apps/api/src/routes/phone-auth.ts
+++ b/apps/api/src/routes/phone-auth.ts
@@ -402,11 +402,10 @@ app.get("/admin/reset-codes", async (c) => {
       .selectFrom("verification")
       .select(["identifier", "value", "expiresAt"])
       .where("identifier", "like", "forgot:%")
+      .where("expiresAt", ">", Date.now())
       .execute();
 
-    const result = codes
-      .filter((v) => v.expiresAt > Date.now()) // Only non-expired
-      .map((v) => {
+    const result = codes.map((v) => {
         const [code] = v.value.split(":");
         const userIdentifier = v.identifier.replace("forgot:", "");
         return {

--- a/apps/api/src/routes/phone-auth.ts
+++ b/apps/api/src/routes/phone-auth.ts
@@ -423,23 +423,6 @@ app.get("/admin/reset-codes", async (c) => {
   }
 });
 
-/**
- * Public endpoint to get the organizer's WhatsApp number.
- * Used by the forgot-password screen (which is shown to unauthenticated users).
- */
-app.get("/organizer-contact", async (c) => {
-  try {
-    const db = getDatabase();
-    const settings = await db
-      .selectFrom("settings")
-      .select(["organizer_whatsapp"])
-      .executeTakeFirst();
-
-    return c.json({ whatsapp: settings?.organizer_whatsapp || null });
-  } catch {
-    return c.json({ whatsapp: null });
-  }
-});
 
 // Named export for worker.ts (Cloudflare Workers)
 export { app as phoneAuthRoute };

--- a/apps/api/src/routes/phone-auth.ts
+++ b/apps/api/src/routes/phone-auth.ts
@@ -270,7 +270,7 @@ app.post("/forgot-password", zValidator("json", forgotPasswordSchema), async (c)
         })
         .execute();
 
-      console.log(`[AUTH] Password reset code generated for ${identifier}`);
+      console.log("[AUTH] Password reset code generated");
     }
 
     // Always return success to prevent enumeration
@@ -288,7 +288,7 @@ app.post("/forgot-password", zValidator("json", forgotPasswordSchema), async (c)
 const verifyResetSchema = z.object({
   phoneNumber: z.string().optional(),
   email: z.string().min(1).optional(),
-  code: z.string().length(6, "Code must be 6 digits"),
+  code: z.string().length(6, "Code must be 6 digits").regex(/^\d{6}$/, "Code must be numeric"),
   newPassword: z.string().min(8, "Password must be at least 8 characters"),
 }).refine((data) => data.phoneNumber || data.email, {
   message: "Either phoneNumber or email is required",
@@ -374,7 +374,7 @@ app.post("/verify-reset", zValidator("json", verifyResetSchema), async (c) => {
     // Clean up verification entry
     await db.deleteFrom("verification").where("id", "=", verification.id).execute();
 
-    console.log(`[AUTH] Password reset successful for ${identifier}`);
+    console.log("[AUTH] Password reset successful");
     return c.json({ success: true });
   } catch (error) {
     console.error("verify-reset error:", error);

--- a/apps/api/src/routes/phone-auth.ts
+++ b/apps/api/src/routes/phone-auth.ts
@@ -270,7 +270,6 @@ app.post("/forgot-password", zValidator("json", forgotPasswordSchema), async (c)
         })
         .execute();
 
-      console.log("[AUTH] Password reset code generated");
     }
 
     // Always return success to prevent enumeration
@@ -374,7 +373,6 @@ app.post("/verify-reset", zValidator("json", verifyResetSchema), async (c) => {
     // Clean up verification entry
     await db.deleteFrom("verification").where("id", "=", verification.id).execute();
 
-    console.log("[AUTH] Password reset successful");
     return c.json({ success: true });
   } catch (error) {
     console.error("verify-reset error:", error);

--- a/apps/api/src/routes/phone-auth.ts
+++ b/apps/api/src/routes/phone-auth.ts
@@ -213,7 +213,7 @@ app.post("/reset-password", zValidator("json", resetPasswordSchema), async (c) =
  */
 const forgotPasswordSchema = z.object({
   phoneNumber: z.string().optional(),
-  email: z.string().email().optional(),
+  email: z.string().min(1).optional(),
 }).refine((data) => data.phoneNumber || data.email, {
   message: "Either phoneNumber or email is required",
 });
@@ -287,7 +287,7 @@ app.post("/forgot-password", zValidator("json", forgotPasswordSchema), async (c)
  */
 const verifyResetSchema = z.object({
   phoneNumber: z.string().optional(),
-  email: z.string().email().optional(),
+  email: z.string().min(1).optional(),
   code: z.string().length(6, "Code must be 6 digits"),
   newPassword: z.string().min(8, "Password must be at least 8 characters"),
 }).refine((data) => data.phoneNumber || data.email, {

--- a/apps/mobile-web/app.json
+++ b/apps/mobile-web/app.json
@@ -33,7 +33,15 @@
       "expo-localization",
       "expo-secure-store",
       "expo-sqlite",
-      "expo-web-browser"
+      "expo-web-browser",
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "deploymentTarget": "15.1"
+          }
+        }
+      ]
     ],
     "splash": {
       "image": "./assets/splash-icon.png",
@@ -41,9 +49,9 @@
       "backgroundColor": "#ffffff"
     },
     "ios": {
-      "supportsTablet": true,
+      "supportsTablet": false,
       "bundleIdentifier": "com.pepegrillo.football-with-friends",
-      "buildNumber": "2",
+      "buildNumber": "7",
       "infoPlist": {
         "NSPhotoLibraryUsageDescription": "Football with Friends uses your photo library to update your profile picture.",
         "NSCameraUsageDescription": "Football with Friends uses your camera to take a profile photo.",

--- a/apps/mobile-web/app/(auth)/_layout.tsx
+++ b/apps/mobile-web/app/(auth)/_layout.tsx
@@ -76,6 +76,12 @@ export default function AuthLayout() {
           headerTitle: "",
         }}
       />
+      <Stack.Screen
+        name="forgot-password"
+        options={{
+          headerTitle: "",
+        }}
+      />
     </Stack>
   );
 }

--- a/apps/mobile-web/app/(auth)/email-signin.tsx
+++ b/apps/mobile-web/app/(auth)/email-signin.tsx
@@ -48,16 +48,12 @@ export default function EmailSignInScreen() {
     setServerError(null);
 
     try {
-      console.log(`[EMAIL-AUTH] Signing in with ${data.email}`);
       const result = await signIn.email({
         email: data.email,
         password: data.password,
       });
-      console.log(`[EMAIL-AUTH] Result:`, JSON.stringify(result));
 
       if (result.error) {
-        console.error(`[EMAIL-AUTH] Error:`, result.error);
-        // Check if user needs password reset (old scrypt hash)
         const needs = await needsPasswordReset({ email: data.email });
         if (needs) {
           setShowPasswordReset(true);
@@ -71,7 +67,6 @@ export default function EmailSignInScreen() {
       router.replace("/(tabs)");
     } catch (err) {
       setServerError(t("auth.unexpectedError"));
-      console.error("[EMAIL-AUTH] Exception:", err);
     } finally {
       setIsLoading(false);
     }

--- a/apps/mobile-web/app/(auth)/email-signin.tsx
+++ b/apps/mobile-web/app/(auth)/email-signin.tsx
@@ -10,11 +10,12 @@ import {
   Card,
   Text,
   YStack,
+  XStack,
   Input,
   Button,
   Spinner,
 } from "@repo/ui";
-import { Link, router } from "expo-router";
+import { router } from "expo-router";
 import { useState } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -47,12 +48,15 @@ export default function EmailSignInScreen() {
     setServerError(null);
 
     try {
+      console.log(`[EMAIL-AUTH] Signing in with ${data.email}`);
       const result = await signIn.email({
         email: data.email,
         password: data.password,
       });
+      console.log(`[EMAIL-AUTH] Result:`, JSON.stringify(result));
 
       if (result.error) {
+        console.error(`[EMAIL-AUTH] Error:`, result.error);
         // Check if user needs password reset (old scrypt hash)
         const needs = await needsPasswordReset({ email: data.email });
         if (needs) {
@@ -67,7 +71,7 @@ export default function EmailSignInScreen() {
       router.replace("/(tabs)");
     } catch (err) {
       setServerError(t("auth.unexpectedError"));
-      console.error("Sign in error:", err);
+      console.error("[EMAIL-AUTH] Exception:", err);
     } finally {
       setIsLoading(false);
     }
@@ -118,7 +122,7 @@ export default function EmailSignInScreen() {
       >
         <YStack
           gap="$6"
-          justifyContent="center"
+          width="100%"
           maxWidth={400}
           marginHorizontal="auto"
           paddingVertical="$8"
@@ -132,7 +136,7 @@ export default function EmailSignInScreen() {
             </Text>
           </YStack>
 
-          <Card variant="elevated" padding="$4">
+          <Card variant="elevated" padding="$5" width="100%">
             <YStack gap="$4">
               {!showPasswordReset ? (
                 <>
@@ -180,6 +184,16 @@ export default function EmailSignInScreen() {
                       />
                     )}
                   />
+
+                  <Text
+                    color="$blue10"
+                    fontSize="$3"
+                    textAlign="right"
+                    cursor="pointer"
+                    onPress={() => router.push("/(auth)/forgot-password")}
+                  >
+                    {t("auth.forgotPassword")}
+                  </Text>
                 </>
               ) : (
                 <>
@@ -255,16 +269,17 @@ export default function EmailSignInScreen() {
             </YStack>
           </Card>
 
-          <YStack gap="$2" alignItems="center">
-            <Text color="$gray11">
-              {t("auth.noAccount")}{" "}
-              <Link href="/(auth)/email-signup" asChild>
-                <Text color="$blue10" fontWeight="600" cursor="pointer">
-                  {t("auth.signUpNow")}
-                </Text>
-              </Link>
+          <XStack gap="$1" justifyContent="center">
+            <Text color="$gray11">{t("auth.noAccount")}</Text>
+            <Text
+              color="$blue10"
+              fontWeight="600"
+              cursor="pointer"
+              onPress={() => router.push("/(auth)/email-signup")}
+            >
+              {t("auth.signUpNow")}
             </Text>
-          </YStack>
+          </XStack>
         </YStack>
       </ScrollView>
     </Container>

--- a/apps/mobile-web/app/(auth)/email-signup.tsx
+++ b/apps/mobile-web/app/(auth)/email-signup.tsx
@@ -6,11 +6,12 @@ import {
   Card,
   Text,
   YStack,
+  XStack,
   Input,
   Button,
   Spinner,
 } from "@repo/ui";
-import { Link, router } from "expo-router";
+import { router } from "expo-router";
 import { useState } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -70,7 +71,7 @@ export default function EmailSignUpScreen() {
       >
         <YStack
           gap="$6"
-          justifyContent="center"
+          width="100%"
           maxWidth={400}
           marginHorizontal="auto"
           paddingVertical="$8"
@@ -84,7 +85,7 @@ export default function EmailSignUpScreen() {
             </Text>
           </YStack>
 
-          <Card variant="elevated" padding="$4">
+          <Card variant="elevated" padding="$5" width="100%">
             <YStack gap="$4">
               <Controller
                 control={emailForm.control}
@@ -191,16 +192,17 @@ export default function EmailSignUpScreen() {
             </YStack>
           </Card>
 
-          <YStack gap="$2" alignItems="center">
-            <Text color="$gray11">
-              {t("auth.hasAccount")}{" "}
-              <Link href="/(auth)/email-signin" asChild>
-                <Text color="$blue10" fontWeight="600" cursor="pointer">
-                  {t("auth.signInLink")}
-                </Text>
-              </Link>
+          <XStack gap="$1" justifyContent="center">
+            <Text color="$gray11">{t("auth.hasAccount")}</Text>
+            <Text
+              color="$blue10"
+              fontWeight="600"
+              cursor="pointer"
+              onPress={() => router.push("/(auth)/email-signin")}
+            >
+              {t("auth.signInLink")}
             </Text>
-          </YStack>
+          </XStack>
         </YStack>
       </ScrollView>
     </Container>

--- a/apps/mobile-web/app/(auth)/forgot-password.tsx
+++ b/apps/mobile-web/app/(auth)/forgot-password.tsx
@@ -4,23 +4,20 @@ import {
   resetPasswordWithCode,
   signInWithPhone,
   signIn,
-  getOrganizerContact,
 } from "@repo/api-client";
 import {
   Container,
   Card,
   Text,
   YStack,
-  XStack,
   Input,
   Button,
   Spinner,
-  Image,
 } from "@repo/ui";
 import { router } from "expo-router";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Linking, ScrollView } from "react-native";
+import { ScrollView } from "react-native";
 
 export default function ForgotPasswordScreen() {
   const { t } = useTranslation();
@@ -31,13 +28,6 @@ export default function ForgotPasswordScreen() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [serverError, setServerError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [organizerWhatsapp, setOrganizerWhatsapp] = useState<string | null>(
-    null,
-  );
-
-  useEffect(() => {
-    getOrganizerContact().then(setOrganizerWhatsapp);
-  }, []);
 
   const isPhone = identifier.startsWith("+") || /^\d/.test(identifier);
 
@@ -117,14 +107,6 @@ export default function ForgotPasswordScreen() {
     }
   };
 
-  const openWhatsApp = () => {
-    if (!organizerWhatsapp) return;
-    const message = encodeURIComponent(
-      "Hi, I need my password reset code for Football con los pibes",
-    );
-    Linking.openURL(`https://wa.me/${organizerWhatsapp}?text=${message}`);
-  };
-
   return (
     <Container variant="padded">
       <ScrollView
@@ -164,30 +146,6 @@ export default function ForgotPasswordScreen() {
                 </>
               ) : (
                 <>
-                  {/* WhatsApp contact button */}
-                  {organizerWhatsapp && (
-                    <Button
-                      onPress={openWhatsApp}
-                      variant="outline"
-                      size="$4"
-                    >
-                      <XStack
-                        gap="$2"
-                        alignItems="center"
-                        justifyContent="center"
-                      >
-                        <Image
-                          source={require("../../assets/whatsapp-logo.svg")}
-                          style={{ width: 20, height: 20 }}
-                          tintColor="#25D366"
-                        />
-                        <Text fontSize="$4" fontFamily="$body">
-                          {t("auth.contactOrganizer")}
-                        </Text>
-                      </XStack>
-                    </Button>
-                  )}
-
                   <Input
                     label={t("auth.enterResetCode")}
                     placeholder={t("auth.resetCodePlaceholder")}

--- a/apps/mobile-web/app/(auth)/forgot-password.tsx
+++ b/apps/mobile-web/app/(auth)/forgot-password.tsx
@@ -29,7 +29,7 @@ export default function ForgotPasswordScreen() {
   const [serverError, setServerError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
-  const isPhone = identifier.startsWith("+") || /^\d/.test(identifier);
+  const isPhone = !identifier.includes("@");
 
   const handleRequestCode = async () => {
     if (!identifier.trim()) {

--- a/apps/mobile-web/app/(auth)/forgot-password.tsx
+++ b/apps/mobile-web/app/(auth)/forgot-password.tsx
@@ -1,0 +1,247 @@
+// @ts-nocheck - Tamagui type recursion workaround
+import {
+  requestPasswordReset,
+  resetPasswordWithCode,
+  signInWithPhone,
+  signIn,
+  getOrganizerContact,
+} from "@repo/api-client";
+import {
+  Container,
+  Card,
+  Text,
+  YStack,
+  XStack,
+  Input,
+  Button,
+  Spinner,
+  Image,
+} from "@repo/ui";
+import { router } from "expo-router";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Linking, ScrollView } from "react-native";
+
+export default function ForgotPasswordScreen() {
+  const { t } = useTranslation();
+  const [step, setStep] = useState<"request" | "verify">("request");
+  const [identifier, setIdentifier] = useState("");
+  const [code, setCode] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [organizerWhatsapp, setOrganizerWhatsapp] = useState<string | null>(
+    null,
+  );
+
+  useEffect(() => {
+    getOrganizerContact().then(setOrganizerWhatsapp);
+  }, []);
+
+  const isPhone = identifier.startsWith("+") || /^\d/.test(identifier);
+
+  const handleRequestCode = async () => {
+    if (!identifier.trim()) {
+      setServerError(t("auth.enterIdentifier"));
+      return;
+    }
+
+    setIsLoading(true);
+    setServerError(null);
+
+    try {
+      await requestPasswordReset(
+        isPhone
+          ? { phoneNumber: identifier.trim() }
+          : { email: identifier.trim() },
+      );
+      setStep("verify");
+    } catch (err: any) {
+      setServerError(err.message || t("auth.unexpectedError"));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleResetPassword = async () => {
+    if (code.length !== 6) {
+      setServerError(t("auth.invalidResetCode"));
+      return;
+    }
+    if (newPassword.length < 8) {
+      setServerError(t("auth.passwordTooShort"));
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setServerError(t("auth.passwordMismatch"));
+      return;
+    }
+
+    setIsLoading(true);
+    setServerError(null);
+
+    try {
+      await resetPasswordWithCode({
+        ...(isPhone
+          ? { phoneNumber: identifier.trim() }
+          : { email: identifier.trim() }),
+        code,
+        newPassword,
+      });
+
+      // Auto sign-in
+      try {
+        if (isPhone) {
+          await signInWithPhone({
+            phoneNumber: identifier.trim(),
+            password: newPassword,
+          });
+        } else {
+          await signIn.email({
+            email: identifier.trim(),
+            password: newPassword,
+          });
+        }
+        router.replace("/(tabs)");
+      } catch {
+        // If auto sign-in fails, redirect to the appropriate signin screen
+        router.replace(
+          isPhone ? "/(auth)/phone-signin" : "/(auth)/email-signin",
+        );
+      }
+    } catch (err: any) {
+      setServerError(err.message || t("auth.invalidResetCode"));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const openWhatsApp = () => {
+    if (!organizerWhatsapp) return;
+    const message = encodeURIComponent(
+      "Hi, I need my password reset code for Football con los pibes",
+    );
+    Linking.openURL(`https://wa.me/${organizerWhatsapp}?text=${message}`);
+  };
+
+  return (
+    <Container variant="padded">
+      <ScrollView
+        contentContainerStyle={{ flexGrow: 1 }}
+        showsVerticalScrollIndicator={false}
+      >
+        <YStack
+          gap="$6"
+          width="100%"
+          maxWidth={400}
+          marginHorizontal="auto"
+          paddingVertical="$8"
+        >
+          <YStack gap="$2" alignItems="center">
+            <Text fontSize="$9" fontWeight="bold">
+              {t("auth.forgotPasswordTitle")}
+            </Text>
+            <Text color="$gray11" textAlign="center">
+              {step === "request"
+                ? t("auth.forgotPasswordDescription")
+                : t("auth.contactOrganizerForCode")}
+            </Text>
+          </YStack>
+
+          <Card variant="elevated" padding="$5" width="100%">
+            <YStack gap="$4">
+              {step === "request" ? (
+                <>
+                  <Input
+                    label={t("auth.phoneOrEmail")}
+                    placeholder="+49... / email@example.com"
+                    value={identifier}
+                    onChangeText={setIdentifier}
+                    autoCapitalize="none"
+                    keyboardType="email-address"
+                  />
+                </>
+              ) : (
+                <>
+                  {/* WhatsApp contact button */}
+                  {organizerWhatsapp && (
+                    <Button
+                      onPress={openWhatsApp}
+                      variant="outline"
+                      size="$4"
+                    >
+                      <XStack
+                        gap="$2"
+                        alignItems="center"
+                        justifyContent="center"
+                      >
+                        <Image
+                          source={require("../../assets/whatsapp-logo.svg")}
+                          style={{ width: 20, height: 20 }}
+                          tintColor="#25D366"
+                        />
+                        <Text fontSize="$4" fontFamily="$body">
+                          {t("auth.contactOrganizer")}
+                        </Text>
+                      </XStack>
+                    </Button>
+                  )}
+
+                  <Input
+                    label={t("auth.enterResetCode")}
+                    placeholder={t("auth.resetCodePlaceholder")}
+                    value={code}
+                    onChangeText={setCode}
+                    keyboardType="number-pad"
+                    maxLength={6}
+                  />
+
+                  <Input
+                    label={t("auth.createNewPassword")}
+                    placeholder={t("auth.createNewPassword")}
+                    value={newPassword}
+                    onChangeText={setNewPassword}
+                    secureTextEntry
+                  />
+
+                  <Input
+                    label={t("auth.confirmNewPassword")}
+                    placeholder={t("auth.confirmNewPassword")}
+                    value={confirmPassword}
+                    onChangeText={setConfirmPassword}
+                    secureTextEntry
+                  />
+                </>
+              )}
+
+              {serverError && (
+                <Text color="$red10" fontSize="$3" textAlign="center">
+                  {serverError}
+                </Text>
+              )}
+
+              <YStack paddingTop="$4">
+                <Button
+                  onPress={
+                    step === "request" ? handleRequestCode : handleResetPassword
+                  }
+                  disabled={isLoading}
+                  variant="primary"
+                >
+                  {isLoading ? (
+                    <Spinner size="small" color="white" />
+                  ) : step === "request" ? (
+                    t("auth.requestResetCode")
+                  ) : (
+                    t("auth.resetPassword")
+                  )}
+                </Button>
+              </YStack>
+            </YStack>
+          </Card>
+        </YStack>
+      </ScrollView>
+    </Container>
+  );
+}

--- a/apps/mobile-web/app/(auth)/forgot-password.tsx
+++ b/apps/mobile-web/app/(auth)/forgot-password.tsx
@@ -134,16 +134,14 @@ export default function ForgotPasswordScreen() {
           <Card variant="elevated" padding="$5" width="100%">
             <YStack gap="$4">
               {step === "request" ? (
-                <>
-                  <Input
-                    label={t("auth.phoneOrEmail")}
-                    placeholder="+49... / email@example.com"
-                    value={identifier}
-                    onChangeText={setIdentifier}
-                    autoCapitalize="none"
-                    keyboardType="email-address"
-                  />
-                </>
+                <Input
+                  label={t("auth.phoneOrEmail")}
+                  placeholder="+49... / email@example.com"
+                  value={identifier}
+                  onChangeText={setIdentifier}
+                  autoCapitalize="none"
+                  keyboardType="email-address"
+                />
               ) : (
                 <>
                   <Input

--- a/apps/mobile-web/app/(auth)/index.tsx
+++ b/apps/mobile-web/app/(auth)/index.tsx
@@ -44,55 +44,65 @@ export default function AuthLandingScreen() {
     setServerError(null);
 
     try {
-      // For web, we need to pass the full URL since the OAuth callback comes from Google
-      const callbackURL =
-        typeof window !== "undefined"
-          ? `${getConfiguredApiUrl()}/api/auth/web-callback?redirect=${encodeURIComponent(
-              window.location.origin + "/",
-            )}`
-          : "/";
+      if (Platform.OS === "web") {
+        // Web: use manual redirect flow since BetterAuth's default doesn't work on Vercel
+        const callbackURL = `${getConfiguredApiUrl()}/api/auth/web-callback?redirect=${encodeURIComponent(
+          window.location.origin + "/",
+        )}`;
 
-      console.log("[AUTH] 🚀 Calling signIn.social with BetterAuth client");
-      console.log("[AUTH] 📍 Callback URL:", callbackURL);
+        console.log("[AUTH] 📍 Web callback URL:", callbackURL);
 
-      // Use fetchOptions to get the redirect URL without auto-redirecting
-      // BetterAuth's default redirect uses window.location.href which doesn't work on Vercel
-      const result = await signIn.social({
-        provider: "google",
-        callbackURL,
-        fetchOptions: {
-          onSuccess: (ctx) => {
-            // Handle redirect manually using window.location.assign() which works on Vercel
-            const redirectUrl =
-              ctx.response.headers.get("location") || (ctx.data as any)?.url;
-            if (redirectUrl) {
-              console.log("[AUTH] ➡️ Manually redirecting to:", redirectUrl);
-              window.location.assign(redirectUrl);
-            }
+        const result = await signIn.social({
+          provider: "google",
+          callbackURL,
+          fetchOptions: {
+            onSuccess: (ctx) => {
+              const redirectUrl =
+                ctx.response.headers.get("location") || (ctx.data as any)?.url;
+              if (redirectUrl) {
+                window.location.assign(redirectUrl);
+              }
+            },
           },
-        },
-      });
+        });
 
-      console.log("[AUTH] 📥 signIn.social result:", result);
+        if (result.error) {
+          console.error("[AUTH] ❌ Google sign in error:", result.error);
+          setServerError(result.error.message || t("auth.googleSignInFailed"));
+          setIsGoogleLoading(false);
+          return;
+        }
 
-      if (result.error) {
-        console.error("[AUTH] ❌ Google sign in error:", result.error);
-        setServerError(result.error.message || t("auth.googleSignInFailed"));
-        setIsGoogleLoading(false);
-        return;
-      }
+        if ((result.data as any)?.url) {
+          window.location.assign((result.data as any).url);
+          return;
+        }
 
-      // If we have a URL in the result, redirect manually
-      if ((result.data as any)?.url) {
-        console.log("[AUTH] ➡️ Redirecting via result.data.url");
-        window.location.assign((result.data as any).url);
-        return;
-      }
+        if (result.data?.user) {
+          router.replace("/(tabs)");
+        }
+      } else {
+        // Native: expoClient plugin handles OAuth via system browser + deep link
+        console.log("[AUTH] 📱 Native Google OAuth via expoClient");
 
-      // If we get here without redirect, navigate to tabs
-      if (result.data?.user) {
-        console.log("[AUTH] ✅ Sign in successful, navigating to tabs");
-        router.replace("/(tabs)");
+        const result = await signIn.social({
+          provider: "google",
+          callbackURL: "/",
+        });
+
+        console.log("[AUTH] 📥 Native signIn.social result:", JSON.stringify(result));
+
+        if (result.error) {
+          console.error("[AUTH] ❌ Google sign in error:", result.error);
+          setServerError(result.error.message || t("auth.googleSignInFailed"));
+          setIsGoogleLoading(false);
+          return;
+        }
+
+        if (result.data?.user) {
+          console.log("[AUTH] ✅ Sign in successful, navigating to tabs");
+          router.replace("/(tabs)");
+        }
       }
     } catch (err) {
       console.error("[AUTH] ❌ Google sign in error:", err);
@@ -158,6 +168,8 @@ export default function AuthLandingScreen() {
             {t("auth.signInToContinue")}
           </Text>
         </YStack>
+
+
 
         {/* Auth Options */}
         <YStack gap="$3" alignSelf="stretch" alignItems="stretch">

--- a/apps/mobile-web/app/(auth)/index.tsx
+++ b/apps/mobile-web/app/(auth)/index.tsx
@@ -39,18 +39,14 @@ export default function AuthLandingScreen() {
     theme.background?.val?.startsWith("#1");
 
   const handleGoogleAuth = async () => {
-    console.log("[AUTH] 🔵 Google OAuth button clicked");
     setIsGoogleLoading(true);
     setServerError(null);
 
     try {
       if (Platform.OS === "web") {
-        // Web: use manual redirect flow since BetterAuth's default doesn't work on Vercel
         const callbackURL = `${getConfiguredApiUrl()}/api/auth/web-callback?redirect=${encodeURIComponent(
           window.location.origin + "/",
         )}`;
-
-        console.log("[AUTH] 📍 Web callback URL:", callbackURL);
 
         const result = await signIn.social({
           provider: "google",
@@ -67,7 +63,6 @@ export default function AuthLandingScreen() {
         });
 
         if (result.error) {
-          console.error("[AUTH] ❌ Google sign in error:", result.error);
           setServerError(result.error.message || t("auth.googleSignInFailed"));
           setIsGoogleLoading(false);
           return;
@@ -82,30 +77,22 @@ export default function AuthLandingScreen() {
           router.replace("/(tabs)");
         }
       } else {
-        // Native: expoClient plugin handles OAuth via system browser + deep link
-        console.log("[AUTH] 📱 Native Google OAuth via expoClient");
-
         const result = await signIn.social({
           provider: "google",
           callbackURL: "/",
         });
 
-        console.log("[AUTH] 📥 Native signIn.social result:", JSON.stringify(result));
-
         if (result.error) {
-          console.error("[AUTH] ❌ Google sign in error:", result.error);
           setServerError(result.error.message || t("auth.googleSignInFailed"));
           setIsGoogleLoading(false);
           return;
         }
 
         if (result.data?.user) {
-          console.log("[AUTH] ✅ Sign in successful, navigating to tabs");
           router.replace("/(tabs)");
         }
       }
     } catch (err) {
-      console.error("[AUTH] ❌ Google sign in error:", err);
       setServerError(t("auth.googleSignInFailed"));
       setIsGoogleLoading(false);
     }
@@ -168,8 +155,6 @@ export default function AuthLandingScreen() {
             {t("auth.signInToContinue")}
           </Text>
         </YStack>
-
-
 
         {/* Auth Options */}
         <YStack gap="$3" alignSelf="stretch" alignItems="stretch">

--- a/apps/mobile-web/app/(auth)/phone-signin.tsx
+++ b/apps/mobile-web/app/(auth)/phone-signin.tsx
@@ -10,12 +10,13 @@ import {
   Card,
   Text,
   YStack,
+  XStack,
   Input,
   Button,
   Spinner,
   PhoneInput,
 } from "@repo/ui";
-import { Link, router } from "expo-router";
+import { router } from "expo-router";
 import { useState } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -116,7 +117,7 @@ export default function PhoneSignInScreen() {
       >
         <YStack
           gap="$6"
-          justifyContent="center"
+          width="100%"
           maxWidth={400}
           marginHorizontal="auto"
           paddingVertical="$8"
@@ -130,7 +131,7 @@ export default function PhoneSignInScreen() {
             </Text>
           </YStack>
 
-          <Card variant="elevated" padding="$4">
+          <Card variant="elevated" padding="$5" width="100%">
             <YStack gap="$4">
               {!showPasswordReset ? (
                 <>
@@ -173,6 +174,16 @@ export default function PhoneSignInScreen() {
                       />
                     )}
                   />
+
+                  <Text
+                    color="$blue10"
+                    fontSize="$3"
+                    textAlign="right"
+                    cursor="pointer"
+                    onPress={() => router.push("/(auth)/forgot-password")}
+                  >
+                    {t("auth.forgotPassword")}
+                  </Text>
                 </>
               ) : (
                 <>
@@ -248,16 +259,17 @@ export default function PhoneSignInScreen() {
             </YStack>
           </Card>
 
-          <YStack gap="$2" alignItems="center">
-            <Text color="$gray11">
-              {t("auth.noAccount")}{" "}
-              <Link href="/(auth)/phone-signup" asChild>
-                <Text color="$blue10" fontWeight="600" cursor="pointer">
-                  {t("auth.signUpNow")}
-                </Text>
-              </Link>
+          <XStack gap="$1" justifyContent="center">
+            <Text color="$gray11">{t("auth.noAccount")}</Text>
+            <Text
+              color="$blue10"
+              fontWeight="600"
+              cursor="pointer"
+              onPress={() => router.push("/(auth)/phone-signup")}
+            >
+              {t("auth.signUpNow")}
             </Text>
-          </YStack>
+          </XStack>
         </YStack>
       </ScrollView>
     </Container>

--- a/apps/mobile-web/app/(auth)/phone-signup.tsx
+++ b/apps/mobile-web/app/(auth)/phone-signup.tsx
@@ -6,12 +6,13 @@ import {
   Card,
   Text,
   YStack,
+  XStack,
   Input,
   Button,
   Spinner,
   PhoneInput,
 } from "@repo/ui";
-import { Link, router } from "expo-router";
+import { router } from "expo-router";
 import { useState } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -80,7 +81,7 @@ export default function PhoneSignUpScreen() {
       >
         <YStack
           gap="$6"
-          justifyContent="center"
+          width="100%"
           maxWidth={400}
           marginHorizontal="auto"
           paddingVertical="$8"
@@ -94,7 +95,7 @@ export default function PhoneSignUpScreen() {
             </Text>
           </YStack>
 
-          <Card variant="elevated" padding="$4">
+          <Card variant="elevated" padding="$5" width="100%">
             <YStack gap="$4">
               <Controller
                 control={phoneForm.control}
@@ -177,16 +178,17 @@ export default function PhoneSignUpScreen() {
             </YStack>
           </Card>
 
-          <YStack gap="$2" alignItems="center">
-            <Text color="$gray11">
-              {t("auth.hasAccount")}{" "}
-              <Link href="/(auth)/phone-signin" asChild>
-                <Text color="$blue10" fontWeight="600" cursor="pointer">
-                  {t("auth.signInLink")}
-                </Text>
-              </Link>
+          <XStack gap="$1" justifyContent="center">
+            <Text color="$gray11">{t("auth.hasAccount")}</Text>
+            <Text
+              color="$blue10"
+              fontWeight="600"
+              cursor="pointer"
+              onPress={() => router.push("/(auth)/phone-signin")}
+            >
+              {t("auth.signInLink")}
             </Text>
-          </YStack>
+          </XStack>
         </YStack>
       </ScrollView>
     </Container>

--- a/apps/mobile-web/app/(tabs)/admin/index.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/index.tsx
@@ -4,6 +4,7 @@ import {
   useMutation,
   useQueryClient,
   client,
+  getAdminResetCodes,
 } from "@repo/api-client";
 import {
   Container,
@@ -1304,8 +1305,65 @@ function SettingsTab() {
         >
           {updateMutation.isPending ? t("shared.loading") : t("shared.save")}
         </Button>
+
+        {/* Password Reset Codes */}
+        <ResetCodesSection />
       </YStack>
     </ScrollView>
+  );
+}
+
+function ResetCodesSection() {
+  const { t } = useTranslation();
+  const { data: codes, isLoading, refetch } = useQuery({
+    queryKey: ["admin-reset-codes"],
+    queryFn: getAdminResetCodes,
+    refetchInterval: 30000, // Auto-refresh every 30s
+  });
+
+  return (
+    <Card variant="elevated">
+      <YStack padding="$4" gap="$3">
+        <XStack justifyContent="space-between" alignItems="center">
+          <Text fontSize="$5" fontWeight="600">
+            {t("admin.resetCodes", { defaultValue: "Password Reset Codes" })}
+          </Text>
+          <Button size="$2" variant="outline" onPress={() => refetch()}>
+            {isLoading ? <Spinner size="small" /> : t("shared.refresh", { defaultValue: "Refresh" })}
+          </Button>
+        </XStack>
+
+        {!codes || codes.length === 0 ? (
+          <Text color="$gray11" fontSize="$3">
+            {t("admin.noResetCodes", { defaultValue: "No pending reset codes" })}
+          </Text>
+        ) : (
+          codes.map((item) => (
+            <Card key={item.identifier} variant="elevated" padding="$3">
+              <XStack justifyContent="space-between" alignItems="center">
+                <YStack gap="$1">
+                  <Text fontSize="$3" fontWeight="600">
+                    {item.identifier}
+                  </Text>
+                  <Text fontSize="$2" color="$gray11">
+                    {t("admin.expiresAt", { defaultValue: "Expires" })}:{" "}
+                    {new Date(item.expiresAt).toLocaleTimeString()}
+                  </Text>
+                </YStack>
+                <Text
+                  fontSize="$7"
+                  fontWeight="bold"
+                  fontFamily="$mono"
+                  letterSpacing={2}
+                >
+                  {item.code}
+                </Text>
+              </XStack>
+            </Card>
+          ))
+        )}
+      </YStack>
+    </Card>
   );
 }
 

--- a/apps/mobile-web/app/(tabs)/profile/index.tsx
+++ b/apps/mobile-web/app/(tabs)/profile/index.tsx
@@ -36,6 +36,7 @@ import {
   Platform,
   Alert,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { changeLanguage, getCurrentLanguage } from "../../../lib/i18n";
 import { useThemeContext } from "../../../lib/theme-context";
@@ -44,6 +45,7 @@ export default function ProfileScreen() {
   const { data: session, isPending, refetch: refetchSession } = useSession();
   const { t } = useTranslation();
   const { theme, toggleTheme } = useThemeContext();
+  const insets = useSafeAreaInsets();
   const [currentLanguage, setCurrentLanguage] = useState(getCurrentLanguage());
   const [isEditing, setIsEditing] = useState(false);
   const [isChangingPassword, setIsChangingPassword] = useState(false);
@@ -362,7 +364,7 @@ export default function ProfileScreen() {
           headerShown: false,
         }}
       />
-      <Container variant="padded">
+      <Container variant="padded" paddingTop={insets.top + 16}>
       <ScrollView
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ paddingBottom: 24 }}

--- a/apps/mobile-web/eas.json
+++ b/apps/mobile-web/eas.json
@@ -19,7 +19,12 @@
       "android": {
         "buildType": "apk"
       },
-      "channel": "preview"
+      "channel": "preview",
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://football-api-staging.pepe-grillo-parlante.workers.dev",
+        "EXPO_PUBLIC_ENV": "preview",
+        "EXPO_PUBLIC_GOOGLE_CLIENT_ID": "114959048918-po7fdnktjj37nsflujuflfdd9vcsgut9.apps.googleusercontent.com"
+      }
     },
     "production": {
       "autoIncrement": true,
@@ -29,12 +34,19 @@
       "android": {
         "buildType": "app-bundle"
       },
-      "channel": "production"
+      "channel": "production",
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://football-api.pepe-grillo-parlante.workers.dev",
+        "EXPO_PUBLIC_ENV": "production",
+        "EXPO_PUBLIC_GOOGLE_CLIENT_ID": "114959048918-po7fdnktjj37nsflujuflfdd9vcsgut9.apps.googleusercontent.com"
+      }
     }
   },
   "submit": {
     "production": {
-      "ios": {},
+      "ios": {
+        "ascAppId": "6759833737"
+      },
       "android": {
         "serviceAccountKeyPath": "./google-play-service-account.json",
         "track": "internal"

--- a/apps/mobile-web/package.json
+++ b/apps/mobile-web/package.json
@@ -28,6 +28,7 @@
     "expo": "~55.0.11",
     "expo-apple-authentication": "^55.0.11",
     "expo-application": "^55.0.12",
+    "expo-build-properties": "^55.0.11",
     "expo-crypto": "^55.0.12",
     "expo-dev-client": "~55.0.22",
     "expo-device": "~55.0.12",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -301,7 +301,20 @@
     "resetMyPassword": "Update Password",
     "passwordResetSuccess": "Password updated! Signing you in...",
     "passwordResetFailed": "Failed to update password. Please try again.",
-    "passwordMismatch": "Passwords do not match"
+    "passwordMismatch": "Passwords do not match",
+    "forgotPassword": "Forgot Password?",
+    "forgotPasswordTitle": "Reset Password",
+    "forgotPasswordDescription": "Enter your phone number or email to request a reset code.",
+    "requestResetCode": "Request Reset Code",
+    "contactOrganizerForCode": "A reset code has been generated. Contact the organizer via WhatsApp to get your code.",
+    "contactOrganizer": "Contact Organizer",
+    "enterResetCode": "Reset Code",
+    "resetCodePlaceholder": "6-digit code",
+    "resetPassword": "Reset Password",
+    "phoneOrEmail": "Phone or Email",
+    "invalidResetCode": "Invalid or expired reset code",
+    "codeRequested": "Reset code requested!",
+    "enterIdentifier": "Please enter your phone number or email"
   },
   "addMatch": {
     "title": "Add Match",
@@ -641,7 +654,10 @@
     "descriptionSpanish": "Description (Spanish)",
     "sortOrder": "Sort Order",
     "activate": "Activate",
-    "deactivate": "Deactivate"
+    "deactivate": "Deactivate",
+    "resetCodes": "Password Reset Codes",
+    "noResetCodes": "No pending reset codes",
+    "expiresAt": "Expires"
   },
   "errors": {
     "matchAlreadyExists": "A match already exists on this date",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -307,7 +307,6 @@
     "forgotPasswordDescription": "Enter your phone number or email to request a reset code.",
     "requestResetCode": "Request Reset Code",
     "contactOrganizerForCode": "A reset code has been generated. Contact the organizer via WhatsApp to get your code.",
-    "contactOrganizer": "Contact Organizer",
     "enterResetCode": "Reset Code",
     "resetCodePlaceholder": "6-digit code",
     "resetPassword": "Reset Password",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -312,7 +312,6 @@
     "resetPassword": "Reset Password",
     "phoneOrEmail": "Phone or Email",
     "invalidResetCode": "Invalid or expired reset code",
-    "codeRequested": "Reset code requested!",
     "enterIdentifier": "Please enter your phone number or email"
   },
   "addMatch": {

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -308,7 +308,6 @@
     "forgotPasswordDescription": "Ingresá tu teléfono o email para solicitar un código de restablecimiento.",
     "requestResetCode": "Solicitar código",
     "contactOrganizerForCode": "Se generó un código de restablecimiento. Contactá al organizador por WhatsApp para obtenerlo.",
-    "contactOrganizer": "Contactar organizador",
     "enterResetCode": "Código de restablecimiento",
     "resetCodePlaceholder": "Código de 6 dígitos",
     "resetPassword": "Restablecer contraseña",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -302,7 +302,20 @@
     "resetMyPassword": "Actualizar Contraseña",
     "passwordResetSuccess": "¡Contraseña actualizada! Iniciando sesión...",
     "passwordResetFailed": "Error al actualizar la contraseña. Por favor, intentá de nuevo.",
-    "passwordMismatch": "Las contraseñas no coinciden"
+    "passwordMismatch": "Las contraseñas no coinciden",
+    "forgotPassword": "¿Olvidaste tu contraseña?",
+    "forgotPasswordTitle": "Restablecer contraseña",
+    "forgotPasswordDescription": "Ingresá tu teléfono o email para solicitar un código de restablecimiento.",
+    "requestResetCode": "Solicitar código",
+    "contactOrganizerForCode": "Se generó un código de restablecimiento. Contactá al organizador por WhatsApp para obtenerlo.",
+    "contactOrganizer": "Contactar organizador",
+    "enterResetCode": "Código de restablecimiento",
+    "resetCodePlaceholder": "Código de 6 dígitos",
+    "resetPassword": "Restablecer contraseña",
+    "phoneOrEmail": "Teléfono o Email",
+    "invalidResetCode": "Código inválido o expirado",
+    "codeRequested": "¡Código solicitado!",
+    "enterIdentifier": "Ingresá tu teléfono o email"
   },
   "addMatch": {
     "title": "Crear partido",
@@ -644,7 +657,10 @@
     "descriptionSpanish": "Descripción (Español)",
     "sortOrder": "Orden",
     "activate": "Activar",
-    "deactivate": "Desactivar"
+    "deactivate": "Desactivar",
+    "resetCodes": "Códigos de restablecimiento",
+    "noResetCodes": "Sin códigos pendientes",
+    "expiresAt": "Expira"
   },
   "errors": {
     "matchAlreadyExists": "Ya existe un partido en esta fecha",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -313,7 +313,6 @@
     "resetPassword": "Restablecer contraseña",
     "phoneOrEmail": "Teléfono o Email",
     "invalidResetCode": "Código inválido o expirado",
-    "codeRequested": "¡Código solicitado!",
     "enterIdentifier": "Ingresá tu teléfono o email"
   },
   "addMatch": {

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -358,7 +358,10 @@ export async function resetPasswordForMigration(data: {
 
   if (!response.ok) {
     const result = await response.json();
-    throw new Error(result.error || "Failed to reset password");
+    const msg = typeof result.error === "string"
+      ? result.error
+      : result.error?.message || "Failed to reset password";
+    throw new Error(msg);
   }
 }
 
@@ -381,7 +384,10 @@ export async function requestPasswordReset(identifier: {
 
   if (!response.ok) {
     const result = await response.json();
-    throw new Error(result.error || "Failed to request password reset");
+    const msg = typeof result.error === "string"
+      ? result.error
+      : result.error?.message || "Failed to request password reset";
+    throw new Error(msg);
   }
 }
 
@@ -405,7 +411,10 @@ export async function resetPasswordWithCode(data: {
 
   if (!response.ok) {
     const result = await response.json();
-    throw new Error(result.error || "Failed to reset password");
+    const msg = typeof result.error === "string"
+      ? result.error
+      : result.error?.message || "Failed to reset password";
+    throw new Error(msg);
   }
 }
 

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -406,6 +406,7 @@ export async function resetPasswordWithCode(data: {
 export async function getAdminResetCodes(): Promise<
   Array<{ identifier: string; code: string; expiresAt: string }>
 > {
+  await _tokenLoadPromise;
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -156,6 +156,9 @@ function createDynamicFetch() {
       const apiBase = getApiUrl();
       const finalUrl = originalUrl.replace(LOCALHOST_API, apiBase);
 
+      console.log(`[AUTH-FETCH] ${init?.method || 'GET'} ${finalUrl}`);
+      console.log(`[AUTH-FETCH] apiBase=${apiBase}, hasToken=${!!_cachedBearerToken}`);
+
       const fetchInit: RequestInit = { ...init, credentials: "include" };
 
       // Inject Bearer token header for authenticated requests (all platforms)
@@ -179,6 +182,7 @@ function createDynamicFetch() {
 
       // Capture set-auth-token from responses and clear token on sign-out (all platforms)
       return responsePromise.then((response) => {
+        console.log(`[AUTH-FETCH] Response: ${response.status} ${response.statusText} for ${finalUrl}`);
         const newToken = response.headers.get("set-auth-token");
         if (newToken) {
           // The set-auth-token value is "token.hash" (URL-encoded). Store just the
@@ -194,6 +198,9 @@ function createDynamicFetch() {
           storage.deleteItem(BEARER_TOKEN_KEY).catch(console.error);
         }
         return response;
+      }).catch((err: any) => {
+        console.error(`[AUTH-FETCH] ERROR for ${finalUrl}:`, err?.message || err);
+        throw err;
       });
     });
   }) as typeof fetch;
@@ -281,17 +288,24 @@ export async function signUpWithPhone(data: PhoneSignUpData) {
  * Uses native phoneNumber.verify() for session management (fixes infinite polling)
  */
 export async function signInWithPhone(data: PhoneSignInData) {
+  console.log(`[AUTH] signInWithPhone called for ${data.phoneNumber}`);
+
   // sendOtp is a no-op on server, but required by the flow
-  await authClient.phoneNumber.sendOtp({ phoneNumber: data.phoneNumber });
+  console.log(`[AUTH] Calling sendOtp...`);
+  const otpResult = await authClient.phoneNumber.sendOtp({ phoneNumber: data.phoneNumber });
+  console.log(`[AUTH] sendOtp result:`, JSON.stringify(otpResult));
 
   // verify() with password as code - server validates against stored hash
+  console.log(`[AUTH] Calling verify...`);
   const result = await authClient.phoneNumber.verify({
     phoneNumber: data.phoneNumber,
     code: data.password,
   });
+  console.log(`[AUTH] verify result:`, JSON.stringify(result));
 
   // verify() returns { status, token, user } on success
   if (result.error || !result.data?.token) {
+    console.error(`[AUTH] signInWithPhone failed:`, result.error);
     throw new Error("Invalid phone number or password");
   }
 
@@ -345,6 +359,95 @@ export async function resetPasswordForMigration(data: {
   if (!response.ok) {
     const result = await response.json();
     throw new Error(result.error || "Failed to reset password");
+  }
+}
+
+/**
+ * Request a password reset code.
+ * The code is stored server-side; user must contact the admin via WhatsApp to get it.
+ */
+export async function requestPasswordReset(identifier: {
+  phoneNumber?: string;
+  email?: string;
+}): Promise<void> {
+  const response = await fetch(
+    `${getApiUrl()}/api/phone-auth/forgot-password`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(identifier),
+    }
+  );
+
+  if (!response.ok) {
+    const result = await response.json();
+    throw new Error(result.error || "Failed to request password reset");
+  }
+}
+
+/**
+ * Verify reset code and set a new password.
+ */
+export async function resetPasswordWithCode(data: {
+  phoneNumber?: string;
+  email?: string;
+  code: string;
+  newPassword: string;
+}): Promise<void> {
+  const response = await fetch(
+    `${getApiUrl()}/api/phone-auth/verify-reset`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    }
+  );
+
+  if (!response.ok) {
+    const result = await response.json();
+    throw new Error(result.error || "Failed to reset password");
+  }
+}
+
+/**
+ * Admin: get pending password reset codes.
+ */
+export async function getAdminResetCodes(): Promise<
+  Array<{ identifier: string; code: string; expiresAt: string }>
+> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (_cachedBearerToken) {
+    headers["Authorization"] = `Bearer ${_cachedBearerToken}`;
+  }
+
+  const response = await fetch(
+    `${getApiUrl()}/api/phone-auth/admin/reset-codes`,
+    { headers }
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch reset codes");
+  }
+
+  const result = await response.json();
+  return result.codes;
+}
+
+/**
+ * Get the organizer's WhatsApp number (public endpoint, no auth required).
+ */
+export async function getOrganizerContact(): Promise<string | null> {
+  try {
+    const response = await fetch(
+      `${getApiUrl()}/api/phone-auth/organizer-contact`
+    );
+    if (!response.ok) return null;
+    const result = await response.json();
+    return result.whatsapp || null;
+  } catch {
+    return null;
   }
 }
 

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -444,21 +444,6 @@ export async function getAdminResetCodes(): Promise<
   return result.codes;
 }
 
-/**
- * Get the organizer's WhatsApp number (public endpoint, no auth required).
- */
-export async function getOrganizerContact(): Promise<string | null> {
-  try {
-    const response = await fetch(
-      `${getApiUrl()}/api/phone-auth/organizer-contact`
-    );
-    if (!response.ok) return null;
-    const result = await response.json();
-    return result.whatsapp || null;
-  } catch {
-    return null;
-  }
-}
 
 // Export types
 export type Session = typeof authClient.$Infer.Session;

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -71,6 +71,14 @@ export function getBearerToken(): string | undefined {
   return _cachedBearerToken;
 }
 
+// Extract a human-readable error message from API responses.
+// Handles both string errors and Zod validation error objects.
+function extractApiError(result: any, fallback: string): string {
+  if (typeof result.error === "string") return result.error;
+  if (result.error?.message) return result.error.message;
+  return fallback;
+}
+
 // Base URL for localhost development (will be replaced at runtime for deployed environments)
 const LOCALHOST_API = "http://localhost:3001";
 
@@ -156,9 +164,6 @@ function createDynamicFetch() {
       const apiBase = getApiUrl();
       const finalUrl = originalUrl.replace(LOCALHOST_API, apiBase);
 
-      console.log(`[AUTH-FETCH] ${init?.method || 'GET'} ${finalUrl}`);
-      console.log(`[AUTH-FETCH] apiBase=${apiBase}, hasToken=${!!_cachedBearerToken}`);
-
       const fetchInit: RequestInit = { ...init, credentials: "include" };
 
       // Inject Bearer token header for authenticated requests (all platforms)
@@ -182,7 +187,6 @@ function createDynamicFetch() {
 
       // Capture set-auth-token from responses and clear token on sign-out (all platforms)
       return responsePromise.then((response) => {
-        console.log(`[AUTH-FETCH] Response: ${response.status} ${response.statusText} for ${finalUrl}`);
         const newToken = response.headers.get("set-auth-token");
         if (newToken) {
           // The set-auth-token value is "token.hash" (URL-encoded). Store just the
@@ -198,9 +202,6 @@ function createDynamicFetch() {
           storage.deleteItem(BEARER_TOKEN_KEY).catch(console.error);
         }
         return response;
-      }).catch((err: any) => {
-        console.error(`[AUTH-FETCH] ERROR for ${finalUrl}:`, err?.message || err);
-        throw err;
       });
     });
   }) as typeof fetch;
@@ -288,24 +289,14 @@ export async function signUpWithPhone(data: PhoneSignUpData) {
  * Uses native phoneNumber.verify() for session management (fixes infinite polling)
  */
 export async function signInWithPhone(data: PhoneSignInData) {
-  console.log(`[AUTH] signInWithPhone called for ${data.phoneNumber}`);
+  await authClient.phoneNumber.sendOtp({ phoneNumber: data.phoneNumber });
 
-  // sendOtp is a no-op on server, but required by the flow
-  console.log(`[AUTH] Calling sendOtp...`);
-  const otpResult = await authClient.phoneNumber.sendOtp({ phoneNumber: data.phoneNumber });
-  console.log(`[AUTH] sendOtp result:`, JSON.stringify(otpResult));
-
-  // verify() with password as code - server validates against stored hash
-  console.log(`[AUTH] Calling verify...`);
   const result = await authClient.phoneNumber.verify({
     phoneNumber: data.phoneNumber,
     code: data.password,
   });
-  console.log(`[AUTH] verify result:`, JSON.stringify(result));
 
-  // verify() returns { status, token, user } on success
   if (result.error || !result.data?.token) {
-    console.error(`[AUTH] signInWithPhone failed:`, result.error);
     throw new Error("Invalid phone number or password");
   }
 
@@ -358,10 +349,7 @@ export async function resetPasswordForMigration(data: {
 
   if (!response.ok) {
     const result = await response.json();
-    const msg = typeof result.error === "string"
-      ? result.error
-      : result.error?.message || "Failed to reset password";
-    throw new Error(msg);
+    throw new Error(extractApiError(result, "Failed to reset password"));
   }
 }
 
@@ -384,10 +372,7 @@ export async function requestPasswordReset(identifier: {
 
   if (!response.ok) {
     const result = await response.json();
-    const msg = typeof result.error === "string"
-      ? result.error
-      : result.error?.message || "Failed to request password reset";
-    throw new Error(msg);
+    throw new Error(extractApiError(result, "Failed to request password reset"));
   }
 }
 
@@ -411,10 +396,7 @@ export async function resetPasswordWithCode(data: {
 
   if (!response.ok) {
     const result = await response.json();
-    const msg = typeof result.error === "string"
-      ? result.error
-      : result.error?.message || "Failed to reset password";
-    throw new Error(msg);
+    throw new Error(extractApiError(result, "Failed to reset password"));
   }
 }
 

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -32,6 +32,10 @@ export {
   signInWithPhone,
   needsPasswordReset,
   resetPasswordForMigration,
+  requestPasswordReset,
+  resetPasswordWithCode,
+  getAdminResetCodes,
+  getOrganizerContact,
 } from "./auth";
 export type { Session, User, PhoneSignUpData, PhoneSignInData } from "./auth";
 

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -35,7 +35,6 @@ export {
   requestPasswordReset,
   resetPasswordWithCode,
   getAdminResetCodes,
-  getOrganizerContact,
 } from "./auth";
 export type { Session, User, PhoneSignUpData, PhoneSignInData } from "./auth";
 

--- a/packages/shared/src/database/schema.ts
+++ b/packages/shared/src/database/schema.ts
@@ -152,6 +152,16 @@ export interface MatchPlayerStatsTable {
   updated_at: ColumnType<Date, string | undefined, string>;
 }
 
+// BetterAuth verification table (used for password reset codes, OTPs, etc.)
+export interface VerificationTable {
+  id: string;
+  identifier: string;
+  value: string;
+  expiresAt: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
 // Database interface
 export interface Database {
   locations: LocationsTable;
@@ -165,6 +175,7 @@ export interface Database {
   match_player_stats: MatchPlayerStatsTable;
   voting_criteria: VotingCriteriaTable;
   match_votes: MatchVotesTable;
+  verification: VerificationTable;
 }
 
 // SQLite system tables used by migrations and database introspection

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -278,7 +278,9 @@ function NativeSelect({
           backgroundColor="$background"
           borderColor={error ? "$red8" : "$gray7"}
           borderWidth={1}
+          borderRadius="$3"
           padding="$3"
+          height={48}
           iconAfter={ChevronDown}
           opacity={disabled ? 0.5 : 1}
           disabled={disabled}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       expo-application:
         specifier: ^55.0.12
         version: 55.0.12(expo@55.0.11)
+      expo-build-properties:
+        specifier: ^55.0.11
+        version: 55.0.11(expo@55.0.11)
       expo-crypto:
         specifier: ^55.0.12
         version: 55.0.12(expo@55.0.11)
@@ -4700,6 +4703,11 @@ packages:
       expo: '*'
       react: 19.2.0
       react-native: '*'
+
+  expo-build-properties@55.0.11:
+    resolution: {integrity: sha512-r/CvGqWPxP2pEfR3WQfQjJqgVMQvVqF6rGMN0wAf3HXqzPpvEZt/jB3gDAHIeUpFl3IwpxwBaAgX0rDYoftw9Q==}
+    peerDependencies:
+      expo: '*'
 
   expo-constants@55.0.11:
     resolution: {integrity: sha512-efWOJr0oVDId0lhvXJwoWfzucwi1/upDDseuYAhK0m8v5Hg7ObDehMmKRMGL0dgABmlSnppNmmYIeTVe7e2yVg==}
@@ -13977,6 +13985,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  expo-build-properties@55.0.11(expo@55.0.11):
+    dependencies:
+      '@expo/schema-utils': 55.0.2
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      resolve-from: 5.0.0
+      semver: 7.7.4
 
   expo-constants@55.0.11(expo@55.0.11)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(typescript@5.9.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,9 +149,6 @@ importers:
       better-auth:
         specifier: ^1.5.5
         version: 1.5.6(@cloudflare/workers-types@4.20260403.1)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      expo:
-        specifier: ~55.0.11
-        version: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       hono:
         specifier: ^4.12.8
         version: 4.12.10
@@ -161,9 +158,6 @@ importers:
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
-      react-native:
-        specifier: 0.83.4
-        version: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
       zod:
         specifier: ^4.3.6
         version: 4.3.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       better-auth:
         specifier: ^1.5.5
         version: 1.5.6(@cloudflare/workers-types@4.20260403.1)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      expo:
+        specifier: ~55.0.11
+        version: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       hono:
         specifier: ^4.12.8
         version: 4.12.10
@@ -158,6 +161,9 @@ importers:
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
+      react-native:
+        specifier: 0.83.4
+        version: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
## Summary
- **Fix "Sign Up Now" / "Sign In" links** not working on native iOS — replaced broken `Link asChild` + nested `Text` pattern with `XStack` + `router.push()`
- **Add forgot password flow** — user requests a reset code, admin relays it via WhatsApp, user enters code + new password
- **Add admin reset codes viewer** in the Settings tab for quick code lookup
- **Remove debug console.logs** from all auth flows (was logging on every API request)
- **App Store prep changes** — supportsTablet: false, expo-build-properties, EAS env vars, build number bump

## Changes
- **API**: 3 new endpoints in `phone-auth.ts` (`POST /forgot-password`, `POST /verify-reset`, `GET /admin/reset-codes`)
- **Client**: `requestPasswordReset()`, `resetPasswordWithCode()`, `getAdminResetCodes()` + `extractApiError()` helper
- **Frontend**: New `forgot-password.tsx` screen, "Forgot Password?" link on signin screens, admin reset codes section
- **Schema**: Added `VerificationTable` type to Kysely database schema
- **i18n**: EN/ES translations for forgot password flow + admin reset codes
