### PR TITLE
Add accessibility labels and test IDs across mobile-web

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,15 @@ The application implements comprehensive timezone support to ensure consistent d
 - Match listings show dates in Berlin timezone regardless of user location
 - Shared across mobile, web, and API via `@repo/shared` package
 
+### Accessibility & Automation Identifiers
+Interactive elements follow a shared convention so screen readers AND automation tools (Chrome DevTools MCP, agent-browser) can reliably identify them.
+
+- Priority: **semantic role + accessible name first**, `testID` only as a fallback for repeated/ambiguous elements. Chrome DevTools MCP snapshots the accessibility tree, not the DOM.
+- Icon-only buttons require `accessibilityLabel` (from the `a11y` i18n namespace). Any `Pressable` acting as a button requires `accessibilityRole="button"`.
+- `testID` naming: kebab-case hierarchical, `{screen}-{element}[-{id}]` (e.g. `matches-fab-add`, `matches-card-42`).
+
+Full convention, examples, and verification steps: [`docs/accessibility-and-test-ids.md`](docs/accessibility-and-test-ids.md).
+
 ### Development Workflow
 1. **Install dependencies**: `pnpm install` (installs for all workspaces)
 2. **Start development**: `pnpm dev` (starts API and mobile app concurrently)

--- a/apps/mobile-web/app/(auth)/email-signin.tsx
+++ b/apps/mobile-web/app/(auth)/email-signin.tsx
@@ -146,6 +146,7 @@ export default function EmailSignInScreen() {
                         onChangeText={onChange}
                         autoCapitalize="none"
                         keyboardType="email-address"
+                        testID="auth-email-signin-email"
                         error={
                           emailForm.formState.errors.email
                             ? t(
@@ -168,6 +169,7 @@ export default function EmailSignInScreen() {
                         value={value}
                         onChangeText={onChange}
                         secureTextEntry
+                        testID="auth-email-signin-password"
                         error={
                           emailForm.formState.errors.password
                             ? t(
@@ -186,6 +188,7 @@ export default function EmailSignInScreen() {
                     textAlign="right"
                     cursor="pointer"
                     onPress={() => router.push("/(auth)/forgot-password")}
+                    testID="auth-email-signin-forgot-link"
                   >
                     {t("auth.forgotPassword")}
                   </Text>
@@ -218,6 +221,7 @@ export default function EmailSignInScreen() {
                         value={newPassword}
                         onChangeText={setNewPassword}
                         secureTextEntry
+                        testID="auth-email-signin-new-password"
                       />
 
                       <Input
@@ -226,6 +230,7 @@ export default function EmailSignInScreen() {
                         value={confirmPassword}
                         onChangeText={setConfirmPassword}
                         secureTextEntry
+                        testID="auth-email-signin-confirm-password"
                       />
                     </>
                   )}
@@ -244,6 +249,7 @@ export default function EmailSignInScreen() {
                     onPress={emailForm.handleSubmit(onSubmit)}
                     disabled={isLoading}
                     variant="primary"
+                    testID="auth-email-signin-submit"
                   >
                     {isLoading ? <Spinner size="small" color="white" /> : t("auth.signIn")}
                   </Button>
@@ -252,6 +258,7 @@ export default function EmailSignInScreen() {
                     onPress={handlePasswordReset}
                     disabled={isLoading}
                     variant="primary"
+                    testID="auth-email-signin-reset-submit"
                   >
                     {isLoading ? (
                       <Spinner size="small" color="white" />

--- a/apps/mobile-web/app/(auth)/email-signup.tsx
+++ b/apps/mobile-web/app/(auth)/email-signup.tsx
@@ -96,6 +96,7 @@ export default function EmailSignUpScreen() {
                     placeholder={t("auth.namePlaceholder")}
                     value={value}
                     onChangeText={onChange}
+                    testID="auth-email-signup-name"
                     error={
                       emailForm.formState.errors.name
                         ? t(emailForm.formState.errors.name.message as string)
@@ -116,6 +117,7 @@ export default function EmailSignUpScreen() {
                     onChangeText={onChange}
                     autoCapitalize="none"
                     keyboardType="email-address"
+                    testID="auth-email-signup-email"
                     error={
                       emailForm.formState.errors.email
                         ? t(
@@ -138,6 +140,7 @@ export default function EmailSignUpScreen() {
                     value={value}
                     onChangeText={onChange}
                     secureTextEntry
+                    testID="auth-email-signup-password"
                     error={
                       emailForm.formState.errors.password
                         ? t(
@@ -162,6 +165,7 @@ export default function EmailSignUpScreen() {
                     onChangeText={onChange}
                     autoCapitalize="none"
                     helperText={t("auth.usernameHelp")}
+                    testID="auth-email-signup-username"
                     error={
                       emailForm.formState.errors.username
                         ? t(
@@ -185,6 +189,7 @@ export default function EmailSignUpScreen() {
                   onPress={emailForm.handleSubmit(onSubmit)}
                   disabled={isLoading}
                   variant="primary"
+                  testID="auth-email-signup-submit"
                 >
                   {isLoading ? <Spinner size="small" /> : t("auth.signUp")}
                 </Button>

--- a/apps/mobile-web/app/(auth)/forgot-password.tsx
+++ b/apps/mobile-web/app/(auth)/forgot-password.tsx
@@ -141,6 +141,7 @@ export default function ForgotPasswordScreen() {
                   onChangeText={setIdentifier}
                   autoCapitalize="none"
                   keyboardType="email-address"
+                  testID="auth-forgot-identifier"
                 />
               ) : (
                 <>
@@ -151,6 +152,7 @@ export default function ForgotPasswordScreen() {
                     onChangeText={setCode}
                     keyboardType="number-pad"
                     maxLength={6}
+                    testID="auth-forgot-code"
                   />
 
                   <Input
@@ -159,6 +161,7 @@ export default function ForgotPasswordScreen() {
                     value={newPassword}
                     onChangeText={setNewPassword}
                     secureTextEntry
+                    testID="auth-forgot-new-password"
                   />
 
                   <Input
@@ -167,6 +170,7 @@ export default function ForgotPasswordScreen() {
                     value={confirmPassword}
                     onChangeText={setConfirmPassword}
                     secureTextEntry
+                    testID="auth-forgot-confirm-password"
                   />
                 </>
               )}
@@ -184,6 +188,11 @@ export default function ForgotPasswordScreen() {
                   }
                   disabled={isLoading}
                   variant="primary"
+                  testID={
+                    step === "request"
+                      ? "auth-forgot-request-submit"
+                      : "auth-forgot-reset-submit"
+                  }
                 >
                   {isLoading ? (
                     <Spinner size="small" color="white" />

--- a/apps/mobile-web/app/(auth)/index.tsx
+++ b/apps/mobile-web/app/(auth)/index.tsx
@@ -209,6 +209,7 @@ export default function AuthLandingScreen() {
             size="$5"
             width="100%"
             fontWeight="400"
+            testID="auth-landing-phone-btn"
           >
             <XStack gap="$3" alignItems="center" justifyContent="center">
               <Image
@@ -257,6 +258,7 @@ export default function AuthLandingScreen() {
                   disabled={isGoogleLoading}
                   opacity={isGoogleLoading ? 0.5 : 1}
                   fontWeight="400"
+                  testID="auth-landing-google-btn"
                 >
                   <XStack gap="$3" alignItems="center" justifyContent="center">
                     <Image
@@ -282,6 +284,7 @@ export default function AuthLandingScreen() {
               width="100%"
               disabled={isGoogleLoading}
               opacity={isGoogleLoading ? 0.5 : 1}
+              testID="auth-landing-google-btn"
               backgroundColor="$googleButtonBg"
               borderWidth={1}
               borderColor="$googleButtonBorder"
@@ -352,6 +355,7 @@ export default function AuthLandingScreen() {
             variant="outline"
             size="$5"
             fontWeight="400"
+            testID="auth-landing-email-btn"
           >
             <XStack gap="$3" alignItems="center" justifyContent="center">
               <Mail size={24} color="$gray11" />

--- a/apps/mobile-web/app/(auth)/phone-signin.tsx
+++ b/apps/mobile-web/app/(auth)/phone-signin.tsx
@@ -166,6 +166,7 @@ export default function PhoneSignInScreen() {
                         value={value}
                         onChangeText={onChange}
                         secureTextEntry
+                        testID="auth-phone-signin-password"
                         error={
                           phoneForm.formState.errors.password
                             ? t(phoneForm.formState.errors.password.message as string)
@@ -181,6 +182,7 @@ export default function PhoneSignInScreen() {
                     textAlign="right"
                     cursor="pointer"
                     onPress={() => router.push("/(auth)/forgot-password")}
+                    testID="auth-phone-signin-forgot-link"
                   >
                     {t("auth.forgotPassword")}
                   </Text>
@@ -213,6 +215,7 @@ export default function PhoneSignInScreen() {
                         value={newPassword}
                         onChangeText={setNewPassword}
                         secureTextEntry
+                        testID="auth-phone-signin-new-password"
                       />
 
                       <Input
@@ -221,6 +224,7 @@ export default function PhoneSignInScreen() {
                         value={confirmPassword}
                         onChangeText={setConfirmPassword}
                         secureTextEntry
+                        testID="auth-phone-signin-confirm-password"
                       />
                     </>
                   )}
@@ -239,6 +243,7 @@ export default function PhoneSignInScreen() {
                     onPress={phoneForm.handleSubmit(onSubmit)}
                     disabled={isLoading}
                     variant="primary"
+                    testID="auth-phone-signin-submit"
                   >
                     {isLoading ? <Spinner size="small" color="white" /> : t("auth.signIn")}
                   </Button>
@@ -247,6 +252,7 @@ export default function PhoneSignInScreen() {
                     onPress={handlePasswordReset}
                     disabled={isLoading}
                     variant="primary"
+                    testID="auth-phone-signin-reset-submit"
                   >
                     {isLoading ? (
                       <Spinner size="small" color="white" />

--- a/apps/mobile-web/app/(auth)/phone-signup.tsx
+++ b/apps/mobile-web/app/(auth)/phone-signup.tsx
@@ -106,6 +106,7 @@ export default function PhoneSignUpScreen() {
                     placeholder={t("auth.namePlaceholder")}
                     value={value}
                     onChangeText={onChange}
+                    testID="auth-phone-signup-name"
                     error={
                       phoneForm.formState.errors.name
                         ? t(phoneForm.formState.errors.name.message as string)
@@ -147,6 +148,7 @@ export default function PhoneSignUpScreen() {
                     value={value}
                     onChangeText={onChange}
                     secureTextEntry
+                    testID="auth-phone-signup-password"
                     error={
                       phoneForm.formState.errors.password
                         ? t(
@@ -171,6 +173,7 @@ export default function PhoneSignUpScreen() {
                   onPress={phoneForm.handleSubmit(onSubmit)}
                   disabled={isLoading}
                   variant="primary"
+                  testID="auth-phone-signup-submit"
                 >
                   {isLoading ? <Spinner size="small" color="white" /> : t("auth.signUp")}
                 </Button>

--- a/apps/mobile-web/app/(tabs)/admin/add-match.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/add-match.tsx
@@ -315,6 +315,7 @@ export default function AddMatchScreen() {
             size="$5"
             onPress={handleSubmit}
             disabled={createMutation.isPending}
+            testID="admin-add-match-submit"
           >
             {createMutation.isPending
               ? t("addMatch.adding")

--- a/apps/mobile-web/app/(tabs)/admin/edit-match.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/edit-match.tsx
@@ -360,6 +360,7 @@ export default function EditMatchScreen() {
             size="$5"
             onPress={handleSubmit}
             disabled={updateMutation.isPending}
+            testID="admin-edit-match-submit"
           >
             {updateMutation.isPending
               ? t("editMatch.saving")

--- a/apps/mobile-web/app/(tabs)/admin/index.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/index.tsx
@@ -148,6 +148,7 @@ export default function OrganizerScreen() {
               size="$3"
               variant={activeTab === "matches" ? "primary" : "outline"}
               onPress={() => setActiveTab("matches")}
+              testID="admin-tab-matches"
             >
               {t("organizer.tabs.matches")}
             </Button>
@@ -156,6 +157,7 @@ export default function OrganizerScreen() {
               size="$3"
               variant={activeTab === "locations" ? "primary" : "outline"}
               onPress={() => setActiveTab("locations")}
+              testID="admin-tab-locations"
             >
               {t("organizer.tabs.locations")}
             </Button>
@@ -164,6 +166,7 @@ export default function OrganizerScreen() {
               size="$3"
               variant={activeTab === "courts" ? "primary" : "outline"}
               onPress={() => setActiveTab("courts")}
+              testID="admin-tab-courts"
             >
               {t("organizer.tabs.courts")}
             </Button>
@@ -174,6 +177,7 @@ export default function OrganizerScreen() {
               size="$3"
               variant={activeTab === "voting" ? "primary" : "outline"}
               onPress={() => setActiveTab("voting")}
+              testID="admin-tab-voting"
             >
               {t("voting.title")}
             </Button>
@@ -182,6 +186,7 @@ export default function OrganizerScreen() {
               size="$3"
               variant={activeTab === "settings" ? "primary" : "outline"}
               onPress={() => setActiveTab("settings")}
+              testID="admin-tab-settings"
             >
               {t("settings.title")}
             </Button>
@@ -328,6 +333,7 @@ function MatchesTab() {
         <Button
           variant="primary"
           onPress={() => router.push("/(tabs)/admin/add-match")}
+          testID="admin-matches-add-btn"
         >
           {t("addMatch.title")}
         </Button>
@@ -377,6 +383,7 @@ function MatchesTab() {
                       size="$3"
                       variant="outline"
                       onPress={() => router.push(`/(tabs)/matches/${match.id}`)}
+                      testID={`admin-match-row-${match.id}-view`}
                     >
                       {t("organizer.viewMatch")}
                     </Button>
@@ -391,6 +398,7 @@ function MatchesTab() {
                             params: { matchId: match.id },
                           })
                         }
+                        testID={`admin-match-row-${match.id}-edit`}
                       >
                         {t("organizer.edit")}
                       </Button>
@@ -401,6 +409,7 @@ function MatchesTab() {
                         variant="danger"
                         onPress={() => handleDelete(match)}
                         disabled={deleteMutation.isPending}
+                        testID={`admin-match-row-${match.id}-delete`}
                       >
                         {t("organizer.delete")}
                       </Button>
@@ -414,6 +423,7 @@ function MatchesTab() {
                         variant="outline"
                         onPress={() => handleCancel(match)}
                         disabled={cancelMutation.isPending}
+                        testID={`admin-match-row-${match.id}-cancel`}
                       >
                         {t("organizer.cancelMatch")}
                       </Button>
@@ -423,6 +433,7 @@ function MatchesTab() {
                         variant="danger"
                         onPress={() => handleDelete(match)}
                         disabled={deleteMutation.isPending}
+                        testID={`admin-match-row-${match.id}-delete`}
                       >
                         {t("organizer.delete")}
                       </Button>
@@ -625,7 +636,11 @@ function LocationsTab() {
     >
       <YStack gap="$3" paddingBottom="$6">
         {/* Add Location Button */}
-        <Button variant="primary" onPress={() => setShowAddDialog(true)}>
+        <Button
+          variant="primary"
+          onPress={() => setShowAddDialog(true)}
+          testID="admin-locations-add-btn"
+        >
           {t("locations.addLocation")}
         </Button>
 
@@ -652,6 +667,7 @@ function LocationsTab() {
                     size="$3"
                     variant="outline"
                     onPress={() => openEdit(location)}
+                    testID={`admin-location-row-${location.id}-edit`}
                   >
                     {t("organizer.edit")}
                   </Button>
@@ -660,6 +676,7 @@ function LocationsTab() {
                     variant="danger"
                     onPress={() => handleDelete(location)}
                     disabled={deleteMutation.isPending}
+                    testID={`admin-location-row-${location.id}-delete`}
                   >
                     {t("locations.delete")}
                   </Button>
@@ -933,7 +950,11 @@ function CourtsTab() {
     >
       <YStack gap="$3" paddingBottom="$6">
         {/* Add Court Button */}
-        <Button variant="primary" onPress={() => setShowAddDialog(true)}>
+        <Button
+          variant="primary"
+          onPress={() => setShowAddDialog(true)}
+          testID="admin-courts-add-btn"
+        >
           {t("courts.addCourt")}
         </Button>
 
@@ -968,6 +989,7 @@ function CourtsTab() {
                     size="$3"
                     variant="outline"
                     onPress={() => openEdit(court)}
+                    testID={`admin-court-row-${court.id}-edit`}
                   >
                     {t("courts.edit")}
                   </Button>
@@ -976,6 +998,7 @@ function CourtsTab() {
                     variant="danger"
                     onPress={() => handleDelete(court)}
                     disabled={deleteMutation.isPending}
+                    testID={`admin-court-row-${court.id}-delete`}
                   >
                     {t("courts.delete")}
                   </Button>
@@ -1302,6 +1325,7 @@ function SettingsTab() {
           variant="primary"
           onPress={handleSave}
           disabled={updateMutation.isPending}
+          testID="admin-settings-save-btn"
         >
           {updateMutation.isPending ? t("shared.loading") : t("shared.save")}
         </Button>
@@ -1608,7 +1632,11 @@ function VotingCriteriaTab() {
     >
       <YStack gap="$3" paddingBottom="$6">
         {/* Add Criteria Button */}
-        <Button variant="primary" onPress={() => setShowAddDialog(true)}>
+        <Button
+          variant="primary"
+          onPress={() => setShowAddDialog(true)}
+          testID="admin-voting-add-btn"
+        >
           {t("admin.addCriteria")}
         </Button>
 
@@ -1658,6 +1686,7 @@ function VotingCriteriaTab() {
                       })
                     }
                     disabled={toggleActiveMutation.isPending}
+                    testID={`admin-voting-row-${c.id}-toggle`}
                   >
                     {c.isActive ? t("admin.deactivate") : t("admin.activate")}
                   </Button>
@@ -1665,6 +1694,7 @@ function VotingCriteriaTab() {
                     size="$3"
                     variant="outline"
                     onPress={() => openEdit(c)}
+                    testID={`admin-voting-row-${c.id}-edit`}
                   >
                     {t("organizer.edit")}
                   </Button>
@@ -1673,6 +1703,7 @@ function VotingCriteriaTab() {
                     variant="danger"
                     onPress={() => handleDelete(c)}
                     disabled={deleteMutation.isPending}
+                    testID={`admin-voting-row-${c.id}-delete`}
                   >
                     {t("shared.delete")}
                   </Button>

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/gallery.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/gallery.tsx
@@ -244,6 +244,8 @@ export default function MatchGalleryScreen() {
                 icon={<Plus size={16} />}
                 onPress={openUpload}
                 disabled={uploading}
+                accessibilityLabel={t("a11y.uploadMedia")}
+                testID="gallery-upload-btn"
               >
                 {uploading ? t("multimedia.uploading", { percent: 0 }) : t("multimedia.upload")}
               </Button>

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -451,6 +451,8 @@ export default function MatchDetailScreen() {
 
     const actions: PlayerAction[] = [];
 
+    const testIDBase = `match-detail-player-${player.id}`;
+
     // Admin: edit guest player name
     if (isAdmin && player.signupType === "guest") {
       actions.push({
@@ -458,6 +460,7 @@ export default function MatchDetailScreen() {
         label: t("matchDetail.editName"),
         onPress: () => handleEditPlayerName(player.id, player.playerName),
         variant: "outline",
+        testID: `${testIDBase}-edit-name`,
       });
     }
 
@@ -470,6 +473,7 @@ export default function MatchDetailScreen() {
             label: t("matchDetail.markPaid"),
             onPress: () => handleMarkAsPaid(player.id),
             variant: "outline",
+            testID: `${testIDBase}-mark-paid`,
           });
         } else if (isOwn) {
           // Non-admin players get Pay and Notify options
@@ -478,12 +482,14 @@ export default function MatchDetailScreen() {
             label: t("matchDetail.pay"),
             onPress: handleOpenPayment,
             variant: "outline",
+            testID: `${testIDBase}-pay`,
           });
           actions.push({
             icon: WhatsAppIcon,
             label: t("notify.trigger"),
             onPress: handleNotifyPaid,
             variant: "outline",
+            testID: `${testIDBase}-notify`,
           });
         }
         actions.push({
@@ -491,6 +497,7 @@ export default function MatchDetailScreen() {
           label: t("actions.cancel"),
           onPress: () => handleCancelSignup(player.id, player.status),
           variant: "danger-outline",
+          testID: `${testIDBase}-cancel`,
         });
         break;
 
@@ -500,6 +507,7 @@ export default function MatchDetailScreen() {
           label: t("actions.cancel"),
           onPress: () => handleCancelSignup(player.id, player.status),
           variant: "danger-outline",
+          testID: `${testIDBase}-cancel`,
         });
         break;
 
@@ -510,12 +518,14 @@ export default function MatchDetailScreen() {
           label: t("matchDetail.rejoin"),
           onPress: () => handleRejoin(player.id),
           variant: "primary",
+          testID: `${testIDBase}-rejoin`,
         });
         actions.push({
           icon: WhatsAppIcon,
           label: t("notify.cantPlay"),
           onPress: handleNotifyPaid,
           variant: "outline",
+          testID: `${testIDBase}-cant-play`,
         });
         break;
     }
@@ -527,6 +537,7 @@ export default function MatchDetailScreen() {
         label: t("matchDetail.removePlayer"),
         onPress: () => handleRemovePlayer(player.id),
         variant: "danger-outline",
+        testID: `${testIDBase}-remove`,
       });
     }
 
@@ -547,6 +558,7 @@ export default function MatchDetailScreen() {
       addedByName: signup.addedByName,
       isCurrentUser: signup.userId === userId,
       actions: getPlayerActions(signup),
+      testID: `match-detail-player-row-${signup.id}`,
     }));
   };
 
@@ -654,6 +666,8 @@ export default function MatchDetailScreen() {
                           })
                         }
                         padding="$2"
+                        accessibilityLabel={t("a11y.editMatch")}
+                        testID="match-detail-edit-btn"
                       >
                         <Pencil size={20} />
                       </Button>
@@ -667,6 +681,8 @@ export default function MatchDetailScreen() {
                       circular
                       onPress={handleAddToCalendar}
                       padding="$2"
+                      accessibilityLabel={t("a11y.addToCalendar")}
+                      testID="match-detail-calendar-btn"
                     >
                       <Calendar size={20} />
                     </Button>
@@ -679,6 +695,8 @@ export default function MatchDetailScreen() {
                     circular
                     onPress={handleShareMatch}
                     padding="$2"
+                    accessibilityLabel={t("a11y.shareMatch")}
+                    testID="match-detail-share-btn"
                   >
                     <Share2 size={20} />
                   </Button>
@@ -758,6 +776,7 @@ export default function MatchDetailScreen() {
                       variant="primary"
                       size="$5"
                       onPress={() => setShowJoinModal(true)}
+                      testID="match-detail-join-btn"
                     >
                       {t("actions.wantToPlay")}
                     </Button>
@@ -807,6 +826,7 @@ export default function MatchDetailScreen() {
                         variant="outline"
                         size="$3"
                         onPress={() => setShowGuestDialog(true)}
+                        testID="match-detail-invite-friend-btn"
                       >
                         <UserPlus size={16} />
                         <Text marginLeft="$1">{t("actions.signUpGuest")}</Text>

--- a/apps/mobile-web/app/(tabs)/matches/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/index.tsx
@@ -129,7 +129,9 @@ export default function MatchesListScreen() {
             {!isLoading &&
               !error &&
               matches &&
-              matches.map((match) => (
+              matches.map((match) => {
+                const dateTime = formatMatchDateTime(match.date, match.time);
+                return (
                 <Pressable
                   key={match.id}
                   onPress={() => router.push(`/(tabs)/matches/${match.id}`)}
@@ -138,12 +140,10 @@ export default function MatchesListScreen() {
                   accessibilityLabel={
                     match.location?.name
                       ? t("a11y.openMatch", {
-                          date: formatMatchDateTime(match.date, match.time),
+                          date: dateTime,
                           location: match.location.name,
                         })
-                      : t("a11y.openMatchNoLocation", {
-                          date: formatMatchDateTime(match.date, match.time),
-                        })
+                      : t("a11y.openMatchNoLocation", { date: dateTime })
                   }
                   testID={`matches-card-${match.id}`}
                 >
@@ -160,7 +160,7 @@ export default function MatchesListScreen() {
                   >
                     <XStack justifyContent="space-between" alignItems="center">
                       <Text color="white" fontSize="$5" fontWeight="500">
-                        {formatMatchDateTime(match.date, match.time)}
+                        {dateTime}
                       </Text>
                       {(match as any).userSignupStatus &&
                         (match as any).userSignupStatus !== "CANCELLED" && (
@@ -186,7 +186,8 @@ export default function MatchesListScreen() {
                     )}
                   </YStack>
                 </Pressable>
-              ))}
+                );
+              })}
 
             {/* Load More Button */}
             {!isLoading && !error && hasNextPage && (

--- a/apps/mobile-web/app/(tabs)/matches/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/index.tsx
@@ -69,6 +69,8 @@ export default function MatchesListScreen() {
               size="$3"
               onPress={() => router.push("/(tabs)/rules")}
               paddingHorizontal="$3"
+              accessibilityLabel={t("a11y.viewRules")}
+              testID="matches-rules-btn"
             >
               <XStack gap="$2" alignItems="center">
                 <BookOpen size={20} />
@@ -85,6 +87,7 @@ export default function MatchesListScreen() {
             value={activeTab}
             onValueChange={(value) => setActiveTab(value as MatchType)}
             tabs={tabs}
+            testIDPrefix="matches-tab"
           />
         </YStack>
 
@@ -131,6 +134,18 @@ export default function MatchesListScreen() {
                   key={match.id}
                   onPress={() => router.push(`/(tabs)/matches/${match.id}`)}
                   style={{ width: "100%" }}
+                  accessibilityRole="button"
+                  accessibilityLabel={
+                    match.location?.name
+                      ? t("a11y.openMatch", {
+                          date: formatMatchDateTime(match.date, match.time),
+                          location: match.location.name,
+                        })
+                      : t("a11y.openMatchNoLocation", {
+                          date: formatMatchDateTime(match.date, match.time),
+                        })
+                  }
+                  testID={`matches-card-${match.id}`}
                 >
                   <YStack
                     backgroundColor="$brandNavy"
@@ -180,6 +195,8 @@ export default function MatchesListScreen() {
                 onPress={() => fetchNextPage()}
                 disabled={isFetchingNextPage}
                 marginTop="$4"
+                accessibilityLabel={t("a11y.loadMoreMatches")}
+                testID="matches-load-more"
               >
                 {isFetchingNextPage ? (
                   <Spinner size="small" />
@@ -207,6 +224,8 @@ export default function MatchesListScreen() {
             padding="$0"
             justifyContent="center"
             alignItems="center"
+            accessibilityLabel={t("a11y.addMatch")}
+            testID="matches-fab-add"
           >
             <Plus size={28} color="white" />
           </Button>

--- a/apps/mobile-web/app/(tabs)/social/index.tsx
+++ b/apps/mobile-web/app/(tabs)/social/index.tsx
@@ -24,7 +24,12 @@ export default function SocialHubScreen() {
         marginHorizontal="auto"
         width="100%"
       >
-        <Pressable onPress={() => router.push("/(tabs)/social/stats")}>
+        <Pressable
+          onPress={() => router.push("/(tabs)/social/stats")}
+          accessibilityRole="button"
+          accessibilityLabel={t("a11y.openStats")}
+          testID="social-hub-stats"
+        >
           <Card variant="elevated" padding="$5">
             <XStack gap="$4" alignItems="center">
               <YStack
@@ -49,7 +54,12 @@ export default function SocialHubScreen() {
           </Card>
         </Pressable>
 
-        <Pressable onPress={() => router.push("/(tabs)/social/multimedia")}>
+        <Pressable
+          onPress={() => router.push("/(tabs)/social/multimedia")}
+          accessibilityRole="button"
+          accessibilityLabel={t("a11y.openMultimedia")}
+          testID="social-hub-multimedia"
+        >
           <Card variant="elevated" padding="$5">
             <XStack gap="$4" alignItems="center">
               <YStack

--- a/apps/mobile-web/app/(tabs)/social/multimedia/index.tsx
+++ b/apps/mobile-web/app/(tabs)/social/multimedia/index.tsx
@@ -117,7 +117,7 @@ export default function MultimediaFeedScreen() {
                       accessibilityLabel={t("a11y.openGallery", {
                         date: formatDisplayDate(g.matchDate, "MMM d"),
                       })}
-                      testID={`feed-group-${g.matchId}`}
+                      testID={`social-multimedia-feed-group-${g.matchId}`}
                     >
                       <XStack alignItems="center" gap="$3">
                         <XStack gap={4} alignItems="center">

--- a/apps/mobile-web/app/(tabs)/social/multimedia/index.tsx
+++ b/apps/mobile-web/app/(tabs)/social/multimedia/index.tsx
@@ -114,7 +114,10 @@ export default function MultimediaFeedScreen() {
                         router.push(`/(tabs)/matches/${g.matchId}/gallery`)
                       }
                       accessibilityRole="button"
-                      accessibilityLabel={`Open gallery for ${formatDisplayDate(g.matchDate, "MMM d")}`}
+                      accessibilityLabel={t("a11y.openGallery", {
+                        date: formatDisplayDate(g.matchDate, "MMM d"),
+                      })}
+                      testID={`feed-group-${g.matchId}`}
                     >
                       <XStack alignItems="center" gap="$3">
                         <XStack gap={4} alignItems="center">

--- a/docs/accessibility-and-test-ids.md
+++ b/docs/accessibility-and-test-ids.md
@@ -148,4 +148,4 @@ The audit is phased as separate PRs:
 - Tier 4 — auth flows
 - Tier 5 — `eslint-plugin-jsx-a11y` wired in
 
-Each tier ships independently and is reverible. No visible UI changes in any of them — only added props.
+Each tier ships independently and is reversible. No visible UI changes in any of them — only added props.

--- a/docs/accessibility-and-test-ids.md
+++ b/docs/accessibility-and-test-ids.md
@@ -1,0 +1,151 @@
+# Accessibility & Automation Identifiers
+
+This document defines how we annotate interactive UI elements so that:
+
+1. Screen readers and keyboard users can use the app.
+2. Chrome DevTools MCP (`take_snapshot`) and agent-browser automation can reliably identify and click elements.
+
+These two goals are aligned: a well-labelled, semantically correct UI is also an easily automatable one.
+
+## Priority: accessibility first, `testID` as fallback
+
+Chrome DevTools MCP and similar agents snapshot the **accessibility tree**, not the raw DOM. An element only appears as a clickable node when it has a semantic **role** and an **accessible name**. `testID` (mapped by React Native Web to `data-testid`) is useful only as a disambiguator for repeated or ambiguous elements — it is NOT what automation primarily uses.
+
+The right ordering when making an element identifiable:
+
+1. **Semantic role** — use Tamagui's `<Button>` (renders a real `<button>` on web) or set `accessibilityRole="button"` on a `Pressable`.
+2. **Accessible name** — visible text content, or `accessibilityLabel` for icon-only / ambiguous elements.
+3. **`testID`** — only for repeated list items, generic containers acting as targets, or elements whose name is dynamic/translated.
+
+## Platform mapping
+
+React Native Web performs these translations automatically — props flow through without any extra wrapper code. Tamagui v2 forwards web-standard ARIA equivalents.
+
+| React Native prop         | Web output                  |
+| ------------------------- | --------------------------- |
+| `testID="x"`              | `data-testid="x"`           |
+| `accessibilityLabel="x"`  | `aria-label="x"`            |
+| `accessibilityRole="x"`   | `role="x"`                  |
+| `accessibilityHint="x"`   | `aria-describedby` / hint   |
+| `accessibilityState={...}`| `aria-disabled`, `aria-selected`, etc. |
+
+The shared `Button` wrapper (`packages/ui/src/components/Button.tsx`) spreads `...props` to Tamagui's `Button`, so these props flow through at all call sites without modification.
+
+## Rules
+
+### 1. Icon-only buttons MUST have `accessibilityLabel`
+
+Labels come from the i18n `a11y` namespace (see below). Applies to any interactive element whose visible content is only an icon.
+
+```tsx
+// Bad
+<Button onPress={handleAdd}>
+  <Plus size={28} />
+</Button>
+
+// Good
+<Button
+  onPress={handleAdd}
+  accessibilityLabel={t("a11y.addMatch")}
+  testID="matches-fab-add"
+>
+  <Plus size={28} />
+</Button>
+```
+
+### 2. `Pressable` used as a button MUST have `accessibilityRole="button"`
+
+React Native's `Pressable` renders as a `<div>` with no role on web by default. It will not appear in the a11y tree — agents cannot see it. Tamagui's `<Button>` does not have this problem, but we often use `Pressable` directly for custom-styled cards.
+
+```tsx
+// Bad — invisible to agents and screen readers
+<Pressable onPress={() => router.push(`/matches/${match.id}`)}>
+  <YStack>...</YStack>
+</Pressable>
+
+// Good
+<Pressable
+  onPress={() => router.push(`/matches/${match.id}`)}
+  accessibilityRole="button"
+  accessibilityLabel={t("a11y.openMatch", { date, location })}
+  testID={`matches-card-${match.id}`}
+>
+  <YStack>...</YStack>
+</Pressable>
+```
+
+### 3. Add `testID` only when semantics are insufficient
+
+Don't blanket-add `testID`. Use it when:
+
+- An element is repeated (list rows, grid items, reaction buttons).
+- The element's accessible name is translated and unstable across locales.
+- A generic container (`View`, `YStack`) is the interactive target and there is no single text child for agents to match on.
+
+Otherwise rely on role + accessible name.
+
+### 4. `testID` naming convention
+
+Kebab-case, hierarchical: `{screen}-{element}[-{dynamic-id}][-{action}]`.
+
+| Use case                | Pattern                              | Example                          |
+| ----------------------- | ------------------------------------ | -------------------------------- |
+| Simple button           | `{screen}-{element}-btn`             | `match-detail-join-btn`          |
+| Floating action button  | `{screen}-fab-{purpose}`             | `matches-fab-add`                |
+| Repeated card / row     | `{screen}-{type}-{id}`               | `matches-card-42`, `social-user-row-abc123` |
+| Row sub-action          | `{screen}-{type}-{id}-{action}`      | `admin-match-row-42-edit`        |
+| Form field              | `{screen}-{form}-{field}`            | `auth-signin-email`              |
+| Tab / segmented control | `{screen}-tab-{value}`               | `matches-tab-upcoming`           |
+
+Stable IDs (database IDs) are preferred over array indices.
+
+### 5. i18n for accessibility labels
+
+Screen-reader-only strings live in a dedicated `a11y` namespace under `locales/en/common.json` and `locales/es/common.json`. This keeps translator focus separate from visible UI copy and makes it obvious what's for assistive tech.
+
+```json
+{
+  "a11y": {
+    "addMatch": "Add match",
+    "openMatch": "Open match on {{date}} at {{location}}",
+    "editMatch": "Edit match",
+    "deleteMatch": "Delete match",
+    "joinMatch": "Join match",
+    "leaveMatch": "Leave match"
+  }
+}
+```
+
+## Lint guardrail
+
+`eslint-plugin-jsx-a11y` is enabled (warn level) for `apps/mobile-web/**/*.tsx`. Key rules it catches:
+
+- `jsx-a11y/no-static-element-interactions` — a `div`/`View` with `onClick` but no role.
+- `jsx-a11y/click-events-have-key-events` — missing keyboard equivalents.
+- `jsx-a11y/no-noninteractive-element-to-interactive-role` — improper role overrides.
+
+Warnings, not errors: the goal is visibility in code review, not blocking unrelated work. React Native-only props (`accessibilityLabel`, `accessibilityRole`) aren't fully covered by jsx-a11y — those are checked in review.
+
+## Verification
+
+Before merging a PR that touches a screen:
+
+1. **Static**: `pnpm lint` and `pnpm typecheck` pass.
+2. **Runtime**: start the app (`pnpm dev:app`), open it in a web browser (what Chrome DevTools MCP sees).
+3. **Snapshot check** with Chrome DevTools MCP:
+   - `navigate_page` to the screen's URL.
+   - `take_snapshot` and confirm every interactive element appears with a `role` and an accessible name.
+   - For added `testID`s, confirm they reach the DOM as `data-testid` (inspect via `evaluate_script` if needed).
+4. **Click-by-name**: try clicking a primary CTA by its accessible name alone. If the agent can, so can screen readers.
+
+## Rollout scope
+
+The audit is phased as separate PRs:
+
+- Tier 1 — match list + match detail (highest traffic)
+- Tier 2 — admin flows
+- Tier 3 — social & multimedia
+- Tier 4 — auth flows
+- Tier 5 — `eslint-plugin-jsx-a11y` wired in
+
+Each tier ships independently and is reverible. No visible UI changes in any of them — only added props.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import typescriptEslint from "@typescript-eslint/eslint-plugin";
 import typescriptParser from "@typescript-eslint/parser";
 import prettierConfig from "eslint-config-prettier";
 import importPlugin from "eslint-plugin-import";
+import jsxA11y from "eslint-plugin-jsx-a11y";
 import prettierPlugin from "eslint-plugin-prettier";
 import reactPlugin from "eslint-plugin-react";
 import reactHooksPlugin from "eslint-plugin-react-hooks";
@@ -100,6 +101,18 @@ const config = [
       // TypeScript rules
       "@typescript-eslint/explicit-module-boundary-types": "off",
       "@typescript-eslint/consistent-type-imports": "error",
+    },
+  },
+  // Accessibility guardrails for the mobile-web app. Warn-level; see
+  // docs/accessibility-and-test-ids.md for the rationale and manual checks
+  // this pairs with.
+  {
+    files: ["apps/mobile-web/**/*.tsx"],
+    plugins: { "jsx-a11y": jsxA11y },
+    rules: {
+      "jsx-a11y/no-static-element-interactions": "warn",
+      "jsx-a11y/click-events-have-key-events": "warn",
+      "jsx-a11y/no-noninteractive-element-to-interactive-role": "warn",
     },
   },
   // Migration files specific rules

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -439,6 +439,23 @@
     "error": "Error: {message}",
     "saving": "Saving..."
   },
+  "a11y": {
+    "addMatch": "Add match",
+    "openMatch": "Open match on {{date}}, {{location}}",
+    "openMatchNoLocation": "Open match on {{date}}",
+    "viewRules": "View rules",
+    "editMatch": "Edit match",
+    "addToCalendar": "Add match to calendar",
+    "shareMatch": "Share match",
+    "loadMoreMatches": "Load more matches",
+    "joinMatch": "Join match",
+    "inviteFriend": "Invite a friend",
+    "playerAction": "{{action}} for {{playerName}}",
+    "openStats": "Open player stats",
+    "openMultimedia": "Open multimedia feed",
+    "openGallery": "Open gallery for {{date}}",
+    "uploadMedia": "Upload photo or video"
+  },
   "status": {
     "paid": "Paid",
     "pending": "Pending",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -442,6 +442,23 @@
     "error": "Error: {message}",
     "saving": "Guardando..."
   },
+  "a11y": {
+    "addMatch": "Agregar partido",
+    "openMatch": "Abrir partido del {{date}}, {{location}}",
+    "openMatchNoLocation": "Abrir partido del {{date}}",
+    "viewRules": "Ver reglas",
+    "editMatch": "Editar partido",
+    "addToCalendar": "Agregar partido al calendario",
+    "shareMatch": "Compartir partido",
+    "loadMoreMatches": "Cargar más partidos",
+    "joinMatch": "Unirme al partido",
+    "inviteFriend": "Invitar un amigo",
+    "playerAction": "{{action}} para {{playerName}}",
+    "openStats": "Abrir estadísticas",
+    "openMultimedia": "Abrir multimedia",
+    "openGallery": "Abrir galería del {{date}}",
+    "uploadMedia": "Subir foto o video"
+  },
   "status": {
     "paid": "Pagado",
     "pending": "Pendiente",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/packages/ui/src/components/MediaLightbox.tsx
+++ b/packages/ui/src/components/MediaLightbox.tsx
@@ -17,11 +17,13 @@ function IconChip({
   onPress,
   children,
   accessibilityLabel,
+  testID,
   style,
 }: {
   onPress: () => void;
   children: React.ReactNode;
   accessibilityLabel: string;
+  testID?: string;
   style?: object;
 }) {
   return (
@@ -29,6 +31,7 @@ function IconChip({
       onPress={onPress}
       role="button"
       aria-label={accessibilityLabel}
+      testID={testID}
       width={40}
       height={40}
       borderRadius={20}
@@ -110,6 +113,7 @@ export function MediaLightbox({
         <IconChip
           onPress={onClose}
           accessibilityLabel="Close"
+          testID="lightbox-close"
           style={{ position: "absolute", top: 24, right: 16, zIndex: 10 }}
         >
           <X size={24} color="$color" />
@@ -133,6 +137,7 @@ export function MediaLightbox({
           <IconChip
             onPress={() => setIndex((i) => i - 1)}
             accessibilityLabel="Previous"
+            testID="lightbox-prev"
             style={{ position: "absolute", left: 8, top: "50%", zIndex: 10 }}
           >
             <ChevronLeft size={24} color="$color" />
@@ -142,6 +147,7 @@ export function MediaLightbox({
           <IconChip
             onPress={() => setIndex((i) => i + 1)}
             accessibilityLabel="Next"
+            testID="lightbox-next"
             style={{ position: "absolute", right: 8, top: "50%", zIndex: 10 }}
           >
             <ChevronRight size={24} color="$color" />
@@ -164,6 +170,7 @@ export function MediaLightbox({
                 <IconChip
                   onPress={() => setMenuOpen((o) => !o)}
                   accessibilityLabel="More actions"
+                  testID="lightbox-menu-btn"
                 >
                   <MoreVertical size={22} color="$color" />
                 </IconChip>
@@ -195,6 +202,7 @@ export function MediaLightbox({
                       }}
                       role="menuitem"
                       aria-label="Delete"
+                      testID="lightbox-delete"
                       cursor="pointer"
                       hoverStyle={{ backgroundColor: "$red4" }}
                       pressStyle={{ backgroundColor: "$red5" }}

--- a/packages/ui/src/components/PlayersTable.tsx
+++ b/packages/ui/src/components/PlayersTable.tsx
@@ -11,6 +11,7 @@ export interface PlayerAction {
   label: string;
   onPress: () => void;
   variant?: "primary" | "outline" | "danger" | "danger-outline" | "ghost";
+  testID?: string;
 }
 
 export interface PlayerRow {
@@ -24,6 +25,7 @@ export interface PlayerRow {
   actions?: PlayerAction[];
   username?: string | null;
   displayUsername?: string | null;
+  testID?: string;
 }
 
 export interface PlayersTableProps {
@@ -72,6 +74,7 @@ export function PlayersTable({
     return (
     <XStack
       key={player.id}
+      testID={player.testID}
       justifyContent="space-between"
       alignItems="center"
       paddingVertical="$2"
@@ -128,6 +131,7 @@ export function PlayersTable({
                     height={28}
                     onPress={action.onPress}
                     aria-label={action.label}
+                    testID={action.testID}
                   >
                     <IconComponent size={16} />
                   </Button>

--- a/packages/ui/src/components/ReactionBar.tsx
+++ b/packages/ui/src/components/ReactionBar.tsx
@@ -3,6 +3,16 @@ import { REACTION_EMOJIS, type MatchMediaReactionSummary, type ReactionEmoji } f
 import { XStack, Text } from "tamagui";
 import { Pressable } from "react-native";
 
+// ASCII token per emoji so testIDs stay predictable for automation tools
+// (DOM attribute selectors and some agent frameworks struggle with raw emoji).
+const EMOJI_TEST_IDS: Record<ReactionEmoji, string> = {
+  "❤️": "heart",
+  "🔥": "fire",
+  "⚽": "ball",
+  "😂": "laugh",
+  "🍺": "beer",
+};
+
 export type ReactionBarProps = {
   reactions: MatchMediaReactionSummary[];
   onToggle: (emoji: ReactionEmoji) => void;
@@ -22,7 +32,7 @@ export function ReactionBar({ reactions, onToggle, disabled }: ReactionBarProps)
             onPress={() => !disabled && onToggle(emoji)}
             accessibilityRole="button"
             accessibilityLabel={`${emoji} reaction, ${r.count} ${r.count === 1 ? "person" : "people"}`}
-            testID={`reaction-btn-${emoji}`}
+            testID={`reaction-btn-${EMOJI_TEST_IDS[emoji]}`}
           >
             <XStack
               alignItems="center"

--- a/packages/ui/src/components/ReactionBar.tsx
+++ b/packages/ui/src/components/ReactionBar.tsx
@@ -22,6 +22,7 @@ export function ReactionBar({ reactions, onToggle, disabled }: ReactionBarProps)
             onPress={() => !disabled && onToggle(emoji)}
             accessibilityRole="button"
             accessibilityLabel={`${emoji} reaction, ${r.count} ${r.count === 1 ? "person" : "people"}`}
+            testID={`reaction-btn-${emoji}`}
           >
             <XStack
               alignItems="center"

--- a/packages/ui/src/components/Tabs.tsx
+++ b/packages/ui/src/components/Tabs.tsx
@@ -26,9 +26,10 @@ export interface TabsProps {
   value: string;
   onValueChange: (value: string) => void;
   tabs: TabItem[];
+  testIDPrefix?: string;
 }
 
-export function Tabs({ value, onValueChange, tabs }: TabsProps) {
+export function Tabs({ value, onValueChange, tabs, testIDPrefix }: TabsProps) {
   return (
     <TamaguiTabs
       value={value}
@@ -41,6 +42,7 @@ export function Tabs({ value, onValueChange, tabs }: TabsProps) {
           <StyledTab
             key={tab.value}
             value={tab.value}
+            testID={testIDPrefix ? `${testIDPrefix}-${tab.value}` : undefined}
             {...(value === tab.value && {
               backgroundColor: "$background",
               shadowColor: "$shadowColor",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       eslint-plugin-import:
         specifier: ^2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.2
+        version: 6.10.2(eslint@9.39.4)
       eslint-plugin-prettier:
         specifier: ^5.5.5
         version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.8.1)
@@ -3760,6 +3763,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -3859,6 +3863,10 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
@@ -3898,6 +3906,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  ast-types-flow@0.0.8:
+    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -3925,6 +3936,14 @@ packages:
 
   await-lock@2.2.2:
     resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
+
+  axe-core@4.11.3:
+    resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
+    engines: {node: '>=4'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -4400,6 +4419,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  damerau-levenshtein@1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -4565,6 +4587,9 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
   encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
@@ -4704,6 +4729,12 @@ packages:
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
+
+  eslint-plugin-jsx-a11y@6.10.2:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
   eslint-plugin-prettier@5.5.5:
     resolution: {integrity: sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==}
@@ -5888,6 +5919,13 @@ packages:
   lan-network@0.2.0:
     resolution: {integrity: sha512-EZgbsXMrGS+oK+Ta12mCjzBFse+SIewGdwrSTr5g+MSymnjpox2x05ceI20PQejJOFvOgzcXrfDk/SdY7dSCtw==}
     hasBin: true
+
+  language-subtag-registry@0.3.23:
+    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
+
+  language-tags@1.0.9:
+    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
+    engines: {node: '>=0.10'}
 
   latest-version@9.0.0:
     resolution: {integrity: sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==}
@@ -7198,6 +7236,10 @@ packages:
   string-width@8.2.0:
     resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
     engines: {node: '>=20'}
+
+  string.prototype.includes@2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
 
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
@@ -13124,6 +13166,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  aria-query@5.3.2: {}
+
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -13195,6 +13239,8 @@ snapshots:
 
   asap@2.0.6: {}
 
+  ast-types-flow@0.0.8: {}
+
   astral-regex@2.0.0: {}
 
   async-function@1.0.0: {}
@@ -13217,6 +13263,10 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   await-lock@2.2.2: {}
+
+  axe-core@4.11.3: {}
+
+  axobject-query@4.1.0: {}
 
   babel-jest@29.7.0(@babel/core@7.29.0):
     dependencies:
@@ -13762,6 +13812,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  damerau-levenshtein@1.0.8: {}
+
   data-uri-to-buffer@4.0.1: {}
 
   data-view-buffer@1.0.2:
@@ -13904,6 +13956,8 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   encodeurl@1.0.2: {}
 
@@ -14154,6 +14208,25 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.11.3
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.39.4
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
 
   eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.8.1):
     dependencies:
@@ -15492,6 +15565,12 @@ snapshots:
   kysely@0.28.15: {}
 
   lan-network@0.2.0: {}
+
+  language-subtag-registry@0.3.23: {}
+
+  language-tags@1.0.9:
+    dependencies:
+      language-subtag-registry: 0.3.23
 
   latest-version@9.0.0:
     dependencies:
@@ -16975,6 +17054,12 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
+
+  string.prototype.includes@2.0.1:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.1
 
   string.prototype.matchall@4.0.12:
     dependencies:


### PR DESCRIPTION
## Summary

- Annotate interactive elements across mobile-web with `accessibilityLabel`, `accessibilityRole`, and `testID` so screen readers AND automation tools (Chrome DevTools MCP, agent-browser) can identify them reliably. No visible UI changes.
- Establish a convention documented in [`docs/accessibility-and-test-ids.md`](docs/accessibility-and-test-ids.md) with a summary + link in `CLAUDE.md`: semantic role + accessible name are primary; `testID` (kebab-case hierarchical, `{screen}-{element}[-{id}]`) is a fallback for repeated/ambiguous items. Key gotcha: `Pressable` without `accessibilityRole="button"` is invisible to the a11y tree on RN Web — now fixed in match cards and social hub cards.
- New `a11y` i18n namespace in `locales/{en,es}/common.json` for screen-reader-only strings.
- Shared UI updates so callers can pass IDs without modifying the lib each time: `Tabs` accepts `testIDPrefix`; `PlayersTable` rows/actions, `ReactionBar` emojis, and `MediaLightbox` internal `IconChip` accept `testID`.
- Tiers covered: **match list + detail** (cards, FAB, Rules btn, join/leave, player rows + per-action testIDs), **admin dashboard** (5 tabs + per-entity row actions for matches/locations/courts/voting + Settings save + add/edit-match submit), **social** (hub cards, multimedia feed groups, match gallery upload + lightbox controls + reaction buttons), **all auth flows** (landing buttons, email sign-in/up, phone sign-in/up, forgot-password).
- Added `eslint-plugin-jsx-a11y` (warn level) scoped to `apps/mobile-web/**/*.tsx` for: `no-static-element-interactions`, `click-events-have-key-events`, `no-noninteractive-element-to-interactive-role` — catches the `Pressable`-as-button anti-pattern on future additions.

Scope note: `DatePicker`, `TimePicker`, `Select`, and `PhoneInput` triggers don't get `testID` — they'd need composite-component changes in the UI lib (both web and native branches). They remain findable by their visible `label`. Flag this as a follow-up if automation needs them.
