### PR TITLE
Phase 2 completion: delete action, header switcher, noGroup onboarding

### DIFF
--- a/apps/mobile-web/app/(tabs)/_layout.tsx
+++ b/apps/mobile-web/app/(tabs)/_layout.tsx
@@ -1,5 +1,7 @@
 // @ts-nocheck - Tamagui type recursion workaround
 import { useCurrentGroup, useSession } from "@repo/api-client";
+import { GroupSwitcher } from "../../components/group-switcher";
+import { NoGroupOnboarding } from "../../components/no-group-onboarding";
 import { usePushNotifications } from "../../lib/use-push-notifications";
 import {
   Home,
@@ -16,7 +18,7 @@ export default function TabsLayout() {
   const { t } = useTranslation();
   const theme = useTheme();
   const { data: session, isPending } = useSession();
-  const { myRole } = useCurrentGroup();
+  const { myRole, noGroup } = useCurrentGroup();
 
   // Must be called before any early returns (Rules of Hooks)
   usePushNotifications();
@@ -40,13 +42,19 @@ export default function TabsLayout() {
     return <Redirect href="/(auth)" />;
   }
 
+  // Short-circuit to onboarding so matches/admin don't mount scoped queries
+  // that would 409 on every render. `noGroup` is false while loading.
+  if (noGroup) return <NoGroupOnboarding />;
+
   // Admin tab is gated by group-relative role now. Superadmin retains the
   // global override so Ignacio can see admin panels on any group.
   const isSuperadmin = session?.user?.role === "superadmin";
   const isAdmin = isSuperadmin || myRole === "organizer";
 
   return (
-    <Tabs
+    <YStack flex={1}>
+      <GroupSwitcher />
+      <Tabs
       sceneContainerStyle={{
         backgroundColor: theme.background?.val,
       }}
@@ -127,6 +135,7 @@ export default function TabsLayout() {
           href: isAdmin ? undefined : null, // Hide tab if not admin
         }}
       />
-    </Tabs>
+      </Tabs>
+    </YStack>
   );
 }

--- a/apps/mobile-web/app/(tabs)/profile/groups/[groupId].tsx
+++ b/apps/mobile-web/app/(tabs)/profile/groups/[groupId].tsx
@@ -4,13 +4,16 @@ import {
   getWebAppUrl,
   useCreateInvite,
   useCurrentGroup,
+  useDeleteGroup,
   useGroupDetail,
   useGroupInvites,
   useLeaveGroup,
   useRevokeInvite,
   useSession,
 } from "@repo/api-client";
+import { AlertDialog } from "@repo/ui";
 import { router, useLocalSearchParams } from "expo-router";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Platform, ScrollView, Share } from "react-native";
 import { Button, Spinner, Text, XStack, YStack } from "tamagui";
@@ -35,6 +38,8 @@ export default function GroupDetailScreen() {
   const invitesQuery = useGroupInvites(isOrganizerView ? groupId ?? null : null);
   const createInviteMutation = useCreateInvite(groupId ?? "");
   const revokeInviteMutation = useRevokeInvite(groupId ?? "");
+  const deleteMutation = useDeleteGroup();
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   if (isLoading) {
     return (
@@ -58,6 +63,12 @@ export default function GroupDetailScreen() {
   async function onLeave() {
     if (!groupId) return;
     await leaveMutation.mutateAsync(groupId);
+    router.replace("/(tabs)/profile/groups");
+  }
+
+  async function onDelete() {
+    if (!groupId) return;
+    await deleteMutation.mutateAsync(groupId);
     router.replace("/(tabs)/profile/groups");
   }
 
@@ -174,6 +185,28 @@ export default function GroupDetailScreen() {
           >
             {t("groups.detail.leave")}
           </Button>
+        ) : null}
+
+        {amIOwner ? (
+          <>
+            <Button
+              theme="red"
+              onPress={() => setConfirmDelete(true)}
+              disabled={deleteMutation.isPending}
+            >
+              {t("groups.detail.delete")}
+            </Button>
+            <AlertDialog
+              open={confirmDelete}
+              onOpenChange={setConfirmDelete}
+              title={t("groups.detail.delete")}
+              description={t("groups.detail.deleteConfirm")}
+              confirmText={t("groups.detail.delete")}
+              cancelText={t("shared.cancel")}
+              variant="destructive"
+              onConfirm={onDelete}
+            />
+          </>
         ) : null}
       </YStack>
     </ScrollView>

--- a/apps/mobile-web/app/(tabs)/profile/groups/[groupId].tsx
+++ b/apps/mobile-web/app/(tabs)/profile/groups/[groupId].tsx
@@ -15,7 +15,7 @@ import { AlertDialog } from "@repo/ui";
 import { router, useLocalSearchParams } from "expo-router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Platform, ScrollView, Share } from "react-native";
+import { Alert, Platform, ScrollView, Share } from "react-native";
 import { Button, Spinner, Text, XStack, YStack } from "tamagui";
 
 export default function GroupDetailScreen() {
@@ -66,10 +66,19 @@ export default function GroupDetailScreen() {
     router.replace("/(tabs)/profile/groups");
   }
 
-  async function onDelete() {
+  // AlertDialog's onConfirm doesn't await the callback, so the mutation is
+  // fired-and-tracked via onSuccess/onError callbacks — awaiting here would
+  // turn any rejection into an unhandled promise and swallow user feedback.
+  function onDelete() {
     if (!groupId) return;
-    await deleteMutation.mutateAsync(groupId);
-    router.replace("/(tabs)/profile/groups");
+    deleteMutation.mutate(groupId, {
+      onSuccess: () => router.replace("/(tabs)/profile/groups"),
+      onError: (err) =>
+        Alert.alert(
+          t("groups.detail.delete"),
+          err instanceof Error ? err.message : String(err),
+        ),
+    });
   }
 
   function inviteLink(token: string): string {

--- a/apps/mobile-web/components/group-switcher.tsx
+++ b/apps/mobile-web/components/group-switcher.tsx
@@ -1,0 +1,94 @@
+// @ts-nocheck - Tamagui type recursion workaround
+// Hidden at <2 groups so single-group accounts keep the legacy mono-group
+// chrome unchanged.
+
+import { useCurrentGroup } from "@repo/api-client";
+import { Check, ChevronDown } from "@tamagui/lucide-icons";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Sheet, Text, XStack, YStack } from "tamagui";
+
+export function GroupSwitcher() {
+  const { t } = useTranslation();
+  const { group, myGroups, switchGroup } = useCurrentGroup();
+  const [open, setOpen] = useState(false);
+  const insets = useSafeAreaInsets();
+
+  if (myGroups.length < 2 || !group) return null;
+
+  return (
+    <>
+      <XStack
+        accessibilityRole="button"
+        accessibilityLabel={t("groups.switcher.open", { name: group.name })}
+        testID="group-switcher-trigger"
+        onPress={() => setOpen(true)}
+        pressStyle={{ opacity: 0.7 }}
+        paddingHorizontal="$4"
+        paddingVertical="$2"
+        alignItems="center"
+        gap="$2"
+        borderBottomWidth={1}
+        borderBottomColor="$borderColor"
+        backgroundColor="$background"
+      >
+        <Text color="$gray11" fontSize="$2">
+          {t("groups.switcher.label")}
+        </Text>
+        <Text fontSize="$3" fontWeight="600" flexShrink={1} numberOfLines={1}>
+          {group.name}
+        </Text>
+        <ChevronDown size={14} color="$gray10" />
+      </XStack>
+
+      <Sheet
+        modal
+        open={open}
+        onOpenChange={setOpen}
+        snapPointsMode="fit"
+        dismissOnSnapToBottom
+        animation="medium"
+      >
+        <Sheet.Overlay />
+        <Sheet.Handle />
+        <Sheet.Frame
+          backgroundColor="$background"
+          paddingBottom={insets.bottom + 16}
+        >
+          <YStack padding="$4" gap="$1">
+            <Text fontSize="$5" fontWeight="700" marginBottom="$2">
+              {t("groups.switcher.label")}
+            </Text>
+            {myGroups.map((g) => {
+              const active = g.id === group.id;
+              return (
+                <XStack
+                  key={g.id}
+                  accessibilityRole="button"
+                  testID={`group-switcher-item-${g.id}`}
+                  onPress={() => {
+                    if (!active) switchGroup(g.id);
+                    setOpen(false);
+                  }}
+                  pressStyle={{ opacity: 0.7 }}
+                  paddingVertical="$3"
+                  paddingHorizontal="$3"
+                  alignItems="center"
+                  gap="$2"
+                  borderRadius="$3"
+                  backgroundColor={active ? "$blue3" : "transparent"}
+                >
+                  <Text flex={1} fontSize="$4" fontWeight={active ? "600" : "400"}>
+                    {g.name}
+                  </Text>
+                  {active ? <Check size={18} color="$blue10" /> : null}
+                </XStack>
+              );
+            })}
+          </YStack>
+        </Sheet.Frame>
+      </Sheet>
+    </>
+  );
+}

--- a/apps/mobile-web/components/no-group-onboarding.tsx
+++ b/apps/mobile-web/components/no-group-onboarding.tsx
@@ -1,0 +1,34 @@
+// @ts-nocheck - Tamagui type recursion workaround
+// Shown in place of the tabs when the caller belongs to no groups (the API
+// returns 409 NO_GROUP, useCurrentGroup().noGroup becomes true). The CTA is
+// intentionally passive: invites arrive as links, and the user taps them to
+// join. No "paste invite" input yet — the deep-link handler already covers
+// both paths.
+
+import { useTranslation } from "react-i18next";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Text, YStack } from "tamagui";
+
+export function NoGroupOnboarding() {
+  const { t } = useTranslation();
+  const insets = useSafeAreaInsets();
+  return (
+    <YStack
+      flex={1}
+      justifyContent="center"
+      alignItems="center"
+      padding="$6"
+      gap="$3"
+      paddingTop={insets.top + 24}
+      paddingBottom={insets.bottom + 24}
+      backgroundColor="$background"
+    >
+      <Text fontSize="$7" fontWeight="700" textAlign="center">
+        {t("groups.noGroup.title")}
+      </Text>
+      <Text fontSize="$4" color="$gray11" textAlign="center">
+        {t("groups.noGroup.body")}
+      </Text>
+    </YStack>
+  );
+}

--- a/docs/superpowers/plans/2026-04-22-group-oriented-scoping.md
+++ b/docs/superpowers/plans/2026-04-22-group-oriented-scoping.md
@@ -12,7 +12,7 @@
 
 - [x] **Phase 0** — Schema foundation (no behavior change)
 - [x] **Phase 1** — Backfill + scoping (core path scoped; staging verification + tests deferred)
-- [x] **Phase 2** — Group management API + mobile-web switcher *(entry-point screens + tab-gate swap landed; full header switcher component + noGroup onboarding + useDeleteGroup hook deferred)*
+- [x] **Phase 2** — Group management API + mobile-web switcher *(all user-facing items landed; test harness is the only deferred piece, same as Phase 1/3)*
 - [x] **Phase 3** — Invites (link + accept flow) *(core path landed; tests + E2E + staging verification deferred)*
 - [ ] **Phase 4** — Ghost roster (full lifecycle + legacy guest conversion)
 - [ ] **Phase 5** — Polish (phone invites, copy-venues helper, public-directory flag, i18n pass)
@@ -272,24 +272,23 @@ group_id TEXT UNIQUE REFERENCES groups(id) ON DELETE CASCADE
 - [x] `useCurrentGroup()` — exposes `{groupId, group, myRole, amIOwner, myGroups, isLoading, noGroup, switchGroup}`. `switchGroup` persists via `group-storage.ts` and calls `queryClient.invalidateQueries()` (no filter — active group change invalidates everything transitively).
 - [x] `useGroupDetail(groupId)` — plan's `useGroup`, renamed for consistency with other `*Detail` hooks in the codebase.
 - [x] `useGroupMembers(groupId)`.
-- [x] `useCreateGroup()`, `useUpdateGroup()`, `useUpdateMemberRole()` (plan's `usePromoteMember`; one hook handles both directions via body.role), `useKickMember()`, `useLeaveGroup()`, `useTransferOwnership()`.
-- [ ] `useDeleteGroup()` — **deferred**. API endpoint exists; no UI consumer yet so no client hook shipped.
+- [x] `useCreateGroup()`, `useUpdateGroup()`, `useDeleteGroup()`, `useUpdateMemberRole()` (plan's `usePromoteMember`; one hook handles both directions via body.role), `useKickMember()`, `useLeaveGroup()`, `useTransferOwnership()`. `useDeleteGroup` clears the active group id on success when the caller just deleted their active one, so the next scoped request auto-picks a remaining membership.
 - [x] Query-key convention: every scoped key lives under `groupQueryKeys.*`. Switching invalidates globally (see `switchGroup`), which is a simpler correctness guarantee than threading `groupId` through every key.
 
 ### Subtasks — Mobile-Web UX
 
 - [x] `apps/mobile-web/app/(tabs)/_layout.tsx`: admin-tab visibility swapped from `user.role === "admin"` to `isSuperadmin || myRole === "organizer"`.
-- [ ] Header group switcher component (bottom sheet at ≥2 groups) — **deferred**. Not needed for single-tenant launch; entry point is the Profile → My Groups list which serves the same purpose.
+- [x] Header group switcher component (`apps/mobile-web/components/group-switcher.tsx`) — only renders when `myGroups.length >= 2`, shows current group name + chevron, tap opens a Tamagui Sheet listing all memberships. Hidden on single-group accounts so the legacy chrome is unchanged.
 - [x] New screen `apps/mobile-web/app/(tabs)/profile/groups/index.tsx` — "My Groups" list.
 - [x] New screen `apps/mobile-web/app/(tabs)/profile/groups/[groupId].tsx` — group detail (members list + leave button; invites section added in Phase 3).
 - [x] New screen `apps/mobile-web/app/(tabs)/admin/create-group.tsx` — superadmin-only.
 - [x] Match/admin screens: no direct changes needed. Global `invalidateQueries()` on `switchGroup` ensures correctness without keying every query by groupId.
-- [ ] "No group yet" screen for `useCurrentGroup().noGroup` — **deferred**. The API returns `409 NO_GROUP` and the fetch interceptor bubbles the error; formal onboarding screen lands with Phase 5 polish.
+- [x] "No group yet" screen (`apps/mobile-web/components/no-group-onboarding.tsx`) — rendered in place of `<Tabs>` when `useCurrentGroup().noGroup` resolves true, so matches/admin tabs don't mount scoped queries that 409 on every render. CTA is passive (invites arrive as links) — matches how Phase 3 models the join flow.
 
 ### Subtasks — i18n
 
 - [x] Keys added to `locales/en/common.json` and `locales/es/common.json`:
-  - [x] `groups.switcher.label`, `groups.switcher.loading`
+  - [x] `groups.switcher.label`, `groups.switcher.loading`, `groups.switcher.open`
   - [x] `groups.myGroups.title`, `groups.myGroups.empty`, `groups.myGroups.owner|organizer|member`
   - [x] `groups.create.title`, `groups.create.nameLabel`, `groups.create.namePlaceholder`, `groups.create.cta`, `groups.create.success`, `groups.create.superadminOnly`
   - [x] `groups.detail.title`, `groups.detail.members`, `groups.detail.settings`, `groups.detail.leave`, `groups.detail.transfer`, `groups.detail.delete`, `groups.detail.deleteConfirm`, `groups.detail.loadError`

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -734,7 +734,8 @@
   "groups": {
     "switcher": {
       "label": "Group",
-      "loading": "Loading groups…"
+      "loading": "Loading groups…",
+      "open": "Switch group (current: {{name}})"
     },
     "myGroups": {
       "title": "My Groups",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -737,7 +737,8 @@
   "groups": {
     "switcher": {
       "label": "Grupo",
-      "loading": "Cargando grupos…"
+      "loading": "Cargando grupos…",
+      "open": "Cambiar de grupo (actual: {{name}})"
     },
     "myGroups": {
       "title": "Mis grupos",

--- a/packages/api-client/src/groups.ts
+++ b/packages/api-client/src/groups.ts
@@ -175,6 +175,29 @@ export function useUpdateGroup(groupId: string) {
   });
 }
 
+export function useDeleteGroup() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (groupId: string) => {
+      const res = await client.api.groups[":id"].$delete({
+        param: { id: groupId },
+      });
+      return res.json();
+    },
+    onSuccess: (_, groupId) => {
+      // If the caller just deleted their own active group, drop the stored
+      // id so the next scoped request lets the server auto-pick a remaining
+      // membership (same path we take on FORBIDDEN_GROUP in the fetch
+      // interceptor). Invalidate everything: queries carry X-Group-Id via
+      // the interceptor, not in the key, so no scoped filter would match.
+      if (getActiveGroupId() === groupId) {
+        setActiveGroupId(null);
+      }
+      queryClient.invalidateQueries();
+    },
+  });
+}
+
 export function useUpdateMemberRole(groupId: string) {
   const queryClient = useQueryClient();
   return useMutation({

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -58,6 +58,7 @@ export {
   useGroupMembers,
   useCreateGroup,
   useUpdateGroup,
+  useDeleteGroup,
   useUpdateMemberRole,
   useKickMember,
   useLeaveGroup,


### PR DESCRIPTION
## Summary
- `useDeleteGroup` client hook + owner-only destructive delete in the group detail screen (confirm via `@repo/ui` `AlertDialog`). Clears the stored active group id when the caller just deleted their own active group so the next scoped request auto-picks a remaining membership.
- `GroupSwitcher` component rendered above the tabs — only when `myGroups.length >= 2`. Tap opens a Tamagui Sheet listing memberships with the active one checked. Hidden for single-group accounts so the legacy chrome is unchanged.
- `NoGroupOnboarding` component short-circuits `<Tabs>` when `useCurrentGroup().noGroup` is true, so a zero-group user doesn't mount scoped queries that 409 every render.
- `groups.switcher.open` i18n key (EN + ES).

Closes out the three Phase 2 items I explicitly left unticked in the plan doc after PR #42. The formal test harness is the only remaining deferred item (same stance as Phase 1 and Phase 3 — no test runner wired on `apps/api` yet).
