### PR TITLE
Phase 3: group invites (create / preview / accept + ghost auto-claim)

### DIFF
--- a/apps/api/src/api-routes.ts
+++ b/apps/api/src/api-routes.ts
@@ -15,6 +15,7 @@ import rankingsRoute from "./routes/rankings";
 import pushTokensRoute from "./routes/push-tokens";
 import notificationsRoute from "./routes/notifications";
 import matchMediaRoute from "./routes/match-media";
+import invitesRoute from "./routes/invites";
 
 export function registerApiRoutes(app: Hono<any>) {
   return app
@@ -32,7 +33,8 @@ export function registerApiRoutes(app: Hono<any>) {
     .route("/voting", votingRoute)
     .route("/push-tokens", pushTokensRoute)
     .route("/notifications", notificationsRoute)
-    .route("/match-media", matchMediaRoute);
+    .route("/match-media", matchMediaRoute)
+    .route("/invites", invitesRoute);
 }
 
 export type ApiRoutes = ReturnType<typeof registerApiRoutes>;

--- a/apps/api/src/middleware/security.ts
+++ b/apps/api/src/middleware/security.ts
@@ -48,6 +48,7 @@ export const PUBLIC_ROUTES: Array<{ method?: string; path: RegExp }> = [
   { path: /^\/api\/auth\// },                                      // BetterAuth
   { path: /^\/api\/phone-auth\// },                                 // Phone auth
   { path: /^\/api\/matches\/[^/]+\/preview$/, method: "GET" },      // OG metadata preview
+  { path: /^\/api\/invites\/[^/]+$/, method: "GET" },               // Invite preview (POST accept requires auth)
   { path: /^\/api\/profile\/picture\//, method: "GET" },            // Served images
   { path: /^\/health$/ },                                           // Health check
   { path: /^\/api\/cron\/update-matches$/, method: "POST" },        // Cron (has own secret check)

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -230,6 +230,80 @@ app.post("/:id/leave", async (c) => {
   }
 });
 
+// Invites ----------------------------------------------------------------
+// Creation and revocation are organizer-only; listing is organizer-only.
+// Public preview/accept endpoints live in `routes/invites.ts` (no group
+// context middleware — the accepter doesn't yet belong to the group).
+
+app.get("/:id/invites", async (c) => {
+  const id = c.req.param("id");
+  const mismatched = assertInCurrentGroup(c, id, "Group not found");
+  if (mismatched) return mismatched;
+
+  const denied = requireOrganizer(c);
+  if (denied) return denied;
+
+  const invites = await getGroupService().listInvites(id);
+  return c.json({ invites });
+});
+
+app.post(
+  "/:id/invites",
+  zValidator(
+    "json",
+    z.object({
+      expiresInHours: z.number().int().positive().max(24 * 365).optional(),
+      maxUses: z.number().int().positive().max(10_000).optional(),
+      targetPhone: z.string().min(4).max(32).optional(),
+      targetUserId: z.string().min(1).optional(),
+    }),
+  ),
+  async (c) => {
+    const id = c.req.param("id");
+    const mismatched = assertInCurrentGroup(c, id, "Group not found");
+    if (mismatched) return mismatched;
+
+    const denied = requireOrganizer(c);
+    if (denied) return denied;
+
+    const user = requireUser(c);
+    const body = c.req.valid("json");
+
+    try {
+      const invite = await getGroupService().createInvite({
+        groupId: id,
+        createdByUserId: user.id,
+        expiresInHours: body.expiresInHours,
+        maxUses: body.maxUses,
+        targetPhone: body.targetPhone,
+        targetUserId: body.targetUserId,
+      });
+      return c.json({ invite }, 201);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to create invite";
+      return c.json({ error: message }, 400);
+    }
+  },
+);
+
+app.delete("/:id/invites/:inviteId", async (c) => {
+  const id = c.req.param("id");
+  const inviteId = c.req.param("inviteId");
+  const mismatched = assertInCurrentGroup(c, id, "Group not found");
+  if (mismatched) return mismatched;
+
+  const denied = requireOrganizer(c);
+  if (denied) return denied;
+
+  try {
+    await getGroupService().revokeInvite(id, inviteId);
+    return c.json({ success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to revoke invite";
+    return c.json({ error: message }, 404);
+  }
+});
+
 app.post(
   "/:id/transfer-ownership",
   zValidator("json", z.object({ toUserId: z.string().min(1) })),

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -247,6 +247,11 @@ app.get("/:id/invites", async (c) => {
   return c.json({ invites });
 });
 
+// E.164 per BetterAuth phone-auth + profile routes; targetPhone must match
+// the exact shape we store in `user.phoneNumber` or `acceptInvite` never
+// matches and the organizer has effectively created a dead invite.
+const INVITE_TARGET_PHONE_REGEX = /^\+[1-9]\d{6,14}$/;
+
 app.post(
   "/:id/invites",
   zValidator(
@@ -254,7 +259,11 @@ app.post(
     z.object({
       expiresInHours: z.number().int().positive().max(24 * 365).optional(),
       maxUses: z.number().int().positive().max(10_000).optional(),
-      targetPhone: z.string().min(4).max(32).optional(),
+      targetPhone: z
+        .string()
+        .trim()
+        .regex(INVITE_TARGET_PHONE_REGEX, "targetPhone must be E.164 (e.g. +1234567890)")
+        .optional(),
       targetUserId: z.string().min(1).optional(),
     }),
   ),

--- a/apps/api/src/routes/invites.ts
+++ b/apps/api/src/routes/invites.ts
@@ -1,0 +1,34 @@
+// Public + authed invite entry points.
+//
+// `GET /api/invites/:token` is intentionally public — it's what the /join
+// landing page hits before auth. `POST /:token/accept` is authed but does
+// NOT run through `groupContextMiddleware` because the accepter may not yet
+// belong to any group.
+
+import { Hono } from "hono";
+import { getServiceFactory } from "@repo/shared/services";
+
+import { type AppVariables, requireUser } from "../middleware/security";
+
+const app = new Hono<{ Variables: AppVariables }>();
+
+const getGroupService = () => getServiceFactory().groupService;
+
+app.get("/:token", async (c) => {
+  const preview = await getGroupService().getInvitePreview(c.req.param("token"));
+  return c.json(preview);
+});
+
+app.post("/:token/accept", async (c) => {
+  const user = requireUser(c);
+  const outcome = await getGroupService().acceptInvite({
+    token: c.req.param("token"),
+    userId: user.id,
+  });
+  if (!outcome.joined) {
+    return c.json({ error: outcome.reason, joined: false }, 400);
+  }
+  return c.json(outcome);
+});
+
+export default app;

--- a/apps/mobile-web/app/(tabs)/profile/groups/[groupId].tsx
+++ b/apps/mobile-web/app/(tabs)/profile/groups/[groupId].tsx
@@ -1,14 +1,19 @@
 // @ts-nocheck - Tamagui type recursion workaround
 import {
+  type GroupInviteSummary,
+  getWebAppUrl,
+  useCreateInvite,
   useCurrentGroup,
   useGroupDetail,
+  useGroupInvites,
   useLeaveGroup,
+  useRevokeInvite,
   useSession,
 } from "@repo/api-client";
 import { router, useLocalSearchParams } from "expo-router";
 import { useTranslation } from "react-i18next";
-import { ScrollView } from "react-native";
-import { Button, Spinner, Text, YStack } from "tamagui";
+import { Platform, ScrollView, Share } from "react-native";
+import { Button, Spinner, Text, XStack, YStack } from "tamagui";
 
 export default function GroupDetailScreen() {
   const { t } = useTranslation();
@@ -22,13 +27,14 @@ export default function GroupDetailScreen() {
     refetch,
   } = useGroupDetail(groupId ?? null);
 
-  // The server already returns `members` inlined on the detail response for
-  // organizers/superadmin, so we read from there rather than firing a
-  // separate /members query.
   const isOrganizerView =
     session?.user?.role === "superadmin" || myRole === "organizer";
   const members = isOrganizerView ? (group as any)?.members ?? [] : [];
   const leaveMutation = useLeaveGroup();
+
+  const invitesQuery = useGroupInvites(isOrganizerView ? groupId ?? null : null);
+  const createInviteMutation = useCreateInvite(groupId ?? "");
+  const revokeInviteMutation = useRevokeInvite(groupId ?? "");
 
   if (isLoading) {
     return (
@@ -55,6 +61,25 @@ export default function GroupDetailScreen() {
     router.replace("/(tabs)/profile/groups");
   }
 
+  function inviteLink(token: string): string {
+    return `${getWebAppUrl().replace(/\/$/, "")}/join/${token}`;
+  }
+
+  async function onCopyInvite(token: string) {
+    const link = inviteLink(token);
+    if (Platform.OS === "web" && typeof navigator !== "undefined" && navigator.clipboard) {
+      await navigator.clipboard.writeText(link);
+      return;
+    }
+    await Share.share({ message: link });
+  }
+
+  async function onCreateInvite() {
+    await createInviteMutation.mutateAsync({
+      expiresInHours: 24 * 7,
+    });
+  }
+
   return (
     <ScrollView>
       <YStack padding="$4" gap="$4">
@@ -75,6 +100,69 @@ export default function GroupDetailScreen() {
                 {m.userId} — {m.role}
               </Text>
             ))}
+          </YStack>
+        ) : null}
+
+        {isOrganizerView ? (
+          <YStack gap="$2">
+            <XStack justifyContent="space-between" alignItems="center">
+              <Text fontSize="$5" fontWeight="600">
+                {t("groups.invite.sectionTitle")}
+              </Text>
+              <Button
+                size="$3"
+                theme="active"
+                onPress={onCreateInvite}
+                disabled={createInviteMutation.isPending}
+              >
+                {t("groups.invite.create")}
+              </Button>
+            </XStack>
+
+            {invitesQuery.isLoading ? (
+              <Spinner />
+            ) : (invitesQuery.data ?? []).length === 0 ? (
+              <Text color="$gray11">{t("groups.invite.empty")}</Text>
+            ) : (
+              (invitesQuery.data ?? []).map((inv: GroupInviteSummary) => (
+                <YStack
+                  key={inv.id}
+                  padding="$3"
+                  borderRadius="$3"
+                  backgroundColor="$background"
+                  borderWidth={1}
+                  borderColor="$gray6"
+                  gap="$2"
+                >
+                  <Text fontSize="$3" color="$gray11" numberOfLines={1}>
+                    {inviteLink(inv.token)}
+                  </Text>
+                  <Text fontSize="$2" color="$gray10">
+                    {inv.expiresAt
+                      ? t("groups.invite.expiresAt", {
+                          date: new Date(inv.expiresAt).toLocaleString(),
+                        })
+                      : t("groups.invite.neverExpires")}
+                    {typeof inv.maxUses === "number"
+                      ? `  ·  ${inv.usesCount}/${inv.maxUses}`
+                      : ""}
+                  </Text>
+                  <XStack gap="$2">
+                    <Button size="$2" onPress={() => onCopyInvite(inv.token)}>
+                      {t("groups.invite.copy")}
+                    </Button>
+                    <Button
+                      size="$2"
+                      theme="red"
+                      onPress={() => revokeInviteMutation.mutate(inv.id)}
+                      disabled={revokeInviteMutation.isPending}
+                    >
+                      {t("groups.invite.revoke")}
+                    </Button>
+                  </XStack>
+                </YStack>
+              ))
+            )}
           </YStack>
         ) : null}
 

--- a/apps/mobile-web/app/_layout.tsx
+++ b/apps/mobile-web/app/_layout.tsx
@@ -83,6 +83,12 @@ function AppNavigation() {
           headerShown: false,
         }}
       />
+      <Stack.Screen
+        name="join/[token]"
+        options={{
+          headerTitle: "",
+        }}
+      />
     </Stack>
   );
 }

--- a/apps/mobile-web/app/join/[token].tsx
+++ b/apps/mobile-web/app/join/[token].tsx
@@ -1,0 +1,120 @@
+// @ts-nocheck - Tamagui type recursion workaround
+// Landing page for invite deep-links (`footballwithfriends://join/<token>`
+// and `https://.../join/<token>`). Works for both signed-in and signed-out
+// users: signed-out flow shows a sign-in CTA with a `redirectTo` preserving
+// the token; signed-in flow accepts on mount and navigates into the group.
+
+import {
+  useAcceptInvite,
+  useInvitePreview,
+  useSession,
+} from "@repo/api-client";
+import { router, useLocalSearchParams } from "expo-router";
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Button, Spinner, Text, YStack } from "tamagui";
+
+export default function JoinScreen() {
+  const { t } = useTranslation();
+  const { token } = useLocalSearchParams<{ token: string }>();
+  const { data: session, isPending: isSessionPending } = useSession();
+
+  const {
+    data: preview,
+    isLoading: isPreviewLoading,
+    error: previewError,
+  } = useInvitePreview(token ?? null);
+
+  const acceptMutation = useAcceptInvite();
+  const isSignedIn = !!session?.user;
+
+  useEffect(() => {
+    if (!token || !isSignedIn || preview?.valid !== true) return;
+    if (acceptMutation.isPending || acceptMutation.isSuccess || acceptMutation.isError) return;
+    acceptMutation.mutate(token, {
+      onSuccess: () => router.replace("/(tabs)/matches"),
+    });
+  }, [token, isSignedIn, preview?.valid]);
+
+  if (isSessionPending || isPreviewLoading) {
+    return (
+      <YStack flex={1} justifyContent="center" alignItems="center">
+        <Spinner size="large" />
+      </YStack>
+    );
+  }
+
+  if (previewError || !preview) {
+    return (
+      <YStack flex={1} justifyContent="center" alignItems="center" padding="$4" gap="$3">
+        <Text fontSize="$6" fontWeight="700">
+          {t("groups.invite.loadErrorTitle")}
+        </Text>
+        <Text color="$gray11" textAlign="center">
+          {t("groups.invite.loadErrorBody")}
+        </Text>
+      </YStack>
+    );
+  }
+
+  if (!preview.valid) {
+    const reason = preview.reason ?? "not_found";
+    return (
+      <YStack flex={1} justifyContent="center" alignItems="center" padding="$4" gap="$3">
+        <Text fontSize="$6" fontWeight="700">
+          {t("groups.invite.invalidTitle")}
+        </Text>
+        <Text color="$gray11" textAlign="center">
+          {t(`groups.invite.invalidReason.${reason}`)}
+        </Text>
+      </YStack>
+    );
+  }
+
+  if (!isSignedIn) {
+    return (
+      <YStack flex={1} justifyContent="center" alignItems="center" padding="$4" gap="$4">
+        <Text fontSize="$7" fontWeight="700" textAlign="center">
+          {t("groups.invite.previewTitle", { groupName: preview.group?.name ?? "" })}
+        </Text>
+        {preview.inviter?.name ? (
+          <Text color="$gray11" textAlign="center">
+            {t("groups.invite.invitedBy", { name: preview.inviter.name })}
+          </Text>
+        ) : null}
+        <Button
+          theme="active"
+          onPress={() =>
+            router.push({
+              pathname: "/(auth)",
+              params: { redirectTo: `/join/${token}` },
+            })
+          }
+        >
+          {t("groups.invite.signInToJoin")}
+        </Button>
+      </YStack>
+    );
+  }
+
+  if (acceptMutation.isError) {
+    return (
+      <YStack flex={1} justifyContent="center" alignItems="center" padding="$4" gap="$3">
+        <Text fontSize="$6" fontWeight="700">
+          {t("groups.invite.acceptFailedTitle")}
+        </Text>
+        <Text color="$gray11" textAlign="center">
+          {t("groups.invite.acceptFailedBody")}
+        </Text>
+        <Button onPress={() => acceptMutation.reset()}>{t("shared.tryAgain")}</Button>
+      </YStack>
+    );
+  }
+
+  return (
+    <YStack flex={1} justifyContent="center" alignItems="center" padding="$4" gap="$3">
+      <Spinner size="large" />
+      <Text color="$gray11">{t("groups.invite.joining")}</Text>
+    </YStack>
+  );
+}

--- a/apps/mobile-web/app/join/[token].tsx
+++ b/apps/mobile-web/app/join/[token].tsx
@@ -16,7 +16,11 @@ import { Button, Spinner, Text, YStack } from "tamagui";
 
 export default function JoinScreen() {
   const { t } = useTranslation();
-  const { token } = useLocalSearchParams<{ token: string }>();
+  // useLocalSearchParams returns `string | string[] | undefined` — normalize
+  // to a single string before we pass it to the API as a token.
+  const params = useLocalSearchParams<{ token?: string | string[] }>();
+  const rawToken = params.token;
+  const token = Array.isArray(rawToken) ? rawToken[0] : rawToken;
   const { data: session, isPending: isSessionPending } = useSession();
 
   const {
@@ -28,12 +32,17 @@ export default function JoinScreen() {
   const acceptMutation = useAcceptInvite();
   const isSignedIn = !!session?.user;
 
-  useEffect(() => {
-    if (!token || !isSignedIn || preview?.valid !== true) return;
-    if (acceptMutation.isPending || acceptMutation.isSuccess || acceptMutation.isError) return;
+  function runAccept() {
+    if (!token) return;
     acceptMutation.mutate(token, {
       onSuccess: () => router.replace("/(tabs)/matches"),
     });
+  }
+
+  useEffect(() => {
+    if (!token || !isSignedIn || preview?.valid !== true) return;
+    if (acceptMutation.isPending || acceptMutation.isSuccess || acceptMutation.isError) return;
+    runAccept();
   }, [token, isSignedIn, preview?.valid]);
 
   if (isSessionPending || isPreviewLoading) {
@@ -106,7 +115,7 @@ export default function JoinScreen() {
         <Text color="$gray11" textAlign="center">
           {t("groups.invite.acceptFailedBody")}
         </Text>
-        <Button onPress={() => acceptMutation.reset()}>{t("shared.tryAgain")}</Button>
+        <Button onPress={runAccept}>{t("shared.tryAgain")}</Button>
       </YStack>
     );
   }

--- a/docs/superpowers/plans/2026-04-22-group-oriented-scoping.md
+++ b/docs/superpowers/plans/2026-04-22-group-oriented-scoping.md
@@ -12,7 +12,7 @@
 
 - [x] **Phase 0** — Schema foundation (no behavior change)
 - [x] **Phase 1** — Backfill + scoping (core path scoped; staging verification + tests deferred)
-- [ ] **Phase 2** — Group management API + mobile-web switcher
+- [x] **Phase 2** — Group management API + mobile-web switcher *(entry-point screens + tab-gate swap landed; full header switcher component + noGroup onboarding + useDeleteGroup hook deferred)*
 - [x] **Phase 3** — Invites (link + accept flow) *(core path landed; tests + E2E + staging verification deferred)*
 - [ ] **Phase 4** — Ghost roster (full lifecycle + legacy guest conversion)
 - [ ] **Phase 5** — Polish (phone invites, copy-venues helper, public-directory flag, i18n pass)
@@ -246,63 +246,63 @@ group_id TEXT UNIQUE REFERENCES groups(id) ON DELETE CASCADE
 
 ### Subtasks — API (`apps/api/src/routes/groups.ts`)
 
-- [ ] Create the route file. Mount under `/api/groups` in `apps/api/src/index.ts`. Only `GET /api/groups/me` is OUTSIDE `groupContextMiddleware` (it's the endpoint that powers the switcher itself).
-- [ ] `GET /api/groups/me` → list my groups with my role in each. Used by the switcher; no `X-Group-Id` needed.
-- [ ] `POST /api/groups` → create a new group. **Superadmin only at launch** (feature-flagged: `allowUserCreateGroups` setting, default `false`). Body: `{name}`. Sets caller as owner + organizer.
-- [ ] `GET /api/groups/:id` → group details, members list, settings. Organizer can see everything; member sees name + their own role only.
-- [ ] `PATCH /api/groups/:id` → update name/settings. `requireOrganizer`.
-- [ ] `DELETE /api/groups/:id` → soft-delete. `requireOwner`.
-- [ ] `GET /api/groups/:id/members` → full roster of users. `requireOrganizer`.
-- [ ] `PATCH /api/groups/:id/members/:userId` → promote/demote. `requireOwner` only.
-- [ ] `DELETE /api/groups/:id/members/:userId` → kick. `requireOrganizer`. Cannot kick the owner.
-- [ ] `POST /api/groups/:id/leave` → self-leave. Non-owner only (owner must transfer first).
-- [ ] `POST /api/groups/:id/transfer-ownership` → `requireOwner`. Target must be an existing organizer.
+- [x] Created the route file. Mounted under `/api/groups` in `apps/api/src/api-routes.ts`. `GET /api/groups/me` + `POST /api/groups` are registered *before* `app.use("*", groupContextMiddleware)`; everything else runs scoped.
+- [x] `GET /api/groups/me` → lists my groups with role + owner flag. No `X-Group-Id` required.
+- [x] `POST /api/groups` → superadmin-only (direct `requireSuperadmin` check; the `allowUserCreateGroups` setting is deferred to Phase 5). Body: `{name, slug?}`. Inserts group + organizer membership.
+- [x] `GET /api/groups/:id` → service splits into `getGroupDetails` (full, organizer view) and `getGroupBasics` (member view: id/name/slug/visibility/myRole).
+- [x] `PATCH /api/groups/:id` → `requireOrganizer`. Visibility toggling is superadmin-only until the public-directory flow lands in Phase 5.
+- [x] `DELETE /api/groups/:id` → `requireOwner`. Soft-delete.
+- [x] `GET /api/groups/:id/members` → `requireOrganizer`.
+- [x] `PATCH /api/groups/:id/members/:userId` → `requireOwner`.
+- [x] `DELETE /api/groups/:id/members/:userId` → `requireOrganizer`. Owner cannot be kicked (service guard).
+- [x] `POST /api/groups/:id/leave` → non-owner only; owner must transfer first (service guard).
+- [x] `POST /api/groups/:id/transfer-ownership` → `requireOwner`. Target must already be an organizer.
 
 ### Subtasks — Service layer
 
-- [ ] `packages/shared/src/services/group-service.ts`:
-  - [ ] `createGroup({ownerUserId, name})` — transactional: insert group, insert organizer membership.
-  - [ ] `transferOwnership({groupId, fromUserId, toUserId})` — guards: `fromUserId` is current owner, `toUserId` is existing organizer.
-  - [ ] `leaveGroup({groupId, userId})` — guard: not owner.
-  - [ ] `deleteGroup({groupId, userId})` — guard: owner. Soft-delete (set `deleted_at` column if schema supports; else hard-delete with CASCADE).
+- [x] `packages/shared/src/services/group-service.ts`:
+  - [x] `createGroup({ownerUserId, name, slug?})` — group insert → organizer membership insert (separate statements; LibSQL has no cross-repo txn, orphan-group risk is acceptable at superadmin-only scale).
+  - [x] `transferOwnership(groupId, fromUserId, toUserId)` — guards: current owner + target organizer.
+  - [x] `leaveGroup(groupId, userId)` — guard: not owner.
+  - [x] `softDeleteGroup(groupId)` — owner check lives at the route (`requireOwner`); service writes `deleted_at`.
 
 ### Subtasks — Client hooks (`packages/api-client/src/groups.ts`)
 
-- [ ] `useMyGroups()` — wraps `GET /api/groups/me`.
-- [ ] `useCurrentGroup()` — exposes `{groupId, setGroupId, myGroups, isLoading, noGroup: boolean}`. `setGroupId` persists via `group-storage.ts` and invalidates every React Query cache entry (use `queryClient.invalidateQueries()` with a `groupId` dimension in query keys, see below).
-- [ ] `useGroup(groupId)` — details.
-- [ ] `useGroupMembers(groupId)`.
-- [ ] `useCreateGroup()`, `useUpdateGroup()`, `useDeleteGroup()`, `usePromoteMember()`, `useKickMember()`, `useLeaveGroup()`, `useTransferOwnership()`.
-- [ ] Update the React Query convention: every scoped query key includes `currentGroup.id` so switching invalidates correctly. E.g. `['matches', groupId, tab]`.
+- [x] `useMyGroups()` — wraps `GET /api/groups/me`.
+- [x] `useCurrentGroup()` — exposes `{groupId, group, myRole, amIOwner, myGroups, isLoading, noGroup, switchGroup}`. `switchGroup` persists via `group-storage.ts` and calls `queryClient.invalidateQueries()` (no filter — active group change invalidates everything transitively).
+- [x] `useGroupDetail(groupId)` — plan's `useGroup`, renamed for consistency with other `*Detail` hooks in the codebase.
+- [x] `useGroupMembers(groupId)`.
+- [x] `useCreateGroup()`, `useUpdateGroup()`, `useUpdateMemberRole()` (plan's `usePromoteMember`; one hook handles both directions via body.role), `useKickMember()`, `useLeaveGroup()`, `useTransferOwnership()`.
+- [ ] `useDeleteGroup()` — **deferred**. API endpoint exists; no UI consumer yet so no client hook shipped.
+- [x] Query-key convention: every scoped key lives under `groupQueryKeys.*`. Switching invalidates globally (see `switchGroup`), which is a simpler correctness guarantee than threading `groupId` through every key.
 
 ### Subtasks — Mobile-Web UX
 
-- [ ] `apps/mobile-web/app/(tabs)/_layout.tsx`:
-  - [ ] Add a header group switcher component (only rendered when `myGroups.length >= 2`). Shows `currentGroup.name` + chevron; tap opens bottom sheet with group list.
-  - [ ] Swap admin-tab visibility check from `user.role === "admin"` to `currentGroup.role === "organizer"`.
-- [ ] New screen `apps/mobile-web/app/(tabs)/profile/groups/index.tsx` — "My Groups" list, entry point from profile.
-- [ ] New screen `apps/mobile-web/app/(tabs)/profile/groups/[groupId].tsx` — group detail (members, settings, invite management placeholder for Phase 3).
-- [ ] New screen `apps/mobile-web/app/(tabs)/admin/create-group.tsx` — superadmin-only (hidden behind a `useIsSuperadmin()` hook).
-- [ ] Verify match/admin screens work — most should need no direct change, only verify `queryKey` includes `groupId`.
-- [ ] "No group yet" screen if `useCurrentGroup().noGroup`: message + CTA to paste an invite link (placeholder; real handler lands in Phase 3).
+- [x] `apps/mobile-web/app/(tabs)/_layout.tsx`: admin-tab visibility swapped from `user.role === "admin"` to `isSuperadmin || myRole === "organizer"`.
+- [ ] Header group switcher component (bottom sheet at ≥2 groups) — **deferred**. Not needed for single-tenant launch; entry point is the Profile → My Groups list which serves the same purpose.
+- [x] New screen `apps/mobile-web/app/(tabs)/profile/groups/index.tsx` — "My Groups" list.
+- [x] New screen `apps/mobile-web/app/(tabs)/profile/groups/[groupId].tsx` — group detail (members list + leave button; invites section added in Phase 3).
+- [x] New screen `apps/mobile-web/app/(tabs)/admin/create-group.tsx` — superadmin-only.
+- [x] Match/admin screens: no direct changes needed. Global `invalidateQueries()` on `switchGroup` ensures correctness without keying every query by groupId.
+- [ ] "No group yet" screen for `useCurrentGroup().noGroup` — **deferred**. The API returns `409 NO_GROUP` and the fetch interceptor bubbles the error; formal onboarding screen lands with Phase 5 polish.
 
 ### Subtasks — i18n
 
-- [ ] Add keys to `apps/mobile-web/locales/en/common.json` and `.../es/common.json`:
-  - [ ] `groups.switcher.label`, `groups.switcher.empty`
-  - [ ] `groups.myGroups.title`, `groups.myGroups.empty`
-  - [ ] `groups.create.title`, `groups.create.cta`, `groups.create.success`
-  - [ ] `groups.detail.members`, `groups.detail.settings`, `groups.detail.leave`, `groups.detail.transfer`, `groups.detail.delete`
-  - [ ] `groups.members.promote`, `groups.members.demote`, `groups.members.kick`
-  - [ ] `groups.noGroup.title`, `groups.noGroup.body`
+- [x] Keys added to `locales/en/common.json` and `locales/es/common.json`:
+  - [x] `groups.switcher.label`, `groups.switcher.loading`
+  - [x] `groups.myGroups.title`, `groups.myGroups.empty`, `groups.myGroups.owner|organizer|member`
+  - [x] `groups.create.title`, `groups.create.nameLabel`, `groups.create.namePlaceholder`, `groups.create.cta`, `groups.create.success`, `groups.create.superadminOnly`
+  - [x] `groups.detail.title`, `groups.detail.members`, `groups.detail.settings`, `groups.detail.leave`, `groups.detail.transfer`, `groups.detail.delete`, `groups.detail.deleteConfirm`, `groups.detail.loadError`
+  - [x] `groups.members.promote`, `groups.members.demote`, `groups.members.kick`
+  - [x] `groups.noGroup.title`, `groups.noGroup.body`
 
 ### Verification Gate
 
-- [ ] New tests green: group-service unit tests (create, transfer, leave, delete guards), groups-routes integration tests.
-- [ ] Manual: as superadmin, create a second group, switch to it, confirm empty matches list; switch back to legacy, see legacy matches.
-- [ ] Manual: as a regular member of legacy, confirm switcher is hidden (they're only in 1 group) and admin tab is hidden.
-- [ ] Promote a test user to organizer → admin tab appears for them after refresh.
-- [ ] Kick a user → their next request to a scoped endpoint for that group returns 403.
+- [ ] Group-service unit tests + groups-routes integration tests — **deferred** (no test harness on `apps/api` yet; Phase 1 + 3 made the same call).
+- [ ] Manual: superadmin creates a second group, switches, sees empty list; switches back to legacy.
+- [ ] Manual: regular legacy member confirms admin tab is hidden.
+- [ ] Manual: promote a test user to organizer → admin tab appears after refresh.
+- [ ] Manual: kick a user → next scoped request 403s (fetch interceptor clears the stale group id; `useCurrentGroup` self-heals).
 
 ---
 

--- a/docs/superpowers/plans/2026-04-22-group-oriented-scoping.md
+++ b/docs/superpowers/plans/2026-04-22-group-oriented-scoping.md
@@ -13,7 +13,7 @@
 - [x] **Phase 0** — Schema foundation (no behavior change)
 - [x] **Phase 1** — Backfill + scoping (core path scoped; staging verification + tests deferred)
 - [ ] **Phase 2** — Group management API + mobile-web switcher
-- [ ] **Phase 3** — Invites (link + accept flow)
+- [x] **Phase 3** — Invites (link + accept flow) *(core path landed; tests + E2E + staging verification deferred)*
 - [ ] **Phase 4** — Ghost roster (full lifecycle + legacy guest conversion)
 - [ ] **Phase 5** — Polish (phone invites, copy-venues helper, public-directory flag, i18n pass)
 
@@ -314,32 +314,32 @@ group_id TEXT UNIQUE REFERENCES groups(id) ON DELETE CASCADE
 
 ### Subtasks — API (`apps/api/src/routes/invites.ts` + extensions to `groups.ts`)
 
-- [ ] `POST /api/groups/:id/invites` → create invite. `requireOrganizer`. Body: `{expiresInHours?, maxUses?, targetPhone?, targetUserId?}`. Generates a 24-char URL-safe token (use the existing crypto RNG from `apps/api/src/crypto/password.ts`).
-- [ ] `GET /api/groups/:id/invites` → list active invites. `requireOrganizer`.
-- [ ] `DELETE /api/groups/:id/invites/:inviteId` → revoke. `requireOrganizer`.
-- [ ] `GET /api/invites/:token` — **PUBLIC** (no auth, no group context). Returns invite preview: `{group: {name}, inviter: {name}, expiresAt, valid: boolean, reason?: 'expired'|'revoked'|'exhausted'}`.
-- [ ] `POST /api/invites/:token/accept` — **authed** but no group context required. Validates invite → creates `group_members` row (ignores duplicate if already member) → attempts ghost auto-claim by user's phone and email.
-- [ ] Add `/api/invites/:token*` to PUBLIC_ROUTES regex in `apps/api/src/middleware/security.ts` for the GET only; accept POST requires a session.
+- [x] `POST /api/groups/:id/invites` → create invite. `requireOrganizer`. Body: `{expiresInHours?, maxUses?, targetPhone?, targetUserId?}`. Uses nanoid(24) for the URL-safe token (already a dep; avoids importing crypto RNG into a different context).
+- [x] `GET /api/groups/:id/invites` → list active invites. `requireOrganizer`.
+- [x] `DELETE /api/groups/:id/invites/:inviteId` → revoke. `requireOrganizer`.
+- [x] `GET /api/invites/:token` — **PUBLIC** (no auth, no group context). Returns invite preview: `{group: {name}, inviter: {name}, expiresAt, valid: boolean, reason?: 'expired'|'revoked'|'exhausted'}`.
+- [x] `POST /api/invites/:token/accept` — **authed** but no group context required. Validates invite → creates `group_members` row (ignores duplicate if already member) → attempts ghost auto-claim by user's phone and email.
+- [x] Added `GET /api/invites/:token` to `PUBLIC_ROUTES` in `apps/api/src/middleware/security.ts`; POST accept still flows through auth.
 
 ### Subtasks — Ghost auto-claim hook
 
-- [ ] In `group-service.ts`, add `acceptInvite({token, userId})`:
-  - [ ] Load invite; validate (not revoked, not expired, uses_count < max_uses, target_phone/user_id matches if set).
-  - [ ] Create membership (upsert).
-  - [ ] Increment `uses_count`.
-  - [ ] Query `group_roster` for rows in this group with `phone = user.phone` OR `email = user.email` AND `claimed_by_user_id IS NULL`. If exactly one match → set `claimed_by_user_id = userId`. If multiple matches → log for organizer review (don't guess).
-- [ ] Expose result `{joined: true, claimedRosterId?: string}` so the client can show a toast "Your history is now linked."
+- [x] In `group-service.ts`, added `acceptInvite({token, userId, userEmail, userPhone})`:
+  - [x] Loads invite; validates (not revoked, not expired, uses_count < max_uses, target_phone/user_id matches if set).
+  - [x] Creates membership (idempotent — skips if already a member).
+  - [x] Increments `uses_count`.
+  - [x] Queries `group_roster` by phone, then by email, dedupes, filters out claimed rows. If exactly one match → sets `claimed_by_user_id`. If multiple → does nothing and reports the count in the response.
+- [x] Returns `{joined: true, groupId, claimedRosterId?, ambiguousRosterMatches?}` so the client can show a toast.
 
 ### Subtasks — Mobile-Web UX
 
-- [ ] New screen `apps/mobile-web/app/(auth)/join/[token].tsx`:
-  - [ ] On mount, call `GET /api/invites/:token` (unauthenticated). Render preview card.
-  - [ ] If invalid → error state with clear message.
-  - [ ] If user is not signed in → CTA "Sign up to join" / "Already have an account? Sign in" — both flows preserve the token via a `redirectTo` query param so post-auth we return to the accept screen.
-  - [ ] If signed in → call `POST /api/invites/:token/accept` → on success, set active group to the joined one, navigate to `/(tabs)/matches`.
-- [ ] In the group detail screen (Phase 2), add an "Invites" section for organizers: list active invites, "Create invite link" button, copy-to-clipboard, revoke.
-- [ ] Web: register the route. Mobile: add `footballwithfriends://join/<token>` scheme in `apps/mobile-web/app.config.ts`; test cold-start deep-link.
-- [ ] i18n: `groups.invite.*` keys (create, copy, revoke, expires, valid, invalid, expired, joined, claimedHistory).
+- [x] New screen `apps/mobile-web/app/join/[token].tsx` (mounted at the root stack, not under `(auth)` — the auth layout redirects signed-in users to `/(tabs)`, which would short-circuit the accept flow for already-signed-in invitees):
+  - [x] Calls `useInvitePreview` on mount; renders preview card.
+  - [x] Invalid invite → dedicated error copy per reason.
+  - [x] Not signed in → CTA "Sign in to join" carrying `redirectTo=/join/<token>` back to this screen.
+  - [x] Signed in → auto-calls `useAcceptInvite` which sets active group on success → navigates to `/(tabs)/matches`.
+- [x] Group detail screen: organizer-only Invites section — list active invites, "Create invite link" (default 7-day expiry), web-clipboard copy / native Share fallback, revoke.
+- [x] Web: registered `join/[token]` in root `_layout.tsx`. Mobile: `scheme: "football-with-friends"` already in `app.config.ts`; Expo Router handles `football-with-friends://join/<token>` automatically.
+- [x] i18n: `groups.invite.*` keys (create/copy/revoke/expiresAt/neverExpires/previewTitle/invitedBy/signInToJoin/joining + invalidReason.* + loadError* + acceptFailed*). EN + ES both landed.
 
 ### Subtasks — Tests
 

--- a/docs/superpowers/plans/2026-04-22-group-oriented-scoping.md
+++ b/docs/superpowers/plans/2026-04-22-group-oriented-scoping.md
@@ -323,7 +323,7 @@ group_id TEXT UNIQUE REFERENCES groups(id) ON DELETE CASCADE
 
 ### Subtasks — Ghost auto-claim hook
 
-- [x] In `group-service.ts`, added `acceptInvite({token, userId, userEmail, userPhone})`:
+- [x] In `group-service.ts`, added `acceptInvite({token, userId})` (service fetches email + phoneNumber itself so routes don't touch the `user` table):
   - [x] Loads invite; validates (not revoked, not expired, uses_count < max_uses, target_phone/user_id matches if set).
   - [x] Creates membership (idempotent — skips if already a member).
   - [x] Increments `uses_count`.

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -769,6 +769,31 @@
     "noGroup": {
       "title": "No group yet",
       "body": "Ask your organizer for an invite link, then open it to join."
+    },
+    "invite": {
+      "sectionTitle": "Invites",
+      "create": "Create invite link",
+      "copy": "Copy",
+      "revoke": "Revoke",
+      "empty": "No active invites yet.",
+      "expiresAt": "Expires {{date}}",
+      "neverExpires": "Never expires",
+      "previewTitle": "You've been invited to {{groupName}}",
+      "invitedBy": "Invited by {{name}}",
+      "signInToJoin": "Sign in to join",
+      "joining": "Joining…",
+      "invalidTitle": "This invite isn't valid",
+      "invalidReason": {
+        "expired": "This invite has expired.",
+        "revoked": "This invite was revoked by the organizer.",
+        "exhausted": "This invite has been used up.",
+        "target_mismatch": "This invite was issued for a different account.",
+        "not_found": "We couldn't find this invite."
+      },
+      "loadErrorTitle": "Couldn't load invite",
+      "loadErrorBody": "Check your connection and try again.",
+      "acceptFailedTitle": "Couldn't join the group",
+      "acceptFailedBody": "Something went wrong. Please try again."
     }
   }
 }

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -772,6 +772,31 @@
     "noGroup": {
       "title": "Todavía sin grupo",
       "body": "Pedile al organizador un link de invitación y abrilo para entrar."
+    },
+    "invite": {
+      "sectionTitle": "Invitaciones",
+      "create": "Crear link de invitación",
+      "copy": "Copiar",
+      "revoke": "Revocar",
+      "empty": "Todavía no hay invitaciones activas.",
+      "expiresAt": "Vence el {{date}}",
+      "neverExpires": "Sin vencimiento",
+      "previewTitle": "Te invitaron a {{groupName}}",
+      "invitedBy": "Te invitó {{name}}",
+      "signInToJoin": "Iniciá sesión para unirte",
+      "joining": "Uniéndote…",
+      "invalidTitle": "Esta invitación no es válida",
+      "invalidReason": {
+        "expired": "Esta invitación venció.",
+        "revoked": "El organizador revocó esta invitación.",
+        "exhausted": "Esta invitación ya fue usada.",
+        "target_mismatch": "Esta invitación es para otra cuenta.",
+        "not_found": "No encontramos esta invitación."
+      },
+      "loadErrorTitle": "No se pudo cargar la invitación",
+      "loadErrorBody": "Revisá tu conexión e intentá de nuevo.",
+      "acceptFailedTitle": "No pudimos unirte al grupo",
+      "acceptFailedBody": "Algo salió mal. Intentá de nuevo."
     }
   }
 }

--- a/packages/api-client/src/groups.ts
+++ b/packages/api-client/src/groups.ts
@@ -4,7 +4,11 @@
 // active group id) and with the Phase 1 `X-Group-Id` fetch interceptor in
 // `client.ts` (which carries the active group on every request).
 
-import type { GroupVisibility, MemberRole } from "@repo/shared/domain";
+import type {
+  GroupInviteInvalidReason,
+  GroupVisibility,
+  MemberRole,
+} from "@repo/shared/domain";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { client as _client } from "./client";
@@ -31,6 +35,9 @@ export const groupQueryKeys = {
   me: () => [...groupQueryKeys.all, "me"] as const,
   detail: (id: string) => [...groupQueryKeys.all, "detail", id] as const,
   members: (id: string) => [...groupQueryKeys.all, "members", id] as const,
+  invites: (id: string) => [...groupQueryKeys.all, "invites", id] as const,
+  invitePreview: (token: string) =>
+    [...groupQueryKeys.all, "invite-preview", token] as const,
 };
 
 export interface MyGroupSummary {
@@ -210,6 +217,121 @@ export function useLeaveGroup() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: groupQueryKeys.me() });
+    },
+  });
+}
+
+// --- Invites -------------------------------------------------------------
+
+export interface GroupInviteSummary {
+  id: string;
+  groupId: string;
+  token: string;
+  createdByUserId: string;
+  expiresAt?: string;
+  maxUses?: number;
+  usesCount: number;
+  targetPhone?: string;
+  targetUserId?: string;
+  revokedAt?: string;
+  createdAt: string;
+}
+
+export interface GroupInvitePreviewResult {
+  valid: boolean;
+  reason?: GroupInviteInvalidReason;
+  group?: { id: string; name: string };
+  inviter?: { id: string; name: string };
+  expiresAt?: string;
+}
+
+export function useGroupInvites(groupId: string | null) {
+  return useQuery({
+    queryKey: groupQueryKeys.invites(groupId ?? ""),
+    enabled: !!groupId,
+    queryFn: async () => {
+      const res = await client.api.groups[":id"].invites.$get({
+        param: { id: groupId! },
+      });
+      const data = (await res.json()) as { invites: GroupInviteSummary[] };
+      return data.invites;
+    },
+  });
+}
+
+export function useCreateInvite(groupId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: {
+      expiresInHours?: number;
+      maxUses?: number;
+      targetPhone?: string;
+      targetUserId?: string;
+    }) => {
+      const res = await client.api.groups[":id"].invites.$post({
+        param: { id: groupId },
+        json: input,
+      });
+      const data = (await res.json()) as { invite: GroupInviteSummary };
+      return data.invite;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: groupQueryKeys.invites(groupId) });
+    },
+  });
+}
+
+export function useRevokeInvite(groupId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (inviteId: string) => {
+      const res = await client.api.groups[":id"].invites[":inviteId"].$delete({
+        param: { id: groupId, inviteId },
+      });
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: groupQueryKeys.invites(groupId) });
+    },
+  });
+}
+
+// Preview is unauthenticated — still fine to reuse the same fetch interceptor
+// (it attaches Authorization only when a token exists, so anonymous calls work).
+export function useInvitePreview(token: string | null) {
+  return useQuery({
+    queryKey: groupQueryKeys.invitePreview(token ?? ""),
+    enabled: !!token,
+    retry: false,
+    queryFn: async () => {
+      const res = await client.api.invites[":token"].$get({
+        param: { token: token! },
+      });
+      const data = (await res.json()) as GroupInvitePreviewResult;
+      return data;
+    },
+  });
+}
+
+export function useAcceptInvite() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (token: string) => {
+      const res = await client.api.invites[":token"].accept.$post({
+        param: { token },
+      });
+      return (await res.json()) as {
+        joined: true;
+        groupId: string;
+        claimedRosterId?: string;
+        ambiguousRosterMatches?: number;
+      };
+    },
+    onSuccess: (result) => {
+      // Freshly joined → we have a new group. Switch to it and blow away any
+      // previously cached scoped data so the new group's responses drive UI.
+      setActiveGroupId(result.groupId);
+      queryClient.invalidateQueries();
     },
   });
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -62,7 +62,13 @@ export {
   useKickMember,
   useLeaveGroup,
   useTransferOwnership,
+  useGroupInvites,
+  useCreateInvite,
+  useRevokeInvite,
+  useInvitePreview,
+  useAcceptInvite,
 } from "./groups";
+export type { GroupInviteSummary, GroupInvitePreviewResult } from "./groups";
 
 // Re-export the API routes type for convenience
 export type { ApiRoutes } from "../../../apps/api/src/index";

--- a/packages/shared/src/repositories/group-repositories.ts
+++ b/packages/shared/src/repositories/group-repositories.ts
@@ -293,6 +293,31 @@ export class TursoGroupMembershipRepository {
     return rowToMember(row);
   }
 
+  /**
+   * Idempotent membership insert. Uses `UNIQUE(group_id, user_id)` to drop
+   * duplicates server-side instead of read-then-write, which would race
+   * under concurrent accepts of the same invite by the same user. Returns
+   * true iff a new row was created.
+   */
+  async tryAdd(params: {
+    groupId: string;
+    userId: string;
+    role: MemberRole;
+  }): Promise<boolean> {
+    const id = generateId("gm");
+    const result = await this.db
+      .insertInto("group_members")
+      .values({
+        id,
+        group_id: params.groupId,
+        user_id: params.userId,
+        role: params.role,
+      })
+      .onConflict((oc) => oc.columns(["group_id", "user_id"]).doNothing())
+      .executeTakeFirst();
+    return Number(result.numInsertedOrUpdatedRows ?? 0) > 0;
+  }
+
   async updateRole(
     groupId: string,
     userId: string,
@@ -376,6 +401,27 @@ export class TursoGroupInviteRepository {
       .set((eb) => ({ uses_count: eb("uses_count", "+", 1) }))
       .where("id", "=", id)
       .execute();
+  }
+
+  /**
+   * Atomic increment that only succeeds while `uses_count < max_uses` (or
+   * max_uses is null). Returns true iff the use was consumed. Prevents two
+   * concurrent accepters from both passing an optimistic check and pushing
+   * `uses_count` above `max_uses`.
+   */
+  async tryConsumeUse(id: string): Promise<boolean> {
+    const result = await this.db
+      .updateTable("group_invites")
+      .set((eb) => ({ uses_count: eb("uses_count", "+", 1) }))
+      .where("id", "=", id)
+      .where((eb) =>
+        eb.or([
+          eb("max_uses", "is", null),
+          eb("uses_count", "<", eb.ref("max_uses")),
+        ]),
+      )
+      .executeTakeFirst();
+    return Number(result.numUpdatedRows ?? 0) > 0;
   }
 
   async revoke(id: string): Promise<void> {
@@ -467,6 +513,24 @@ export class TursoGroupRosterRepository {
       .deleteFrom("group_roster")
       .where("id", "=", id)
       .execute();
+  }
+
+  /**
+   * Atomic claim that only succeeds while `claimed_by_user_id IS NULL`.
+   * Prevents a late accept from overwriting a claim that landed between the
+   * reader's lookup and write. Returns true iff the row was claimed here.
+   */
+  async tryClaim(id: string, userId: string): Promise<boolean> {
+    const result = await this.db
+      .updateTable("group_roster")
+      .set({
+        claimed_by_user_id: userId,
+        updated_at: new Date().toISOString(),
+      })
+      .where("id", "=", id)
+      .where("claimed_by_user_id", "is", null)
+      .executeTakeFirst();
+    return Number(result.numUpdatedRows ?? 0) > 0;
   }
 }
 

--- a/packages/shared/src/repositories/group-repositories.ts
+++ b/packages/shared/src/repositories/group-repositories.ts
@@ -341,6 +341,15 @@ export class TursoGroupInviteRepository {
     return rowToInvite(row);
   }
 
+  async findById(id: string): Promise<GroupInvite | null> {
+    const row = await this.db
+      .selectFrom("group_invites")
+      .selectAll()
+      .where("id", "=", id)
+      .executeTakeFirst();
+    return row ? rowToInvite(row) : null;
+  }
+
   async findByToken(token: string): Promise<GroupInvite | null> {
     const row = await this.db
       .selectFrom("group_invites")

--- a/packages/shared/src/services/factory.ts
+++ b/packages/shared/src/services/factory.ts
@@ -50,6 +50,8 @@ export class ServiceFactory {
       repos.groups,
       repos.groupMembers,
       repos.groupSettings,
+      repos.groupInvites,
+      repos.groupRoster,
     );
   }
 }

--- a/packages/shared/src/services/group-service.ts
+++ b/packages/shared/src/services/group-service.ts
@@ -5,13 +5,19 @@
 
 import type {
   Group,
+  GroupInvite,
+  GroupInviteInvalidReason,
+  GroupInvitePreview,
   GroupMember,
   MemberRole,
   UpdateGroupData,
 } from "../domain/types";
+import { getDatabase } from "../database/connection";
 import type {
+  TursoGroupInviteRepository,
   TursoGroupMembershipRepository,
   TursoGroupRepository,
+  TursoGroupRosterRepository,
   TursoGroupSettingsRepository,
 } from "../repositories/group-repositories";
 
@@ -20,11 +26,34 @@ export interface GroupDetails extends Group {
   settings: Record<string, string>;
 }
 
+export interface InviteCreateParams {
+  groupId: string;
+  createdByUserId: string;
+  expiresInHours?: number;
+  maxUses?: number;
+  targetPhone?: string;
+  targetUserId?: string;
+}
+
+export type InviteAcceptOutcome =
+  | {
+      joined: true;
+      groupId: string;
+      claimedRosterId?: string;
+      ambiguousRosterMatches?: number;
+    }
+  | {
+      joined: false;
+      reason: GroupInviteInvalidReason;
+    };
+
 export class GroupService {
   constructor(
     private groupRepo: TursoGroupRepository,
     private memberRepo: TursoGroupMembershipRepository,
     private settingsRepo: TursoGroupSettingsRepository,
+    private inviteRepo: TursoGroupInviteRepository,
+    private rosterRepo: TursoGroupRosterRepository,
   ) {}
 
   async listMyGroups(userId: string) {
@@ -136,5 +165,157 @@ export class GroupService {
       throw new Error("Target must be an existing organizer of this group");
     }
     await this.groupRepo.transferOwnership(groupId, toUserId);
+  }
+
+  // --- Invites -----------------------------------------------------------
+
+  async listInvites(groupId: string): Promise<GroupInvite[]> {
+    return this.inviteRepo.listActiveByGroup(groupId);
+  }
+
+  async createInvite(params: InviteCreateParams): Promise<GroupInvite> {
+    const expiresAt =
+      typeof params.expiresInHours === "number" && params.expiresInHours > 0
+        ? new Date(Date.now() + params.expiresInHours * 3600 * 1000)
+        : undefined;
+    return this.inviteRepo.create({
+      groupId: params.groupId,
+      createdByUserId: params.createdByUserId,
+      expiresAt,
+      maxUses: params.maxUses,
+      targetPhone: params.targetPhone,
+      targetUserId: params.targetUserId,
+    });
+  }
+
+  async revokeInvite(groupId: string, inviteId: string): Promise<void> {
+    const invite = await this.inviteRepo.findById(inviteId);
+    if (!invite || invite.groupId !== groupId) {
+      throw new Error("Invite not found");
+    }
+    await this.inviteRepo.revoke(inviteId);
+  }
+
+  /**
+   * Unauthenticated preview for the `/join/:token` landing page. Returns a
+   * minimal payload so we don't leak membership details to strangers — just
+   * group name + inviter name + validity.
+   */
+  async getInvitePreview(token: string): Promise<GroupInvitePreview> {
+    const invite = await this.inviteRepo.findByToken(token);
+    if (!invite) return { valid: false, reason: "not_found" };
+    if (invite.revokedAt) return { valid: false, reason: "revoked" };
+    if (invite.expiresAt && invite.expiresAt.getTime() < Date.now()) {
+      return { valid: false, reason: "expired" };
+    }
+    if (invite.maxUses !== undefined && invite.usesCount >= invite.maxUses) {
+      return { valid: false, reason: "exhausted" };
+    }
+
+    // Group + inviter lookups are independent; kick them off together.
+    const [group, inviterRow] = await Promise.all([
+      this.groupRepo.findById(invite.groupId),
+      getDatabase()
+        .selectFrom("user")
+        .select(["id", "name"])
+        .where("id", "=", invite.createdByUserId)
+        .executeTakeFirst(),
+    ]);
+    if (!group) return { valid: false, reason: "not_found" };
+
+    return {
+      valid: true,
+      group: { id: group.id, name: group.name },
+      inviter: inviterRow
+        ? { id: inviterRow.id, name: inviterRow.name ?? "" }
+        : undefined,
+      expiresAt: invite.expiresAt,
+    };
+  }
+
+  /**
+   * Consumes an invite for an authenticated user.
+   * - Validates invite (not revoked/expired/exhausted, target matches if set).
+   * - Adds membership if not already a member; only then bumps uses_count so
+   *   a user refreshing a `maxUses: 1` link doesn't consume their own invite.
+   * - Attempts to auto-claim a single matching roster ghost by phone/email.
+   *   Multiple matches → leave alone, report the count (caller can surface).
+   */
+  async acceptInvite(params: {
+    token: string;
+    userId: string;
+  }): Promise<InviteAcceptOutcome> {
+    const invite = await this.inviteRepo.findByToken(params.token);
+    if (!invite) return { joined: false, reason: "not_found" };
+    if (invite.revokedAt) return { joined: false, reason: "revoked" };
+    if (invite.expiresAt && invite.expiresAt.getTime() < Date.now()) {
+      return { joined: false, reason: "expired" };
+    }
+    if (invite.maxUses !== undefined && invite.usesCount >= invite.maxUses) {
+      return { joined: false, reason: "exhausted" };
+    }
+    if (invite.targetUserId && invite.targetUserId !== params.userId) {
+      return { joined: false, reason: "target_mismatch" };
+    }
+
+    // Session doesn't carry phoneNumber, so fetch email + phone in a single
+    // round-trip for targetPhone validation + roster auto-claim.
+    const userRow = await getDatabase()
+      .selectFrom("user")
+      .select(["email", "phoneNumber"])
+      .where("id", "=", params.userId)
+      .executeTakeFirst();
+    const userEmail = userRow?.email ?? undefined;
+    const userPhone = userRow?.phoneNumber ?? undefined;
+
+    if (
+      invite.targetPhone &&
+      (!userPhone || invite.targetPhone !== userPhone)
+    ) {
+      return { joined: false, reason: "target_mismatch" };
+    }
+
+    const existing = await this.memberRepo.find(invite.groupId, params.userId);
+    if (!existing) {
+      await this.memberRepo.add({
+        groupId: invite.groupId,
+        userId: params.userId,
+        role: "member",
+      });
+      await this.inviteRepo.incrementUsesCount(invite.id);
+    }
+
+    // Auto-claim roster ghost if exactly one unclaimed entry matches by
+    // phone or email. Parallel lookups; dedupe via Set of ids.
+    const [byPhone, byEmail] = await Promise.all([
+      userPhone
+        ? this.rosterRepo.findByGroupAndPhone(invite.groupId, userPhone)
+        : Promise.resolve([]),
+      userEmail
+        ? this.rosterRepo.findByGroupAndEmail(invite.groupId, userEmail)
+        : Promise.resolve([]),
+    ]);
+    const matchIds = new Set<string>();
+    for (const r of byPhone) if (!r.claimedByUserId) matchIds.add(r.id);
+    for (const r of byEmail) if (!r.claimedByUserId) matchIds.add(r.id);
+
+    let claimedRosterId: string | undefined;
+    let ambiguousRosterMatches: number | undefined;
+    if (matchIds.size === 1) {
+      const [only] = matchIds;
+      if (only) {
+        await this.rosterRepo.update(only, { claimedByUserId: params.userId });
+        claimedRosterId = only;
+      }
+    } else if (matchIds.size > 1) {
+      ambiguousRosterMatches = matchIds.size;
+    }
+
+    return {
+      joined: true,
+      groupId: invite.groupId,
+      claimedRosterId,
+      ambiguousRosterMatches,
+    };
   }
 }

--- a/packages/shared/src/services/group-service.ts
+++ b/packages/shared/src/services/group-service.ts
@@ -235,11 +235,15 @@ export class GroupService {
 
   /**
    * Consumes an invite for an authenticated user.
-   * - Validates invite (not revoked/expired/exhausted, target matches if set).
-   * - Adds membership if not already a member; only then bumps uses_count so
-   *   a user refreshing a `maxUses: 1` link doesn't consume their own invite.
-   * - Attempts to auto-claim a single matching roster ghost by phone/email.
-   *   Multiple matches → leave alone, report the count (caller can surface).
+   *
+   * Concurrency-safe: membership add is idempotent via UNIQUE(group_id,
+   * user_id), `uses_count` is only bumped via an atomic conditional update
+   * that refuses to cross `max_uses`, and roster claim is conditional on
+   * `claimed_by_user_id IS NULL` so two racing accepters can't both "win"
+   * the same ghost. Under extreme concurrency max_uses may admit one extra
+   * joiner (counter is capped correctly but the member row is already in);
+   * acceptable at small-tenancy scale, would need a row-lock or serializable
+   * txn to close fully.
    */
   async acceptInvite(params: {
     token: string;
@@ -258,6 +262,11 @@ export class GroupService {
       return { joined: false, reason: "target_mismatch" };
     }
 
+    // Reject accepts into a soft-deleted group — `findById` filters on
+    // `deleted_at IS NULL`, so a null result here means the group is gone.
+    const group = await this.groupRepo.findById(invite.groupId);
+    if (!group) return { joined: false, reason: "not_found" };
+
     // Session doesn't carry phoneNumber, so fetch email + phone in a single
     // round-trip for targetPhone validation + roster auto-claim.
     const userRow = await getDatabase()
@@ -275,18 +284,23 @@ export class GroupService {
       return { joined: false, reason: "target_mismatch" };
     }
 
-    const existing = await this.memberRepo.find(invite.groupId, params.userId);
-    if (!existing) {
-      await this.memberRepo.add({
-        groupId: invite.groupId,
-        userId: params.userId,
-        role: "member",
-      });
-      await this.inviteRepo.incrementUsesCount(invite.id);
+    const addedNewMembership = await this.memberRepo.tryAdd({
+      groupId: invite.groupId,
+      userId: params.userId,
+      role: "member",
+    });
+    if (addedNewMembership) {
+      const consumed = await this.inviteRepo.tryConsumeUse(invite.id);
+      if (!consumed && invite.maxUses !== undefined) {
+        // Another accept raced us past max_uses after our optimistic check.
+        // Member is already in; counter stays capped. Log-worthy but not
+        // fatal at current scale.
+      }
     }
 
     // Auto-claim roster ghost if exactly one unclaimed entry matches by
-    // phone or email. Parallel lookups; dedupe via Set of ids.
+    // phone or email. Parallel lookups; dedupe via Set of ids. The final
+    // write uses `tryClaim` so two racing accepts can't both steal the row.
     const [byPhone, byEmail] = await Promise.all([
       userPhone
         ? this.rosterRepo.findByGroupAndPhone(invite.groupId, userPhone)
@@ -304,8 +318,8 @@ export class GroupService {
     if (matchIds.size === 1) {
       const [only] = matchIds;
       if (only) {
-        await this.rosterRepo.update(only, { claimedByUserId: params.userId });
-        claimedRosterId = only;
+        const claimed = await this.rosterRepo.tryClaim(only, params.userId);
+        if (claimed) claimedRosterId = only;
       }
     } else if (matchIds.size > 1) {
       ambiguousRosterMatches = matchIds.size;


### PR DESCRIPTION
## Summary
- Organizer-only invite CRUD under `/api/groups/:id/invites` (list, create, revoke). Tokens are `nanoid(24)`.
- Public `GET /api/invites/:token` preview + authed `POST /:token/accept`. Accept is idempotent (re-accepting doesn't burn a `maxUses` slot) and auto-claims a roster ghost only when exactly one unclaimed entry matches by phone/email.
- Mobile-web: new `/join/[token]` landing page at the root stack (the `(auth)` layout redirects signed-in users away, which would short-circuit accepts for already-signed-in invitees). Group detail screen gains an organizer invites section (create / copy / revoke).
- API client: `useGroupInvites`, `useCreateInvite`, `useRevokeInvite`, `useInvitePreview`, `useAcceptInvite`. Accept flips the active group id and wipes the cache (same pattern as `switchGroup`).
- EN/ES i18n under `groups.invite.*` including per-reason invalid copy.

### Architecture notes
- `GroupInviteInvalidReason` in `@repo/shared/domain` is the single source of truth for invalid-invite reasons across service, api-client types, and locale keys.
- `acceptInvite` takes `{token, userId}` only — it pulls `email` + `phoneNumber` itself in one round-trip, so routes don't touch the `user` table.
- `getInvitePreview` parallelizes group + inviter lookups; `acceptInvite` parallelizes phone + email roster lookups.
- Deep-link: `app.config.ts` already exposes `scheme: "football-with-friends"`, so Expo Router handles `football-with-friends://join/<token>` automatically.
