### PR TITLE
Add account deletion and legal compliance

### DIFF
--- a/apps/api/src/routes/profile.ts
+++ b/apps/api/src/routes/profile.ts
@@ -458,7 +458,7 @@ app.post(
 
     // Validate confirmation text (accept both "DELETE" and "ELIMINAR")
     const validConfirmTexts = ["DELETE", "ELIMINAR"];
-    if (!validConfirmTexts.includes(confirmText.toUpperCase())) {
+    if (!validConfirmTexts.includes(confirmText.trim().toUpperCase())) {
       return c.json({ error: "Invalid confirmation text" }, 400);
     }
 

--- a/apps/api/src/routes/profile.ts
+++ b/apps/api/src/routes/profile.ts
@@ -11,6 +11,7 @@ import {
   type R2Bucket,
 } from "../lib/r2";
 import { type AppVariables, requireUser } from "../middleware/security";
+import { verifyPassword } from "../crypto/password";
 
 // Phone number validation (international format)
 const phoneRegex = /^\+[1-9]\d{6,14}$/;
@@ -437,6 +438,82 @@ app.post(
       }
 
       return c.json({ error: "Failed to set password" }, 500);
+    }
+  }
+);
+
+// Delete account — permanently removes user and all associated data
+const deleteAccountSchema = z.object({
+  confirmText: z.string(),
+  password: z.string().optional(),
+});
+
+app.post(
+  "/delete-account",
+  zValidator("json", deleteAccountSchema),
+  async (c) => {
+    const { confirmText, password } = c.req.valid("json");
+    const user = requireUser(c);
+    const userId = user.id;
+
+    // Validate confirmation text (accept both "DELETE" and "ELIMINAR")
+    const validConfirmTexts = ["DELETE", "ELIMINAR"];
+    if (!validConfirmTexts.includes(confirmText.toUpperCase())) {
+      return c.json({ error: "Invalid confirmation text" }, 400);
+    }
+
+    try {
+      const db = getDatabase();
+
+      // Check if user has a credential account (password-based)
+      const credentialAccount = await db
+        .selectFrom("account")
+        .select(["id", "password"])
+        .where("userId", "=", userId)
+        .where("providerId", "=", "credential")
+        .executeTakeFirst();
+
+      // If user has a password, require it for deletion
+      if (credentialAccount) {
+        if (!password) {
+          return c.json({ error: "Password is required to delete your account", requiresPassword: true }, 400);
+        }
+        const storedHash = credentialAccount.password;
+        if (storedHash) {
+          const isValid = await verifyPassword({ password, hash: storedHash });
+          if (!isValid) {
+            return c.json({ error: "Incorrect password" }, 400);
+          }
+        }
+      }
+
+      // Clean up non-cascading user data (independent operations run in parallel)
+      await Promise.all([
+        db.deleteFrom("push_tokens").where("user_id", "=", userId).execute(),
+        db.deleteFrom("match_player_stats").where("user_id", "=", userId).execute(),
+        db.deleteFrom("match_votes").where("voter_user_id", "=", userId).execute(),
+        db.deleteFrom("match_votes").where("voted_for_user_id", "=", userId).execute(),
+        db.updateTable("signups").set({ user_id: null }).where("user_id", "=", userId).execute(),
+        db.deleteFrom("match_invitations").where("invited_by_user_id", "=", userId).execute(),
+      ]);
+
+      // Clean up R2 profile pictures
+      try {
+        const bucket = c.env?.PROFILE_PICTURES;
+        if (bucket) {
+          await deleteOldProfilePictures(bucket, userId, 0);
+        }
+      } catch (e) {
+        console.error("Failed to clean up profile pictures:", e);
+      }
+
+      // Delete user row — account and session tables CASCADE automatically
+      await db.deleteFrom("user").where("id", "=", userId).execute();
+
+      return c.json({ success: true });
+    } catch (error) {
+      console.error("Delete account error:", error);
+      return c.json({ error: "Failed to delete account" }, 500);
     }
   }
 );

--- a/apps/mobile-web/app/(tabs)/profile/index.tsx
+++ b/apps/mobile-web/app/(tabs)/profile/index.tsx
@@ -674,7 +674,7 @@ export default function ProfileScreen() {
                 { label: "profile.termsOfService", url: `${getWebAppUrl()}/terms.html` },
                 { label: "profile.support", url: "mailto:pepe.grillo.parlante@gmail.com" },
               ].map((link) => (
-                <Pressable key={link.label} onPress={() => Linking.openURL(link.url)}>
+                <Pressable key={link.label} onPress={() => Linking.openURL(link.url).catch(() => {})}>
                   <XStack justifyContent="space-between" alignItems="center" paddingVertical="$2">
                     <Text color="$gray11" fontSize="$2">{t(link.label)}</Text>
                     <Text color="$gray10" fontSize="$2">&#8250;</Text>

--- a/apps/mobile-web/app/(tabs)/profile/index.tsx
+++ b/apps/mobile-web/app/(tabs)/profile/index.tsx
@@ -4,6 +4,8 @@ import {
   signOut,
   client,
   getConfiguredApiUrl,
+  getWebAppUrl,
+  deleteAccount,
 } from "@repo/api-client";
 import {
   Container,
@@ -35,7 +37,9 @@ import {
   Pressable,
   Platform,
   Alert,
+  Linking,
 } from "react-native";
+import Constants from "expo-constants";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { changeLanguage, getCurrentLanguage } from "../../../lib/i18n";
@@ -58,6 +62,13 @@ export default function ProfileScreen() {
   const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
+
+  // Delete account state
+  const [isDeletingAccount, setIsDeletingAccount] = useState(false);
+  const [deleteConfirmText, setDeleteConfirmText] = useState("");
+  const [deletePassword, setDeletePassword] = useState("");
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   // Password change state
   const [currentPassword, setCurrentPassword] = useState("");
@@ -90,6 +101,33 @@ export default function ProfileScreen() {
     } catch {}
     await signOut();
     router.replace("/(auth)");
+  };
+
+  const handleDeleteAccount = async () => {
+    const expectedWord = t("profile.deleteConfirmWord");
+    if (deleteConfirmText.toUpperCase() !== expectedWord.toUpperCase()) {
+      setDeleteError(t("profile.deleteAccountConfirm"));
+      return;
+    }
+
+    setIsDeleting(true);
+    setDeleteError(null);
+
+    try {
+      // Unregister push token first
+      try {
+        const { unregisterPushToken } = await import("../../../lib/use-push-notifications");
+        await unregisterPushToken();
+      } catch {}
+
+      await deleteAccount(deleteConfirmText, deletePassword || undefined);
+      await signOut();
+      router.replace("/(auth)");
+    } catch (err: any) {
+      setDeleteError(err.message || t("profile.deleteAccountFailed"));
+    } finally {
+      setIsDeleting(false);
+    }
   };
 
   const handleLanguageChange = async (lang: "en" | "es") => {
@@ -651,10 +689,108 @@ export default function ProfileScreen() {
                 </Button>
               )}
 
+              {/* Legal Section */}
+              <YStack gap="$2" marginTop="$3">
+                <Text fontSize="$4" fontWeight="600" color="$gray11">
+                  {t("profile.legal")}
+                </Text>
+                {[
+                  { label: "profile.privacyPolicy", url: `${getWebAppUrl()}/privacy.html` },
+                  { label: "profile.termsOfService", url: `${getWebAppUrl()}/terms.html` },
+                  { label: "profile.support", url: "mailto:pepe.grillo.parlante@gmail.com" },
+                ].map((link) => (
+                  <Pressable key={link.label} onPress={() => Linking.openURL(link.url)}>
+                    <XStack justifyContent="space-between" alignItems="center" paddingVertical="$2">
+                      <Text color="$gray11">{t(link.label)}</Text>
+                      <Text color="$gray10" fontSize="$3">&#8250;</Text>
+                    </XStack>
+                  </Pressable>
+                ))}
+              </YStack>
+
+              {/* App Version */}
+              <XStack justifyContent="space-between" alignItems="center" marginTop="$2">
+                <Text color="$gray10" fontSize="$3">{t("profile.appVersion")}</Text>
+                <Text color="$gray10" fontSize="$3">
+                  {Constants.expoConfig?.version || "1.0.0"}
+                </Text>
+              </XStack>
+
               {/* Sign Out Button */}
-              <Button variant="danger" onPress={handleSignOut} marginTop="$2">
+              <Button variant="danger" onPress={handleSignOut} marginTop="$3">
                 {t("shared.signOut")}
               </Button>
+
+              {/* Delete Account Section */}
+              {isDeletingAccount ? (
+                <YStack gap="$3" marginTop="$3" paddingTop="$3" borderTopWidth={1} borderTopColor="$red5">
+                  <Text color="$red10" fontSize="$3" fontWeight="600">
+                    {t("profile.deleteAccountTitle")}
+                  </Text>
+                  <Text color="$red9" fontSize="$2">
+                    {t("profile.deleteAccountWarning")}
+                  </Text>
+
+                  <Input
+                    label={t("profile.deleteAccountConfirm")}
+                    placeholder={t("profile.deleteConfirmWord")}
+                    value={deleteConfirmText}
+                    onChangeText={setDeleteConfirmText}
+                    autoCapitalize="characters"
+                  />
+
+                  {primaryAuthMethod !== "google" &&
+                    primaryAuthMethod !== "apple" && (
+                    <Input
+                      label={t("auth.password")}
+                      placeholder={t("auth.passwordPlaceholder")}
+                      value={deletePassword}
+                      onChangeText={setDeletePassword}
+                      secureTextEntry
+                    />
+                  )}
+
+                  {deleteError && (
+                    <Text color="$red10" fontSize="$3">
+                      {deleteError}
+                    </Text>
+                  )}
+
+                  <XStack gap="$2">
+                    <Button
+                      flex={1}
+                      variant="outline"
+                      onPress={() => {
+                        setIsDeletingAccount(false);
+                        setDeleteConfirmText("");
+                        setDeletePassword("");
+                        setDeleteError(null);
+                      }}
+                      disabled={isDeleting}
+                    >
+                      {t("shared.cancel")}
+                    </Button>
+                    <Button
+                      flex={1}
+                      variant="danger"
+                      onPress={handleDeleteAccount}
+                      disabled={isDeleting}
+                    >
+                      {isDeleting ? <Spinner size="small" /> : t("profile.deleteAccount")}
+                    </Button>
+                  </XStack>
+                </YStack>
+              ) : (
+                <Button
+                  variant="outline"
+                  onPress={() => setIsDeletingAccount(true)}
+                  marginTop="$2"
+                  color="$red10"
+                  borderColor="$red7"
+                >
+                  {t("profile.deleteAccount")}
+                </Button>
+              )}
             </YStack>
           </Card>
         </YStack>

--- a/apps/mobile-web/app/(tabs)/profile/index.tsx
+++ b/apps/mobile-web/app/(tabs)/profile/index.tsx
@@ -5,7 +5,6 @@ import {
   client,
   getConfiguredApiUrl,
   getWebAppUrl,
-  deleteAccount,
 } from "@repo/api-client";
 import {
   Container,
@@ -42,6 +41,7 @@ import {
 import Constants from "expo-constants";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import { DeleteAccountSection } from "../../../components/delete-account";
 import { changeLanguage, getCurrentLanguage } from "../../../lib/i18n";
 import { useThemeContext } from "../../../lib/theme-context";
 
@@ -62,13 +62,6 @@ export default function ProfileScreen() {
   const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
-
-  // Delete account state
-  const [isDeletingAccount, setIsDeletingAccount] = useState(false);
-  const [deleteConfirmText, setDeleteConfirmText] = useState("");
-  const [deletePassword, setDeletePassword] = useState("");
-  const [deleteError, setDeleteError] = useState<string | null>(null);
-  const [isDeleting, setIsDeleting] = useState(false);
 
   // Password change state
   const [currentPassword, setCurrentPassword] = useState("");
@@ -101,33 +94,6 @@ export default function ProfileScreen() {
     } catch {}
     await signOut();
     router.replace("/(auth)");
-  };
-
-  const handleDeleteAccount = async () => {
-    const expectedWord = t("profile.deleteConfirmWord");
-    if (deleteConfirmText.toUpperCase() !== expectedWord.toUpperCase()) {
-      setDeleteError(t("profile.deleteAccountConfirm"));
-      return;
-    }
-
-    setIsDeleting(true);
-    setDeleteError(null);
-
-    try {
-      // Unregister push token first
-      try {
-        const { unregisterPushToken } = await import("../../../lib/use-push-notifications");
-        await unregisterPushToken();
-      } catch {}
-
-      await deleteAccount(deleteConfirmText, deletePassword || undefined);
-      await signOut();
-      router.replace("/(auth)");
-    } catch (err: any) {
-      setDeleteError(err.message || t("profile.deleteAccountFailed"));
-    } finally {
-      setIsDeleting(false);
-    }
   };
 
   const handleLanguageChange = async (lang: "en" | "es") => {
@@ -689,108 +655,43 @@ export default function ProfileScreen() {
                 </Button>
               )}
 
-              {/* Legal Section */}
-              <YStack gap="$2" marginTop="$3">
-                <Text fontSize="$4" fontWeight="600" color="$gray11">
-                  {t("profile.legal")}
-                </Text>
-                {[
-                  { label: "profile.privacyPolicy", url: `${getWebAppUrl()}/privacy.html` },
-                  { label: "profile.termsOfService", url: `${getWebAppUrl()}/terms.html` },
-                  { label: "profile.support", url: "mailto:pepe.grillo.parlante@gmail.com" },
-                ].map((link) => (
-                  <Pressable key={link.label} onPress={() => Linking.openURL(link.url)}>
-                    <XStack justifyContent="space-between" alignItems="center" paddingVertical="$2">
-                      <Text color="$gray11">{t(link.label)}</Text>
-                      <Text color="$gray10" fontSize="$3">&#8250;</Text>
-                    </XStack>
-                  </Pressable>
-                ))}
-              </YStack>
+              {/* Sign Out Button */}
+              <Button variant="danger" onPress={handleSignOut} marginTop="$3">
+                {t("shared.signOut")}
+              </Button>
+            </YStack>
+          </Card>
+
+          {/* Legal & Account Card */}
+          <Card variant="outlined">
+            <YStack gap="$3">
+              <Text fontSize="$5" fontWeight="600">
+                {t("profile.legal")}
+              </Text>
+
+              {[
+                { label: "profile.privacyPolicy", url: `${getWebAppUrl()}/privacy.html` },
+                { label: "profile.termsOfService", url: `${getWebAppUrl()}/terms.html` },
+                { label: "profile.support", url: "mailto:pepe.grillo.parlante@gmail.com" },
+              ].map((link) => (
+                <Pressable key={link.label} onPress={() => Linking.openURL(link.url)}>
+                  <XStack justifyContent="space-between" alignItems="center" paddingVertical="$2">
+                    <Text color="$gray11" fontSize="$2">{t(link.label)}</Text>
+                    <Text color="$gray10" fontSize="$2">&#8250;</Text>
+                  </XStack>
+                </Pressable>
+              ))}
 
               {/* App Version */}
-              <XStack justifyContent="space-between" alignItems="center" marginTop="$2">
+              <XStack justifyContent="space-between" alignItems="center" marginTop="$1">
                 <Text color="$gray10" fontSize="$3">{t("profile.appVersion")}</Text>
                 <Text color="$gray10" fontSize="$3">
                   {Constants.expoConfig?.version || "1.0.0"}
                 </Text>
               </XStack>
 
-              {/* Sign Out Button */}
-              <Button variant="danger" onPress={handleSignOut} marginTop="$3">
-                {t("shared.signOut")}
-              </Button>
-
-              {/* Delete Account Section */}
-              {isDeletingAccount ? (
-                <YStack gap="$3" marginTop="$3" paddingTop="$3" borderTopWidth={1} borderTopColor="$red5">
-                  <Text color="$red10" fontSize="$3" fontWeight="600">
-                    {t("profile.deleteAccountTitle")}
-                  </Text>
-                  <Text color="$red9" fontSize="$2">
-                    {t("profile.deleteAccountWarning")}
-                  </Text>
-
-                  <Input
-                    label={t("profile.deleteAccountConfirm")}
-                    placeholder={t("profile.deleteConfirmWord")}
-                    value={deleteConfirmText}
-                    onChangeText={setDeleteConfirmText}
-                    autoCapitalize="characters"
-                  />
-
-                  {primaryAuthMethod !== "google" &&
-                    primaryAuthMethod !== "apple" && (
-                    <Input
-                      label={t("auth.password")}
-                      placeholder={t("auth.passwordPlaceholder")}
-                      value={deletePassword}
-                      onChangeText={setDeletePassword}
-                      secureTextEntry
-                    />
-                  )}
-
-                  {deleteError && (
-                    <Text color="$red10" fontSize="$3">
-                      {deleteError}
-                    </Text>
-                  )}
-
-                  <XStack gap="$2">
-                    <Button
-                      flex={1}
-                      variant="outline"
-                      onPress={() => {
-                        setIsDeletingAccount(false);
-                        setDeleteConfirmText("");
-                        setDeletePassword("");
-                        setDeleteError(null);
-                      }}
-                      disabled={isDeleting}
-                    >
-                      {t("shared.cancel")}
-                    </Button>
-                    <Button
-                      flex={1}
-                      variant="danger"
-                      onPress={handleDeleteAccount}
-                      disabled={isDeleting}
-                    >
-                      {isDeleting ? <Spinner size="small" /> : t("profile.deleteAccount")}
-                    </Button>
-                  </XStack>
-                </YStack>
-              ) : (
-                <Button
-                  variant="outline"
-                  onPress={() => setIsDeletingAccount(true)}
-                  marginTop="$2"
-                  color="$red10"
-                  borderColor="$red7"
-                >
-                  {t("profile.deleteAccount")}
-                </Button>
-              )}
+              {/* Delete Account */}
+              <DeleteAccountSection primaryAuthMethod={primaryAuthMethod} />
             </YStack>
           </Card>
         </YStack>

--- a/apps/mobile-web/components/delete-account.tsx
+++ b/apps/mobile-web/components/delete-account.tsx
@@ -16,10 +16,14 @@ export function DeleteAccountSection({ primaryAuthMethod }: DeleteAccountSection
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [showPassword, setShowPassword] = useState(
+    primaryAuthMethod !== "google" && primaryAuthMethod !== "apple"
+  );
 
   const handleDelete = async () => {
+    const trimmed = confirmText.trim();
     const expectedWord = t("profile.deleteConfirmWord");
-    if (confirmText.toUpperCase() !== expectedWord.toUpperCase()) {
+    if (trimmed.toUpperCase() !== expectedWord.toUpperCase()) {
       setError(t("profile.deleteAccountConfirm"));
       return;
     }
@@ -33,10 +37,14 @@ export function DeleteAccountSection({ primaryAuthMethod }: DeleteAccountSection
         await unregisterPushToken();
       } catch {}
 
-      await deleteAccount(confirmText, password || undefined);
+      await deleteAccount(trimmed, password || undefined);
       await signOut();
       router.replace("/(auth)");
     } catch (err: any) {
+      // If server says password is required (e.g. Google user who later set a password)
+      if (err.message?.includes("Password is required")) {
+        setShowPassword(true);
+      }
       setError(err.message || t("profile.deleteAccountFailed"));
     } finally {
       setIsDeleting(false);
@@ -49,8 +57,6 @@ export function DeleteAccountSection({ primaryAuthMethod }: DeleteAccountSection
     setPassword("");
     setError(null);
   };
-
-  const needsPassword = primaryAuthMethod !== "google" && primaryAuthMethod !== "apple";
 
   if (!isExpanded) {
     return (
@@ -83,7 +89,7 @@ export function DeleteAccountSection({ primaryAuthMethod }: DeleteAccountSection
         autoCapitalize="characters"
       />
 
-      {needsPassword && (
+      {showPassword && (
         <Input
           label={t("auth.password")}
           placeholder={t("auth.passwordPlaceholder")}

--- a/apps/mobile-web/components/delete-account.tsx
+++ b/apps/mobile-web/components/delete-account.tsx
@@ -1,0 +1,122 @@
+// @ts-nocheck - Tamagui type recursion workaround
+import { signOut, deleteAccount } from "@repo/api-client";
+import { YStack, XStack, Text, Button, Input, Spinner } from "@repo/ui";
+import { router } from "expo-router";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface DeleteAccountSectionProps {
+  primaryAuthMethod: string;
+}
+
+export function DeleteAccountSection({ primaryAuthMethod }: DeleteAccountSectionProps) {
+  const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    const expectedWord = t("profile.deleteConfirmWord");
+    if (confirmText.toUpperCase() !== expectedWord.toUpperCase()) {
+      setError(t("profile.deleteAccountConfirm"));
+      return;
+    }
+
+    setIsDeleting(true);
+    setError(null);
+
+    try {
+      try {
+        const { unregisterPushToken } = await import("../lib/use-push-notifications");
+        await unregisterPushToken();
+      } catch {}
+
+      await deleteAccount(confirmText, password || undefined);
+      await signOut();
+      router.replace("/(auth)");
+    } catch (err: any) {
+      setError(err.message || t("profile.deleteAccountFailed"));
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setIsExpanded(false);
+    setConfirmText("");
+    setPassword("");
+    setError(null);
+  };
+
+  const needsPassword = primaryAuthMethod !== "google" && primaryAuthMethod !== "apple";
+
+  if (!isExpanded) {
+    return (
+      <Button
+        variant="outline"
+        onPress={() => setIsExpanded(true)}
+        marginTop="$2"
+        color="$red10"
+        borderColor="$red7"
+      >
+        {t("profile.deleteAccount")}
+      </Button>
+    );
+  }
+
+  return (
+    <YStack gap="$3" marginTop="$3" paddingTop="$3" borderTopWidth={1} borderTopColor="$red5">
+      <Text color="$red10" fontSize="$3" fontWeight="600">
+        {t("profile.deleteAccountTitle")}
+      </Text>
+      <Text color="$red9" fontSize="$2">
+        {t("profile.deleteAccountWarning")}
+      </Text>
+
+      <Input
+        label={t("profile.deleteAccountConfirm")}
+        placeholder={t("profile.deleteConfirmWord")}
+        value={confirmText}
+        onChangeText={setConfirmText}
+        autoCapitalize="characters"
+      />
+
+      {needsPassword && (
+        <Input
+          label={t("auth.password")}
+          placeholder={t("auth.passwordPlaceholder")}
+          value={password}
+          onChangeText={setPassword}
+          secureTextEntry
+        />
+      )}
+
+      {error && (
+        <Text color="$red10" fontSize="$3">
+          {error}
+        </Text>
+      )}
+
+      <XStack gap="$2">
+        <Button
+          flex={1}
+          variant="outline"
+          onPress={handleCancel}
+          disabled={isDeleting}
+        >
+          {t("shared.cancel")}
+        </Button>
+        <Button
+          flex={1}
+          variant="danger"
+          onPress={handleDelete}
+          disabled={isDeleting}
+        >
+          {isDeleting ? <Spinner size="small" /> : t("profile.deleteAccount")}
+        </Button>
+      </XStack>
+    </YStack>
+  );
+}

--- a/apps/mobile-web/public/privacy.html
+++ b/apps/mobile-web/public/privacy.html
@@ -24,7 +24,7 @@
 </head>
 <body>
   <h1>Privacy Policy</h1>
-  <p class="updated">Last updated: February 2026</p>
+  <p class="updated">Last updated: April 2026</p>
 
   <p>
     Football with Friends ("we", "our", or "us") is a mobile and web application for organizing
@@ -71,10 +71,13 @@
     are never transmitted beyond the app and our API.
   </p>
 
-  <h2>6. Data Retention</h2>
+  <h2>6. Data Retention and Account Deletion</h2>
   <p>
-    We retain your account data for as long as your account is active. You may request deletion of
-    your account and all associated data at any time by contacting us (see section 9).
+    We retain your account data for as long as your account is active. You can delete your account
+    and all associated data at any time directly from the app (Profile &gt; Delete Account).
+    When you delete your account, we permanently remove your profile information, match stats,
+    votes, and any uploaded photos. Match sign-up records are anonymized to preserve match history
+    integrity. You may also contact us to request deletion (see section 9).
   </p>
 
   <h2>7. Sharing With Third Parties</h2>
@@ -95,7 +98,7 @@
 
   <h2>9. Your Rights and Contact</h2>
   <p>You have the right to access, correct, or delete your personal data. To exercise these rights or for any privacy questions, contact us at:</p>
-  <p><strong>Email</strong>: <a href="mailto:ignacioguri@gmail.com">ignacioguri@gmail.com</a></p>
+  <p><strong>Email</strong>: <a href="mailto:pepe.grillo.parlante@gmail.com">pepe.grillo.parlante@gmail.com</a></p>
 
   <h2>10. Changes to This Policy</h2>
   <p>

--- a/apps/mobile-web/public/terms.html
+++ b/apps/mobile-web/public/terms.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Terms of Service — Football with Friends</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 720px;
+      margin: 40px auto;
+      padding: 0 24px 80px;
+      color: #1a1a1a;
+      line-height: 1.7;
+      font-size: 16px;
+    }
+    h1 { font-size: 28px; font-weight: 700; margin-bottom: 4px; }
+    h2 { font-size: 18px; font-weight: 600; margin-top: 36px; }
+    p, li { color: #333; }
+    ul { padding-left: 20px; }
+    a { color: #3d7c48; }
+    .updated { color: #666; font-size: 14px; margin-bottom: 32px; }
+  </style>
+</head>
+<body>
+  <h1>Terms of Service</h1>
+  <p class="updated">Last updated: April 2026</p>
+
+  <p>
+    These Terms of Service ("Terms") govern your use of the Football with Friends mobile and web
+    application ("App"). By creating an account or using the App, you agree to these Terms.
+  </p>
+
+  <h2>1. Acceptance of Terms</h2>
+  <p>
+    By accessing or using the App, you confirm that you are at least 13 years old and agree to be
+    bound by these Terms. If you do not agree, do not use the App.
+  </p>
+
+  <h2>2. Account Responsibilities</h2>
+  <ul>
+    <li>You are responsible for maintaining the security of your account credentials.</li>
+    <li>You must provide accurate information when creating your account.</li>
+    <li>You are responsible for all activity that occurs under your account.</li>
+    <li>You may delete your account at any time from the Profile screen within the App.</li>
+  </ul>
+
+  <h2>3. Match Participation</h2>
+  <ul>
+    <li>By signing up for a match, you agree to attend or cancel your spot in advance.</li>
+    <li>Payment terms (cost per player, same-day surcharges, late penalties) are set by match organizers and displayed before you sign up.</li>
+    <li>The App facilitates match organization but is not responsible for payments, injuries, or disputes between players.</li>
+  </ul>
+
+  <h2>4. User Conduct</h2>
+  <p>You agree not to:</p>
+  <ul>
+    <li>Use the App for any unlawful purpose.</li>
+    <li>Impersonate other users or provide false information.</li>
+    <li>Attempt to access other users' accounts or private data.</li>
+    <li>Upload inappropriate, offensive, or harmful content.</li>
+    <li>Interfere with the operation of the App or its infrastructure.</li>
+  </ul>
+
+  <h2>5. User Content</h2>
+  <p>
+    You retain ownership of content you upload (such as profile pictures). By uploading content, you
+    grant us a limited license to store and display it within the App for the purpose of providing
+    the service. We do not use your content for advertising or share it with third parties.
+  </p>
+
+  <h2>6. Account Termination and Deletion</h2>
+  <ul>
+    <li>You may delete your account at any time from within the App. This permanently removes your personal data, stats, and votes.</li>
+    <li>We may suspend or terminate accounts that violate these Terms.</li>
+    <li>Upon deletion, match sign-up records are anonymized to preserve match history for other participants.</li>
+  </ul>
+
+  <h2>7. Limitation of Liability</h2>
+  <p>
+    The App is provided "as is" without warranties of any kind. We are not liable for any damages
+    arising from your use of the App, including but not limited to injuries during matches, financial
+    disputes between players, or loss of data. The App is a coordination tool — all match
+    participation is at your own risk.
+  </p>
+
+  <h2>8. Changes to These Terms</h2>
+  <p>
+    We may update these Terms from time to time. We will notify you of significant changes through
+    the App. Continued use after changes constitutes acceptance of the updated Terms.
+  </p>
+
+  <h2>9. Contact</h2>
+  <p>For questions about these Terms, contact us at:</p>
+  <p><strong>Email</strong>: <a href="mailto:pepe.grillo.parlante@gmail.com">pepe.grillo.parlante@gmail.com</a></p>
+</body>
+</html>

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -238,7 +238,20 @@
     "emailLockedByAuth": "Email cannot be changed (used for authentication)",
     "phoneLockedByAuth": "Phone number cannot be changed (used for authentication)",
     "profileUpdated": "Profile updated successfully",
-    "updateFailed": "Failed to update profile"
+    "updateFailed": "Failed to update profile",
+    "deleteAccount": "Delete Account",
+    "deleteAccountTitle": "Delete Your Account?",
+    "deleteAccountWarning": "This will permanently delete your account and all associated data including match history, stats, and votes. This action cannot be undone.",
+    "deleteAccountConfirm": "Type DELETE to confirm",
+    "deleteAccountSuccess": "Your account has been deleted",
+    "deleteAccountFailed": "Failed to delete account",
+    "deleting": "Deleting...",
+    "deleteConfirmWord": "DELETE",
+    "privacyPolicy": "Privacy Policy",
+    "termsOfService": "Terms of Service",
+    "support": "Support & Contact",
+    "legal": "Legal",
+    "appVersion": "App Version"
   },
   "auth": {
     "welcomeBack": "Welcome Back",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -239,7 +239,20 @@
     "emailLockedByAuth": "El email no se puede cambiar (se usa para autenticación)",
     "phoneLockedByAuth": "El teléfono no se puede cambiar (se usa para autenticación)",
     "profileUpdated": "Perfil actualizado exitosamente",
-    "updateFailed": "Error al actualizar el perfil"
+    "updateFailed": "Error al actualizar el perfil",
+    "deleteAccount": "Eliminar Cuenta",
+    "deleteAccountTitle": "¿Eliminar tu cuenta?",
+    "deleteAccountWarning": "Esto eliminará permanentemente tu cuenta y todos los datos asociados incluyendo historial de partidos, estadísticas y votos. Esta acción no se puede deshacer.",
+    "deleteAccountConfirm": "Escribí ELIMINAR para confirmar",
+    "deleteAccountSuccess": "Tu cuenta ha sido eliminada",
+    "deleteAccountFailed": "Error al eliminar la cuenta",
+    "deleting": "Eliminando...",
+    "deleteConfirmWord": "ELIMINAR",
+    "privacyPolicy": "Política de Privacidad",
+    "termsOfService": "Términos de Servicio",
+    "support": "Soporte y Contacto",
+    "legal": "Legal",
+    "appVersion": "Versión de la App"
   },
   "auth": {
     "welcomeBack": "Bienvenido de vuelta",

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -116,6 +116,9 @@ const LOCALHOST_API = "http://localhost:3001";
 // Configured API URL (set via configureApiClient)
 let _configuredApiUrl: string | null = null;
 
+// Configured Web App URL (set via configureWebAppUrl)
+let _configuredWebAppUrl: string | null = null;
+
 // Google Client ID for One Tap (set via configureGoogleClientId)
 let _googleClientId: string | null = null;
 
@@ -128,6 +131,29 @@ export function configureApiClient(apiUrl: string | undefined) {
   if (apiUrl && apiUrl.length > 0 && !apiUrl.includes("${")) {
     _configuredApiUrl = apiUrl.trim();
   }
+}
+
+/**
+ * Configure the Web App URL for legal page links.
+ * Call this early in your app initialization (e.g., in _layout.tsx).
+ * For Expo apps, pass process.env.EXPO_PUBLIC_WEB_APP_URL or use the default.
+ */
+export function configureWebAppUrl(url: string | undefined) {
+  if (url && url.length > 0 && !url.includes("${")) {
+    _configuredWebAppUrl = url.trim().replace(/\/$/, "");
+  }
+}
+
+/**
+ * Get the configured Web App URL for legal page links.
+ * Falls back to the production Vercel URL.
+ */
+export function getWebAppUrl(): string {
+  if (_configuredWebAppUrl) return _configuredWebAppUrl;
+  if (typeof window !== "undefined" && window.location?.origin) {
+    return window.location.origin;
+  }
+  return "https://football-with-friends.vercel.app";
 }
 
 /**
@@ -464,6 +490,36 @@ export async function getAdminResetCodes(): Promise<
   return result.codes;
 }
 
+
+/**
+ * Delete the current user's account and all associated data.
+ * Requires typing a confirmation word and password (for credential accounts).
+ */
+export async function deleteAccount(confirmText: string, password?: string) {
+  await _tokenLoadPromise;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (_cachedBearerToken) {
+    headers["Authorization"] = `Bearer ${_cachedBearerToken}`;
+  }
+
+  const response = await fetch(`${getApiUrl()}/api/profile/delete-account`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ confirmText, password: password || undefined }),
+  });
+
+  if (!response.ok) {
+    const result = await response.json();
+    throw new Error(
+      result.error || "Failed to delete account"
+    );
+  }
+
+  // Clear local auth state
+  await clearBearerToken();
+}
 
 // Export types
 export type Session = typeof authClient.$Infer.Session;

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -25,6 +25,8 @@ export {
   getSession,
   configureApiClient,
   getConfiguredApiUrl,
+  configureWebAppUrl,
+  getWebAppUrl,
   storeBearerToken,
   clearBearerToken,
   getBearerToken,
@@ -35,6 +37,7 @@ export {
   requestPasswordReset,
   resetPasswordWithCode,
   getAdminResetCodes,
+  deleteAccount,
 } from "./auth";
 export type { Session, User, PhoneSignUpData, PhoneSignInData } from "./auth";
 


### PR DESCRIPTION
## Summary
- **Account deletion**: Full flow with `POST /api/profile/delete-account` endpoint — verifies password for credential users, parallelizes cleanup of push tokens/stats/votes/invitations, anonymizes signups, deletes R2 profile pictures, then cascading user deletion
- **Delete account UI**: Inline expandable section in profile with confirmation text input ("DELETE"/"ELIMINAR"), optional password field, and destructive styling
- **Terms of Service**: New `terms.html` page covering acceptance, account responsibilities, match participation, user conduct, content, termination, and liability
- **Privacy policy updates**: Added account deletion rights section, updated contact email to pepe.grillo.parlante@gmail.com
- **Legal links in profile**: Privacy Policy, Terms of Service, and Support & Contact links with `getWebAppUrl()` for environment-aware URLs
- **App version display**: Shows `expo-constants` version in profile settings
- **i18n**: All new strings in English and Spanish

Addresses Apple App Store rejection (Guideline 5.1.1(v) - Data Collection and Storage).
