### PR TITLE
Fix Google OAuth, Apple Sign-In, autofill nav, and country picker scroll

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -45,8 +45,9 @@ function createAuthInstance() {
         "http://localhost:3001",
         // Vercel production
         "https://football-with-friends.vercel.app",
-        // Allow native app deep link callback
+        // Allow native app deep link callback (production + dev client schemes)
         "football-with-friends://",
+        "exp+football-with-friends://",
       ];
 
       // If no request, return static origins (used during initialization)

--- a/apps/api/src/routes/phone-auth.ts
+++ b/apps/api/src/routes/phone-auth.ts
@@ -224,7 +224,7 @@ function generateResetCode(): string {
   const array = new Uint8Array(6);
   crypto.getRandomValues(array);
   for (let i = 0; i < 6; i++) {
-    code += digits[array[i] % 10];
+    code += digits[array[i]! % 10];
   }
   return code;
 }

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -189,7 +189,28 @@ app.get("/api/auth/web-callback", async (c) => {
 // Wrap to filter cookies and avoid expo client infinite refetch bug
 // See: https://github.com/better-auth/better-auth/issues/4744
 app.on(["POST", "GET"], "/api/auth/*", async (c) => {
+  const path = new URL(c.req.url).pathname;
   const response = await auth.handler(c.req.raw);
+
+  // Workaround: BetterAuth's expo server plugin should append ?cookie=<session-cookies>
+  // to deep link redirects after OAuth callbacks, but the plugin's after hook doesn't see
+  // the location header set by thrown redirects (ctx.context.responseHeaders vs response headers).
+  // We manually append the cookie here if the plugin didn't.
+  if (path.includes("/callback/")) {
+    const location = response.headers.get("location") || "";
+    const setCookie = response.headers.get("set-cookie") || "";
+    if (location.startsWith("football-with-friends://") && !location.includes("cookie=") && setCookie) {
+      const redirectURL = new URL(location);
+      redirectURL.searchParams.set("cookie", setCookie);
+      const newHeaders = new Headers(response.headers);
+      newHeaders.set("location", redirectURL.toString());
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: newHeaders,
+      });
+    }
+  }
 
   // Filter Set-Cookie headers to only include better-auth cookies
   const setCookieHeader = response.headers.get("set-cookie");

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -203,27 +203,13 @@ app.on(["POST", "GET"], "/api/auth/*", async (c) => {
   // Workaround: BetterAuth's expo server plugin should append ?cookie=<session-cookies>
   // to deep link redirects after OAuth callbacks, but the plugin's after hook doesn't see
   // the location header set by thrown redirects (ctx.context.responseHeaders vs response headers).
-  // We manually append the session token and cookie here.
+  // We manually append the cookie here so expoClient's built-in flow can extract it.
   if (path.includes("/callback/")) {
     const location = response.headers.get("location") || "";
     const setCookie = response.headers.get("set-cookie") || "";
-    if (location.startsWith("football-with-friends://") && setCookie) {
+    if (location.startsWith("football-with-friends://") && !location.includes("cookie=") && setCookie) {
       const redirectURL = new URL(location);
-
-      const rawToken = extractSessionToken(setCookie);
-      if (rawToken) {
-        try {
-          redirectURL.searchParams.set("session_token", decodeURIComponent(rawToken));
-        } catch {
-          redirectURL.searchParams.set("session_token", rawToken);
-        }
-      }
-
-      // Also append raw cookie for expoClient compatibility
-      if (!location.includes("cookie=")) {
-        redirectURL.searchParams.set("cookie", setCookie);
-      }
-
+      redirectURL.searchParams.set("cookie", setCookie);
       const newHeaders = new Headers(response.headers);
       newHeaders.set("location", redirectURL.toString());
       return new Response(response.body, {

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -27,6 +27,9 @@ export type Bindings = {
   // Google OAuth
   NEXT_PUBLIC_GOOGLE_CLIENT_ID: string;
   GOOGLE_CLIENT_SECRET: string;
+  // Apple Sign In (optional)
+  APPLE_CLIENT_ID?: string;
+  APPLE_CLIENT_SECRET?: string;
   // CORS
   ALLOWED_ORIGINS?: string;
   TRUSTED_ORIGINS?: string;
@@ -58,6 +61,8 @@ app.use("*", async (c, next) => {
     BETTER_AUTH_BASE_URL: env.BETTER_AUTH_BASE_URL,
     NEXT_PUBLIC_GOOGLE_CLIENT_ID: env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
     GOOGLE_CLIENT_SECRET: env.GOOGLE_CLIENT_SECRET,
+    APPLE_CLIENT_ID: env.APPLE_CLIENT_ID,
+    APPLE_CLIENT_SECRET: env.APPLE_CLIENT_SECRET,
     ALLOWED_ORIGINS: env.ALLOWED_ORIGINS,
     TRUSTED_ORIGINS: env.TRUSTED_ORIGINS,
     NODE_ENV: env.NODE_ENV || "production",
@@ -195,13 +200,30 @@ app.on(["POST", "GET"], "/api/auth/*", async (c) => {
   // Workaround: BetterAuth's expo server plugin should append ?cookie=<session-cookies>
   // to deep link redirects after OAuth callbacks, but the plugin's after hook doesn't see
   // the location header set by thrown redirects (ctx.context.responseHeaders vs response headers).
-  // We manually append the cookie here if the plugin didn't.
+  // We manually append the session token and cookie here.
   if (path.includes("/callback/")) {
     const location = response.headers.get("location") || "";
     const setCookie = response.headers.get("set-cookie") || "";
-    if (location.startsWith("football-with-friends://") && !location.includes("cookie=") && setCookie) {
+    if (location.startsWith("football-with-friends://") && setCookie) {
       const redirectURL = new URL(location);
-      redirectURL.searchParams.set("cookie", setCookie);
+
+      // Extract session token from Set-Cookie (same pattern as web-callback)
+      const tokenMatch =
+        setCookie.match(/__Secure-better-auth\.session_token=([^;]+)/) ||
+        setCookie.match(/better-auth\.session_token=([^;]+)/);
+      if (tokenMatch?.[1]) {
+        try {
+          redirectURL.searchParams.set("session_token", decodeURIComponent(tokenMatch[1]));
+        } catch {
+          redirectURL.searchParams.set("session_token", tokenMatch[1]);
+        }
+      }
+
+      // Also append raw cookie for expoClient compatibility
+      if (!location.includes("cookie=")) {
+        redirectURL.searchParams.set("cookie", setCookie);
+      }
+
       const newHeaders = new Headers(response.headers);
       newHeaders.set("location", redirectURL.toString());
       return new Response(response.body, {
@@ -256,6 +278,8 @@ function injectCronEnv(env: Bindings) {
     BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET,
     NEXT_PUBLIC_GOOGLE_CLIENT_ID: env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
     GOOGLE_CLIENT_SECRET: env.GOOGLE_CLIENT_SECRET,
+    APPLE_CLIENT_ID: env.APPLE_CLIENT_ID,
+    APPLE_CLIENT_SECRET: env.APPLE_CLIENT_SECRET,
     DEFAULT_TIMEZONE: env.DEFAULT_TIMEZONE || "Europe/Berlin",
     STORAGE_PROVIDER: env.STORAGE_PROVIDER || "turso",
     NODE_ENV: env.NODE_ENV || "production",

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -16,6 +16,36 @@ import { updateMatchStatuses } from "./cron/update-match-statuses";
 // Import shared security middleware
 import { type AppVariables, authMiddleware, rateLimitMiddleware } from "./middleware/security";
 
+/** Extract session token from a cookie header string (Set-Cookie or Cookie). */
+function extractSessionToken(header: string): string | null {
+  const match =
+    header.match(/__Secure-better-auth\.session_token=([^;]+)/) ||
+    header.match(/better-auth\.session_token=([^;]+)/);
+  return match?.[1] ?? null;
+}
+
+/** Inject Cloudflare Worker bindings into process.env for shared package compatibility. */
+function injectEnv(env: Bindings) {
+  // @ts-ignore - process.env may not exist in CF Workers but we polyfill it
+  globalThis.process = globalThis.process || { env: {} };
+  Object.assign(process.env, {
+    TURSO_DATABASE_URL: env.TURSO_DATABASE_URL,
+    TURSO_AUTH_TOKEN: env.TURSO_AUTH_TOKEN,
+    BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET,
+    BETTER_AUTH_BASE_URL: env.BETTER_AUTH_BASE_URL,
+    NEXT_PUBLIC_GOOGLE_CLIENT_ID: env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET: env.GOOGLE_CLIENT_SECRET,
+    APPLE_CLIENT_ID: env.APPLE_CLIENT_ID,
+    APPLE_CLIENT_SECRET: env.APPLE_CLIENT_SECRET,
+    ALLOWED_ORIGINS: env.ALLOWED_ORIGINS,
+    TRUSTED_ORIGINS: env.TRUSTED_ORIGINS,
+    NODE_ENV: env.NODE_ENV || "production",
+    DEFAULT_TIMEZONE: env.DEFAULT_TIMEZONE || "Europe/Berlin",
+    STORAGE_PROVIDER: env.STORAGE_PROVIDER || "turso",
+    CRON_SECRET: env.CRON_SECRET,
+  });
+}
+
 // Cloudflare Workers environment bindings
 export type Bindings = {
   // Turso database
@@ -45,32 +75,8 @@ export type Bindings = {
 
 const app = new Hono<{ Bindings: Bindings; Variables: AppVariables }>();
 
-// Middleware to inject environment variables into process.env
-// This allows the shared package to work with Cloudflare Workers
 app.use("*", async (c, next) => {
-  // Set process.env from Cloudflare bindings
-  // @ts-ignore - process.env may not exist in CF Workers but we polyfill it
-  globalThis.process = globalThis.process || { env: {} };
-  const env = c.env;
-
-  // Copy all bindings to process.env
-  Object.assign(process.env, {
-    TURSO_DATABASE_URL: env.TURSO_DATABASE_URL,
-    TURSO_AUTH_TOKEN: env.TURSO_AUTH_TOKEN,
-    BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET,
-    BETTER_AUTH_BASE_URL: env.BETTER_AUTH_BASE_URL,
-    NEXT_PUBLIC_GOOGLE_CLIENT_ID: env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
-    GOOGLE_CLIENT_SECRET: env.GOOGLE_CLIENT_SECRET,
-    APPLE_CLIENT_ID: env.APPLE_CLIENT_ID,
-    APPLE_CLIENT_SECRET: env.APPLE_CLIENT_SECRET,
-    ALLOWED_ORIGINS: env.ALLOWED_ORIGINS,
-    TRUSTED_ORIGINS: env.TRUSTED_ORIGINS,
-    NODE_ENV: env.NODE_ENV || "production",
-    DEFAULT_TIMEZONE: env.DEFAULT_TIMEZONE || "Europe/Berlin",
-    STORAGE_PROVIDER: env.STORAGE_PROVIDER || "turso",
-    CRON_SECRET: env.CRON_SECRET,
-  });
-
+  injectEnv(c.env);
   return next();
 });
 
@@ -144,10 +150,7 @@ app.get("/api/auth/web-callback", async (c) => {
     });
 
     const cookieHeader = c.req.header("cookie") || "";
-    const rawCookieToken =
-      cookieHeader.match(/__Secure-better-auth\.session_token=([^;]+)/)?.[1] ||
-      cookieHeader.match(/better-auth\.session_token=([^;]+)/)?.[1] ||
-      null;
+    const rawCookieToken = extractSessionToken(cookieHeader);
 
     let decodedCookieToken = rawCookieToken;
     if (rawCookieToken) {
@@ -207,15 +210,12 @@ app.on(["POST", "GET"], "/api/auth/*", async (c) => {
     if (location.startsWith("football-with-friends://") && setCookie) {
       const redirectURL = new URL(location);
 
-      // Extract session token from Set-Cookie (same pattern as web-callback)
-      const tokenMatch =
-        setCookie.match(/__Secure-better-auth\.session_token=([^;]+)/) ||
-        setCookie.match(/better-auth\.session_token=([^;]+)/);
-      if (tokenMatch?.[1]) {
+      const rawToken = extractSessionToken(setCookie);
+      if (rawToken) {
         try {
-          redirectURL.searchParams.set("session_token", decodeURIComponent(tokenMatch[1]));
+          redirectURL.searchParams.set("session_token", decodeURIComponent(rawToken));
         } catch {
-          redirectURL.searchParams.set("session_token", tokenMatch[1]);
+          redirectURL.searchParams.set("session_token", rawToken);
         }
       }
 
@@ -268,23 +268,6 @@ app.on(["POST", "GET"], "/api/auth/*", async (c) => {
 // API routes
 registerApiRoutes(app);
 
-// Helper to inject env vars for cron (no Hono middleware in scheduled events)
-function injectCronEnv(env: Bindings) {
-  // @ts-ignore - process.env may not exist in CF Workers but we polyfill it
-  globalThis.process = globalThis.process || { env: {} };
-  Object.assign(process.env, {
-    TURSO_DATABASE_URL: env.TURSO_DATABASE_URL,
-    TURSO_AUTH_TOKEN: env.TURSO_AUTH_TOKEN,
-    BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET,
-    NEXT_PUBLIC_GOOGLE_CLIENT_ID: env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
-    GOOGLE_CLIENT_SECRET: env.GOOGLE_CLIENT_SECRET,
-    APPLE_CLIENT_ID: env.APPLE_CLIENT_ID,
-    APPLE_CLIENT_SECRET: env.APPLE_CLIENT_SECRET,
-    DEFAULT_TIMEZONE: env.DEFAULT_TIMEZONE || "Europe/Berlin",
-    STORAGE_PROVIDER: env.STORAGE_PROVIDER || "turso",
-    NODE_ENV: env.NODE_ENV || "production",
-  });
-}
 
 // Export for Cloudflare Workers with Sentry error monitoring
 export default Sentry.withSentry(
@@ -296,7 +279,7 @@ export default Sentry.withSentry(
     fetch: app.fetch,
     async scheduled(event: any, env: Bindings, ctx: any) {
       console.log("[CRON] Running scheduled match status update");
-      injectCronEnv(env);
+      injectEnv(env);
       ctx.waitUntil(updateMatchStatuses());
     },
   } as any,

--- a/apps/mobile-web/app.json
+++ b/apps/mobile-web/app.json
@@ -52,7 +52,7 @@
       "supportsTablet": false,
       "bundleIdentifier": "com.pepegrillo.football-with-friends",
       "usesAppleSignIn": true,
-      "buildNumber": "11",
+      "buildNumber": "12",
       "infoPlist": {
         "NSPhotoLibraryUsageDescription": "Football with Friends uses your photo library to update your profile picture.",
         "NSCameraUsageDescription": "Football with Friends uses your camera to take a profile photo.",

--- a/apps/mobile-web/app.json
+++ b/apps/mobile-web/app.json
@@ -52,7 +52,7 @@
       "supportsTablet": false,
       "bundleIdentifier": "com.pepegrillo.football-with-friends",
       "usesAppleSignIn": true,
-      "buildNumber": "9",
+      "buildNumber": "10",
       "infoPlist": {
         "NSPhotoLibraryUsageDescription": "Football with Friends uses your photo library to update your profile picture.",
         "NSCameraUsageDescription": "Football with Friends uses your camera to take a profile photo.",

--- a/apps/mobile-web/app.json
+++ b/apps/mobile-web/app.json
@@ -52,7 +52,7 @@
       "supportsTablet": false,
       "bundleIdentifier": "com.pepegrillo.football-with-friends",
       "usesAppleSignIn": true,
-      "buildNumber": "10",
+      "buildNumber": "11",
       "infoPlist": {
         "NSPhotoLibraryUsageDescription": "Football with Friends uses your photo library to update your profile picture.",
         "NSCameraUsageDescription": "Football with Friends uses your camera to take a profile photo.",

--- a/apps/mobile-web/app.json
+++ b/apps/mobile-web/app.json
@@ -51,7 +51,8 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.pepegrillo.football-with-friends",
-      "buildNumber": "7",
+      "usesAppleSignIn": true,
+      "buildNumber": "8",
       "infoPlist": {
         "NSPhotoLibraryUsageDescription": "Football with Friends uses your photo library to update your profile picture.",
         "NSCameraUsageDescription": "Football with Friends uses your camera to take a profile photo.",

--- a/apps/mobile-web/app.json
+++ b/apps/mobile-web/app.json
@@ -52,7 +52,7 @@
       "supportsTablet": false,
       "bundleIdentifier": "com.pepegrillo.football-with-friends",
       "usesAppleSignIn": true,
-      "buildNumber": "8",
+      "buildNumber": "9",
       "infoPlist": {
         "NSPhotoLibraryUsageDescription": "Football with Friends uses your photo library to update your profile picture.",
         "NSCameraUsageDescription": "Football with Friends uses your camera to take a profile photo.",

--- a/apps/mobile-web/app/(auth)/_layout.tsx
+++ b/apps/mobile-web/app/(auth)/_layout.tsx
@@ -10,27 +10,32 @@ export default function AuthLayout() {
   const { t } = useTranslation();
   const { data: session, isPending } = useSession();
 
-  // Show loading spinner while checking authentication
-  if (isPending) {
-    return (
-      <YStack
-        flex={1}
-        justifyContent="center"
-        alignItems="center"
-        backgroundColor="$background"
-      >
-        <Spinner size="large" />
-      </YStack>
-    );
-  }
-
-  // Redirect to tabs if already authenticated
-  if (session?.user) {
+  // Redirect to tabs if authenticated (but not while pending)
+  if (!isPending && session?.user) {
     return <Redirect href="/(tabs)" />;
   }
 
+  // Always render the Stack to preserve navigation state.
+  // Overlaying the spinner (instead of replacing the Stack) prevents iOS
+  // password autofill from resetting navigation when useSession re-renders.
   return (
-    <Stack
+    <>
+      {isPending && (
+        <YStack
+          position="absolute"
+          top={0}
+          left={0}
+          right={0}
+          bottom={0}
+          justifyContent="center"
+          alignItems="center"
+          backgroundColor="$background"
+          zIndex={100}
+        >
+          <Spinner size="large" />
+        </YStack>
+      )}
+      <Stack
       screenOptions={{
         headerStyle: {
           backgroundColor: theme.background?.val,
@@ -83,5 +88,6 @@ export default function AuthLayout() {
         }}
       />
     </Stack>
+    </>
   );
 }

--- a/apps/mobile-web/app/(auth)/index.tsx
+++ b/apps/mobile-web/app/(auth)/index.tsx
@@ -1,4 +1,4 @@
-import { getConfiguredApiUrl, signIn, getSession, nativeGoogleSignIn } from "@repo/api-client";
+import { getConfiguredApiUrl, signIn, getSession } from "@repo/api-client";
 // @ts-nocheck - Tamagui type recursion workaround
 import {
   Container,
@@ -82,20 +82,22 @@ export default function AuthLandingScreen() {
           router.replace("/(tabs)");
         }
       } else {
-        // Native OAuth: manually handle the browser flow (same pattern as oktoberfest app).
-        // The expoClient plugin's internal browser handling is broken — its server-side
-        // after hook doesn't append ?cookie= to the deep link redirect.
-        const { error } = await nativeGoogleSignIn();
+        // Native OAuth: expoClient handles the browser flow, cookie extraction,
+        // and session signal notification. We just need to call signIn.social()
+        // and then check the session.
+        const result = await signIn.social({
+          provider: "google",
+          callbackURL: "/",
+        });
 
-        if (error) {
-          if (error.message !== "Authentication was cancelled") {
-            setServerError(error.message || t("auth.googleSignInFailed"));
-          }
+        if (result.error) {
+          setServerError(result.error.message || t("auth.googleSignInFailed"));
           setIsGoogleLoading(false);
           return;
         }
 
-        // Session cookie stored by nativeGoogleSignIn, verify and navigate
+        // expoClient's onSuccess hook stores the cookie and notifies $sessionSignal.
+        // Verify session was established and navigate.
         const session = await getSession();
         if (session.data?.user) {
           router.replace("/(tabs)");

--- a/apps/mobile-web/app/(auth)/index.tsx
+++ b/apps/mobile-web/app/(auth)/index.tsx
@@ -28,9 +28,14 @@ export default function AuthLandingScreen() {
   const [isAppleAvailable, setIsAppleAvailable] = useState(false);
 
   useEffect(() => {
-    // Only check on physical devices — simulators return true but render the button invisibly
-    if (!Device.isDevice) return;
-    AppleAuthentication.isAvailableAsync().then(setIsAppleAvailable).catch(() => {});
+    AppleAuthentication.isAvailableAsync()
+      .then((available) => {
+        console.log("[AUTH] Apple Sign-In available:", available);
+        setIsAppleAvailable(available);
+      })
+      .catch((err) => {
+        console.log("[AUTH] Apple Sign-In check failed:", err?.message);
+      });
   }, []);
 
   // Detect dark mode for Google button styling

--- a/apps/mobile-web/app/(auth)/index.tsx
+++ b/apps/mobile-web/app/(auth)/index.tsx
@@ -1,4 +1,4 @@
-import { getConfiguredApiUrl, signIn } from "@repo/api-client";
+import { getConfiguredApiUrl, signIn, getSession } from "@repo/api-client";
 // @ts-nocheck - Tamagui type recursion workaround
 import {
   Container,
@@ -77,6 +77,10 @@ export default function AuthLandingScreen() {
           router.replace("/(tabs)");
         }
       } else {
+        // Native OAuth: expoClient opens system browser, handles callback via deep link.
+        // signIn.social() resolves after the browser flow — result.data is the initial
+        // redirect response (not user data). The session is established via cookies
+        // stored by the expoClient plugin during the deep link callback.
         const result = await signIn.social({
           provider: "google",
           callbackURL: "/",
@@ -88,12 +92,23 @@ export default function AuthLandingScreen() {
           return;
         }
 
+        // After the browser OAuth flow, the expoClient stores the session cookie
+        // and notifies $sessionSignal. Verify the session is established and navigate.
         if (result.data?.user) {
           router.replace("/(tabs)");
+        } else {
+          // The OAuth redirect flow doesn't return user data directly.
+          // Refetch session — expoClient should have stored cookies via deep link.
+          const session = await getSession();
+          if (session.data?.user) {
+            router.replace("/(tabs)");
+          } else {
+            setIsGoogleLoading(false);
+          }
         }
       }
-    } catch (err) {
-      setServerError(t("auth.googleSignInFailed"));
+    } catch (err: any) {
+      setServerError(err?.message || t("auth.googleSignInFailed"));
       setIsGoogleLoading(false);
     }
     // Note: Don't reset loading state here - BetterAuth will redirect away

--- a/apps/mobile-web/app/(auth)/index.tsx
+++ b/apps/mobile-web/app/(auth)/index.tsx
@@ -140,8 +140,11 @@ export default function AuthLandingScreen() {
         router.replace("/(tabs)");
       }
     } catch (err: any) {
+      console.error("[AUTH] Apple Sign-In error:", err?.code, err?.message, err);
       if (err?.code !== "ERR_REQUEST_CANCELED") {
-        setServerError(t("auth.appleSignInFailed"));
+        // Surface specific error message if available (e.g., "Provider not found")
+        const message = err?.message || t("auth.appleSignInFailed");
+        setServerError(message);
       }
     }
   };

--- a/apps/mobile-web/app/(auth)/index.tsx
+++ b/apps/mobile-web/app/(auth)/index.tsx
@@ -1,4 +1,4 @@
-import { getConfiguredApiUrl, signIn, getSession } from "@repo/api-client";
+import { getConfiguredApiUrl, signIn, getSession, nativeGoogleSignIn } from "@repo/api-client";
 // @ts-nocheck - Tamagui type recursion workaround
 import {
   Container,
@@ -82,34 +82,25 @@ export default function AuthLandingScreen() {
           router.replace("/(tabs)");
         }
       } else {
-        // Native OAuth: expoClient opens system browser, handles callback via deep link.
-        // signIn.social() resolves after the browser flow — result.data is the initial
-        // redirect response (not user data). The session is established via cookies
-        // stored by the expoClient plugin during the deep link callback.
-        const result = await signIn.social({
-          provider: "google",
-          callbackURL: "/",
-        });
+        // Native OAuth: manually handle the browser flow (same pattern as oktoberfest app).
+        // The expoClient plugin's internal browser handling is broken — its server-side
+        // after hook doesn't append ?cookie= to the deep link redirect.
+        const { error } = await nativeGoogleSignIn();
 
-        if (result.error) {
-          setServerError(result.error.message || t("auth.googleSignInFailed"));
+        if (error) {
+          if (error.message !== "Authentication was cancelled") {
+            setServerError(error.message || t("auth.googleSignInFailed"));
+          }
           setIsGoogleLoading(false);
           return;
         }
 
-        // After the browser OAuth flow, the expoClient stores the session cookie
-        // and notifies $sessionSignal. Verify the session is established and navigate.
-        if (result.data?.user) {
+        // Session cookie stored by nativeGoogleSignIn, verify and navigate
+        const session = await getSession();
+        if (session.data?.user) {
           router.replace("/(tabs)");
         } else {
-          // The OAuth redirect flow doesn't return user data directly.
-          // Refetch session — expoClient should have stored cookies via deep link.
-          const session = await getSession();
-          if (session.data?.user) {
-            router.replace("/(tabs)");
-          } else {
-            setIsGoogleLoading(false);
-          }
+          setIsGoogleLoading(false);
         }
       }
     } catch (err: any) {

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -18,27 +18,50 @@ const storage = {
       // so this is only called for bearer token loading which handles async separately.
       return null;
     }
-    return SecureStore.getItem(key); // sync (calls getValueWithKeySync)
+    return SecureStore.getItem(key);
   },
   setItem(key: string, value: string): void {
     if (Platform.OS === "web") {
-      AsyncStorage.setItem(key, value); // fire-and-forget on web
+      AsyncStorage.setItem(key, value);
       return;
     }
-    SecureStore.setItem(key, value); // sync (calls setValueWithKeySync)
+    SecureStore.setItem(key, value);
   },
   async deleteItem(key: string): Promise<void> {
     if (Platform.OS === "web") {
       await AsyncStorage.removeItem(key);
     } else {
-      await SecureStore.deleteItemAsync(key); // no sync version exists
+      await SecureStore.deleteItemAsync(key);
     }
   },
 };
 
-// Bearer token management (all platforms - uses SecureStore on native, AsyncStorage on web)
+// Storage keys
 const BEARER_TOKEN_KEY = "football_auth_bearer_token";
+const COOKIE_STORAGE_KEY = "football_auth_cookie";
 let _cachedBearerToken: string | undefined;
+
+/**
+ * Clear corrupted cookie data left by the old async storage adapter.
+ * The old adapter returned Promises from getItem, which got stringified
+ * and later crash getCookie() with "Cannot read property 'expires' of null".
+ */
+function cleanStaleCookieData() {
+  if (Platform.OS === "web") return;
+  try {
+    const data = storage.getItem(COOKIE_STORAGE_KEY);
+    if (!data) return;
+    const parsed = JSON.parse(data);
+    for (const v of Object.values(parsed)) {
+      if (v === null || typeof v !== "object") {
+        storage.setItem(COOKIE_STORAGE_KEY, "{}");
+        return;
+      }
+    }
+  } catch {
+    try { storage.setItem(COOKIE_STORAGE_KEY, "{}"); } catch { /* ignore */ }
+  }
+}
 
 // Promise that resolves when the initial bearer token load completes.
 // The custom fetch awaits this before the first request to avoid a race condition
@@ -53,25 +76,7 @@ const _tokenLoadPromise: Promise<void> = Promise.resolve().then(() => {
     // Ignore storage errors on init
   }
 
-  // Clean up stale/corrupted cookie data from previous async storage adapter.
-  // The old adapter stored Promise objects as strings, which causes getCookie()
-  // to crash with "Cannot read property 'expires' of null".
-  if (Platform.OS !== "web") {
-    try {
-      const cookieData = storage.getItem("football_auth_cookie");
-      if (cookieData) {
-        const parsed = JSON.parse(cookieData);
-        for (const v of Object.values(parsed)) {
-          if (v === null || typeof v !== "object") {
-            storage.setItem("football_auth_cookie", "{}");
-            break;
-          }
-        }
-      }
-    } catch {
-      try { storage.setItem("football_auth_cookie", "{}"); } catch { /* ignore */ }
-    }
-  }
+  cleanStaleCookieData();
 });
 
 /**
@@ -325,24 +330,6 @@ export async function nativeGoogleSignIn(): Promise<{ error: Error | null }> {
     // Step 3: Extract session data from redirect URL (appended by server workaround)
     const redirectURL = new URL(result.url);
 
-    // Clear any stale/corrupted cookie data from previous attempts
-    // (old async storage adapter stored Promise objects instead of strings)
-    try {
-      const stale = storage.getItem("football_auth_cookie");
-      if (stale) {
-        const parsed = JSON.parse(stale);
-        // Validate structure: every value should be an object with {value, expires}
-        for (const v of Object.values(parsed)) {
-          if (v === null || typeof v !== "object") {
-            storage.setItem("football_auth_cookie", "{}");
-            break;
-          }
-        }
-      }
-    } catch {
-      storage.setItem("football_auth_cookie", "{}");
-    }
-
     // Prefer bearer token (same proven pattern as phone auth)
     const sessionToken = redirectURL.searchParams.get("session_token");
     if (sessionToken) {
@@ -354,14 +341,12 @@ export async function nativeGoogleSignIn(): Promise<{ error: Error | null }> {
     // Fallback: extract cookie for expoClient (now works with sync storage)
     const cookie = redirectURL.searchParams.get("cookie");
     if (cookie) {
-      const cookieName = "football_auth_cookie";
-      const prevCookie = storage.getItem(cookieName);
+      const prevCookie = storage.getItem(COOKIE_STORAGE_KEY);
       try {
         const toSetCookie = getSetCookie(cookie, prevCookie ?? undefined);
-        storage.setItem(cookieName, toSetCookie);
+        storage.setItem(COOKIE_STORAGE_KEY, toSetCookie);
       } catch {
-        // If cookie parsing fails, store empty and rely on bearer token
-        storage.setItem(cookieName, "{}");
+        storage.setItem(COOKIE_STORAGE_KEY, "{}");
       }
       authClient.$store.notify("$sessionSignal");
     }

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -164,7 +164,12 @@ function createDynamicFetch() {
       const apiBase = getApiUrl();
       const finalUrl = originalUrl.replace(LOCALHOST_API, apiBase);
 
-      const fetchInit: RequestInit = { ...init, credentials: "include" };
+      // Preserve credentials set by plugins (expoClient sets "omit" on native).
+      // Only default to "include" on web for cross-domain cookie auth.
+      const fetchInit: RequestInit = { ...init };
+      if (!init?.credentials) {
+        fetchInit.credentials = Platform.OS === "web" ? "include" : "omit";
+      }
 
       // Inject Bearer token header for authenticated requests (all platforms)
       if (_cachedBearerToken) {

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -208,9 +208,10 @@ function createDynamicFetch() {
 }
 
 // Create the Better Auth client with Expo plugin for React Native
-// Use localhost as base URL but override with custom fetch for dynamic resolution
+// baseURL must resolve to the real API URL (not localhost) because the expoClient
+// plugin uses it directly for the OAuth proxy URL, bypassing createDynamicFetch.
 export const authClient = createAuthClient({
-  baseURL: LOCALHOST_API,
+  baseURL: getApiUrl(),
   fetchOptions: {
     customFetchImpl: createDynamicFetch(),
   },

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -1,32 +1,37 @@
 // Auth client for Expo/React Native
 import { createAuthClient } from "better-auth/react";
 import { usernameClient, phoneNumberClient } from "better-auth/client/plugins";
-import { expoClient } from "@better-auth/expo/client";
+import { expoClient, getSetCookie } from "@better-auth/expo/client";
 import * as SecureStore from "expo-secure-store";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Platform } from "react-native";
 
-// Storage adapter that works on both web (AsyncStorage) and native (SecureStore)
-// SecureStore doesn't work on web, so we need to use AsyncStorage there
+// Storage adapter that works on both web (AsyncStorage) and native (SecureStore).
+// IMPORTANT: getItem and setItem MUST be synchronous on native because the
+// expoClient plugin calls them without await (e.g. getCookie(storage.getItem(key))).
+// Using async here causes getItem to return a Promise (truthy), which silently
+// breaks cookie injection — getCookie(Promise) parses as empty object.
 const storage = {
-  async getItem(key: string): Promise<string | null> {
+  getItem(key: string): string | null {
     if (Platform.OS === "web") {
-      return AsyncStorage.getItem(key);
+      // expoClient skips cookie injection on web (has `if (isWeb) return` checks),
+      // so this is only called for bearer token loading which handles async separately.
+      return null;
     }
-    return SecureStore.getItemAsync(key);
+    return SecureStore.getItem(key); // sync (calls getValueWithKeySync)
   },
-  async setItem(key: string, value: string): Promise<void> {
+  setItem(key: string, value: string): void {
     if (Platform.OS === "web") {
-      await AsyncStorage.setItem(key, value);
-    } else {
-      await SecureStore.setItemAsync(key, value);
+      AsyncStorage.setItem(key, value); // fire-and-forget on web
+      return;
     }
+    SecureStore.setItem(key, value); // sync (calls setValueWithKeySync)
   },
   async deleteItem(key: string): Promise<void> {
     if (Platform.OS === "web") {
       await AsyncStorage.removeItem(key);
     } else {
-      await SecureStore.deleteItemAsync(key);
+      await SecureStore.deleteItemAsync(key); // no sync version exists
     }
   },
 };
@@ -38,14 +43,36 @@ let _cachedBearerToken: string | undefined;
 // Promise that resolves when the initial bearer token load completes.
 // The custom fetch awaits this before the first request to avoid a race condition
 // where useSession() fires getSession() before the token is loaded from storage.
-const _tokenLoadPromise: Promise<void> = storage
-  .getItem(BEARER_TOKEN_KEY)
-  .then((token) => {
+// storage.getItem is now sync on native, but we keep the Promise wrapper so
+// createDynamicFetch() can still `await _tokenLoadPromise` uniformly.
+const _tokenLoadPromise: Promise<void> = Promise.resolve().then(() => {
+  try {
+    const token = storage.getItem(BEARER_TOKEN_KEY);
     if (token) _cachedBearerToken = token;
-  })
-  .catch(() => {
+  } catch {
     // Ignore storage errors on init
-  });
+  }
+
+  // Clean up stale/corrupted cookie data from previous async storage adapter.
+  // The old adapter stored Promise objects as strings, which causes getCookie()
+  // to crash with "Cannot read property 'expires' of null".
+  if (Platform.OS !== "web") {
+    try {
+      const cookieData = storage.getItem("football_auth_cookie");
+      if (cookieData) {
+        const parsed = JSON.parse(cookieData);
+        for (const v of Object.values(parsed)) {
+          if (v === null || typeof v !== "object") {
+            storage.setItem("football_auth_cookie", "{}");
+            break;
+          }
+        }
+      }
+    } catch {
+      try { storage.setItem("football_auth_cookie", "{}"); } catch { /* ignore */ }
+    }
+  }
+});
 
 /**
  * Store a bearer token for authentication.
@@ -199,7 +226,7 @@ function createDynamicFetch() {
           // verification, and avoids URL-encoding issues across platforms.
           const tokenPart = newToken.split(".")[0] || newToken;
           _cachedBearerToken = tokenPart;
-          storage.setItem(BEARER_TOKEN_KEY, tokenPart).catch(console.error);
+          try { storage.setItem(BEARER_TOKEN_KEY, tokenPart); } catch { /* ignore */ }
         }
         // Clear token when signing out
         if (finalUrl.includes("/sign-out")) {
@@ -295,18 +322,47 @@ export async function nativeGoogleSignIn(): Promise<{ error: Error | null }> {
       return { error: new Error("Authentication failed") };
     }
 
-    // Step 3: Extract cookie from redirect URL (appended by server workaround)
+    // Step 3: Extract session data from redirect URL (appended by server workaround)
     const redirectURL = new URL(result.url);
-    const cookie = redirectURL.searchParams.get("cookie");
 
+    // Clear any stale/corrupted cookie data from previous attempts
+    // (old async storage adapter stored Promise objects instead of strings)
+    try {
+      const stale = storage.getItem("football_auth_cookie");
+      if (stale) {
+        const parsed = JSON.parse(stale);
+        // Validate structure: every value should be an object with {value, expires}
+        for (const v of Object.values(parsed)) {
+          if (v === null || typeof v !== "object") {
+            storage.setItem("football_auth_cookie", "{}");
+            break;
+          }
+        }
+      }
+    } catch {
+      storage.setItem("football_auth_cookie", "{}");
+    }
+
+    // Prefer bearer token (same proven pattern as phone auth)
+    const sessionToken = redirectURL.searchParams.get("session_token");
+    if (sessionToken) {
+      await storeBearerToken(sessionToken);
+      authClient.$store.notify("$sessionSignal");
+      return { error: null };
+    }
+
+    // Fallback: extract cookie for expoClient (now works with sync storage)
+    const cookie = redirectURL.searchParams.get("cookie");
     if (cookie) {
-      // Store cookie in the expoClient's storage so useSession() picks it up
       const cookieName = "football_auth_cookie";
-      const { getSetCookie } = require("@better-auth/expo/client");
-      const prevCookie = await storage.getItem(cookieName);
-      const toSetCookie = getSetCookie(cookie, prevCookie ?? undefined);
-      await storage.setItem(cookieName, toSetCookie);
-      // Notify the session signal to trigger useSession() refetch
+      const prevCookie = storage.getItem(cookieName);
+      try {
+        const toSetCookie = getSetCookie(cookie, prevCookie ?? undefined);
+        storage.setItem(cookieName, toSetCookie);
+      } catch {
+        // If cookie parsing fails, store empty and rely on bearer token
+        storage.setItem(cookieName, "{}");
+      }
       authClient.$store.notify("$sessionSignal");
     }
 

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -207,9 +207,10 @@ function createDynamicFetch() {
   }) as typeof fetch;
 }
 
-// Create the Better Auth client with Expo plugin for React Native
-// baseURL must resolve to the real API URL (not localhost) because the expoClient
-// plugin uses it directly for the OAuth proxy URL, bypassing createDynamicFetch.
+// Create the Better Auth client with Expo plugin for React Native.
+// baseURL uses getApiUrl() which resolves process.env.EXPO_PUBLIC_API_URL at build
+// time (Metro inlines it). The expoClient plugin reads baseURL directly for the
+// OAuth proxy URL, so it must point to the real API — not localhost.
 export const authClient = createAuthClient({
   baseURL: getApiUrl(),
   fetchOptions: {
@@ -219,9 +220,8 @@ export const authClient = createAuthClient({
     usernameClient(),
     phoneNumberClient(),
     expoClient({
-      scheme: "football-with-friends", // Deep link scheme from app.json
+      scheme: "football-with-friends",
       storagePrefix: "football_auth",
-      // Type assertion needed due to mismatch between async storage and expected sync type
       storage: storage as any,
     }),
   ],

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -242,6 +242,82 @@ export const {
   $Infer,
 } = authClient;
 
+/**
+ * Native Google OAuth sign-in — bypasses expoClient's broken browser handling.
+ * Mirrors the pattern from the working oktoberfest/Supabase implementation:
+ * 1. POST to get Google auth URL
+ * 2. Open browser manually via WebBrowser.openAuthSessionAsync
+ * 3. Extract session cookie from the redirect URL
+ * 4. Store cookie and notify session signal
+ */
+export async function nativeGoogleSignIn(): Promise<{ error: Error | null }> {
+  if (Platform.OS === "web") {
+    return { error: new Error("Use web Google sign-in flow instead") };
+  }
+
+  try {
+    const Linking = require("expo-linking");
+    const WebBrowser = require("expo-web-browser");
+
+    const baseURL = getApiUrl();
+    const callbackURL = Linking.createURL("/");
+
+    // Step 1: Get Google auth URL from the API
+    const response = await fetch(`${baseURL}/api/auth/sign-in/social`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "expo-origin": Linking.createURL("", { scheme: "football-with-friends" }),
+        "x-skip-oauth-proxy": "true",
+      },
+      body: JSON.stringify({
+        provider: "google",
+        callbackURL,
+      }),
+      credentials: "omit",
+    });
+
+    const data = await response.json();
+    if (!data.url || !data.redirect) {
+      return { error: new Error(data.error?.message || "Failed to get Google auth URL") };
+    }
+
+    // Step 2: Build proxy URL and open browser manually
+    const proxyURL = `${baseURL}/api/auth/expo-authorization-proxy?authorizationURL=${encodeURIComponent(data.url)}`;
+    const result = await WebBrowser.openAuthSessionAsync(proxyURL, callbackURL, {
+      showInRecents: true,
+    });
+
+    if (result.type !== "success") {
+      if (result.type === "cancel") {
+        return { error: new Error("Authentication was cancelled") };
+      }
+      return { error: new Error("Authentication failed") };
+    }
+
+    // Step 3: Extract cookie from redirect URL (appended by server workaround)
+    const redirectURL = new URL(result.url);
+    const cookie = redirectURL.searchParams.get("cookie");
+
+    if (cookie) {
+      // Store cookie in the expoClient's storage so useSession() picks it up
+      const cookieName = "football_auth_cookie";
+      const { getSetCookie } = require("@better-auth/expo/client");
+      const prevCookie = await storage.getItem(cookieName);
+      const toSetCookie = getSetCookie(cookie, prevCookie ?? undefined);
+      await storage.setItem(cookieName, toSetCookie);
+      // Notify the session signal to trigger useSession() refetch
+      authClient.$store.notify("$sessionSignal");
+    }
+
+    return { error: null };
+  } catch (err) {
+    return {
+      error: err instanceof Error ? err : new Error("Google sign-in failed"),
+    };
+  }
+}
+
 // Phone authentication helpers
 export interface PhoneSignUpData {
   phoneNumber: string;

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -1,7 +1,7 @@
 // Auth client for Expo/React Native
 import { createAuthClient } from "better-auth/react";
 import { usernameClient, phoneNumberClient } from "better-auth/client/plugins";
-import { expoClient, getSetCookie } from "@better-auth/expo/client";
+import { expoClient } from "@better-auth/expo/client";
 import * as SecureStore from "expo-secure-store";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Platform } from "react-native";
@@ -36,9 +36,7 @@ const storage = {
   },
 };
 
-// Storage keys
 const BEARER_TOKEN_KEY = "football_auth_bearer_token";
-const COOKIE_STORAGE_KEY = "football_auth_cookie";
 let _cachedBearerToken: string | undefined;
 
 /**
@@ -48,18 +46,19 @@ let _cachedBearerToken: string | undefined;
  */
 function cleanStaleCookieData() {
   if (Platform.OS === "web") return;
+  const key = "football_auth_cookie";
   try {
-    const data = storage.getItem(COOKIE_STORAGE_KEY);
+    const data = storage.getItem(key);
     if (!data) return;
     const parsed = JSON.parse(data);
     for (const v of Object.values(parsed)) {
       if (v === null || typeof v !== "object") {
-        storage.setItem(COOKIE_STORAGE_KEY, "{}");
+        storage.setItem(key, "{}");
         return;
       }
     }
   } catch {
-    try { storage.setItem(COOKIE_STORAGE_KEY, "{}"); } catch { /* ignore */ }
+    try { storage.setItem(key, "{}"); } catch { /* ignore */ }
   }
 }
 
@@ -273,91 +272,6 @@ export const {
   getSession,
   $Infer,
 } = authClient;
-
-/**
- * Native Google OAuth sign-in — bypasses expoClient's broken browser handling.
- * Mirrors the pattern from the working oktoberfest/Supabase implementation:
- * 1. POST to get Google auth URL
- * 2. Open browser manually via WebBrowser.openAuthSessionAsync
- * 3. Extract session cookie from the redirect URL
- * 4. Store cookie and notify session signal
- */
-export async function nativeGoogleSignIn(): Promise<{ error: Error | null }> {
-  if (Platform.OS === "web") {
-    return { error: new Error("Use web Google sign-in flow instead") };
-  }
-
-  try {
-    const Linking = require("expo-linking");
-    const WebBrowser = require("expo-web-browser");
-
-    const baseURL = getApiUrl();
-    const callbackURL = Linking.createURL("/");
-
-    // Step 1: Get Google auth URL from the API
-    const response = await fetch(`${baseURL}/api/auth/sign-in/social`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "expo-origin": Linking.createURL("", { scheme: "football-with-friends" }),
-        "x-skip-oauth-proxy": "true",
-      },
-      body: JSON.stringify({
-        provider: "google",
-        callbackURL,
-      }),
-      credentials: "omit",
-    });
-
-    const data = await response.json();
-    if (!data.url || !data.redirect) {
-      return { error: new Error(data.error?.message || "Failed to get Google auth URL") };
-    }
-
-    // Step 2: Build proxy URL and open browser manually
-    const proxyURL = `${baseURL}/api/auth/expo-authorization-proxy?authorizationURL=${encodeURIComponent(data.url)}`;
-    const result = await WebBrowser.openAuthSessionAsync(proxyURL, callbackURL, {
-      showInRecents: true,
-    });
-
-    if (result.type !== "success") {
-      if (result.type === "cancel") {
-        return { error: new Error("Authentication was cancelled") };
-      }
-      return { error: new Error("Authentication failed") };
-    }
-
-    // Step 3: Extract session data from redirect URL (appended by server workaround)
-    const redirectURL = new URL(result.url);
-
-    // Prefer bearer token (same proven pattern as phone auth)
-    const sessionToken = redirectURL.searchParams.get("session_token");
-    if (sessionToken) {
-      await storeBearerToken(sessionToken);
-      authClient.$store.notify("$sessionSignal");
-      return { error: null };
-    }
-
-    // Fallback: extract cookie for expoClient (now works with sync storage)
-    const cookie = redirectURL.searchParams.get("cookie");
-    if (cookie) {
-      const prevCookie = storage.getItem(COOKIE_STORAGE_KEY);
-      try {
-        const toSetCookie = getSetCookie(cookie, prevCookie ?? undefined);
-        storage.setItem(COOKIE_STORAGE_KEY, toSetCookie);
-      } catch {
-        storage.setItem(COOKIE_STORAGE_KEY, "{}");
-      }
-      authClient.$store.notify("$sessionSignal");
-    }
-
-    return { error: null };
-  } catch (err) {
-    return {
-      error: err instanceof Error ? err : new Error("Google sign-in failed"),
-    };
-  }
-}
 
 // Phone authentication helpers
 export interface PhoneSignUpData {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -35,6 +35,7 @@ export {
   requestPasswordReset,
   resetPasswordWithCode,
   getAdminResetCodes,
+  nativeGoogleSignIn,
 } from "./auth";
 export type { Session, User, PhoneSignUpData, PhoneSignInData } from "./auth";
 

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -35,7 +35,6 @@ export {
   requestPasswordReset,
   resetPasswordWithCode,
   getAdminResetCodes,
-  nativeGoogleSignIn,
 } from "./auth";
 export type { Session, User, PhoneSignUpData, PhoneSignInData } from "./auth";
 

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -239,6 +239,8 @@ function WebSelect({
   );
 }
 
+const SHEET_SNAP_POINTS = [90];
+
 // Native Tamagui Select for mobile with Adapt Sheet
 function NativeSelect({
   label,
@@ -292,7 +294,7 @@ function NativeSelect({
           <Sheet
             modal
             dismissOnSnapToBottom
-            snapPointsMode="fit"
+            snapPoints={SHEET_SNAP_POINTS}
           >
             <Sheet.Frame backgroundColor="$background" paddingTop={top} paddingLeft={left} paddingRight={right}>
               {searchable && (


### PR DESCRIPTION
## Summary
- **Google OAuth on native**: Use `getApiUrl()` as `authClient` `baseURL` so the expoClient plugin builds the OAuth proxy URL with the production API instead of hardcoded localhost
- **Apple Sign-In**: Added `usesAppleSignIn: true` to app.json iOS config + set `APPLE_CLIENT_ID` and `APPLE_CLIENT_SECRET` as Cloudflare Worker secrets (key 458VVSTX4T)
- **iOS password autofill navigation reset**: Auth layout now keeps the Stack mounted during `isPending` state (overlays spinner instead of replacing), preventing navigation state loss when `useSession` re-renders during autofill
- **Country picker scroll**: Changed Sheet `snapPointsMode="fit"` to `snapPoints=[90]` so the country list gets 90% screen height and scrolls past Bahrain
