### PR TITLE
Phase 4: ghost roster lifecycle + legacy guest migration

### DIFF
--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -250,7 +250,7 @@ app.get("/:id/invites", async (c) => {
 // E.164 per BetterAuth phone-auth + profile routes; targetPhone must match
 // the exact shape we store in `user.phoneNumber` or `acceptInvite` never
 // matches and the organizer has effectively created a dead invite.
-const INVITE_TARGET_PHONE_REGEX = /^\+[1-9]\d{6,14}$/;
+export const INVITE_TARGET_PHONE_REGEX = /^\+[1-9]\d{6,14}$/;
 
 app.post(
   "/:id/invites",
@@ -314,9 +314,8 @@ app.delete("/:id/invites/:inviteId", async (c) => {
 });
 
 // Roster (ghosts) ---------------------------------------------------------
-// Ghosts are organizer-managed player profiles that may be claimed by a real
-// user via invite accept (Phase 3 auto-claim) or organizer-driven linking.
-// All routes are organizer-only.
+// Organizer-only. Ghosts are managed player profiles that may be claimed
+// by a real user via invite accept or organizer-driven linking.
 
 app.get("/:id/roster", async (c) => {
   const id = c.req.param("id");

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -313,6 +313,149 @@ app.delete("/:id/invites/:inviteId", async (c) => {
   }
 });
 
+// Roster (ghosts) ---------------------------------------------------------
+// Ghosts are organizer-managed player profiles that may be claimed by a real
+// user via invite accept (Phase 3 auto-claim) or organizer-driven linking.
+// All routes are organizer-only.
+
+app.get("/:id/roster", async (c) => {
+  const id = c.req.param("id");
+  const mismatched = assertInCurrentGroup(c, id, "Group not found");
+  if (mismatched) return mismatched;
+
+  const denied = requireOrganizer(c);
+  if (denied) return denied;
+
+  const roster = await getGroupService().listRoster(id);
+  return c.json({ roster });
+});
+
+app.post(
+  "/:id/roster",
+  zValidator(
+    "json",
+    z.object({
+      displayName: z.string().trim().min(1).max(120),
+      phone: z
+        .string()
+        .trim()
+        .regex(INVITE_TARGET_PHONE_REGEX, "phone must be E.164 (e.g. +1234567890)")
+        .optional(),
+      email: z.string().trim().email().optional(),
+    }),
+  ),
+  async (c) => {
+    const id = c.req.param("id");
+    const mismatched = assertInCurrentGroup(c, id, "Group not found");
+    if (mismatched) return mismatched;
+
+    const denied = requireOrganizer(c);
+    if (denied) return denied;
+
+    const user = requireUser(c);
+    const body = c.req.valid("json");
+
+    try {
+      const outcome = await getGroupService().createRosterEntry({
+        groupId: id,
+        displayName: body.displayName,
+        phone: body.phone,
+        email: body.email,
+        createdByUserId: user.id,
+      });
+      if (!outcome.created) {
+        return c.json(
+          { error: outcome.reason, userId: outcome.userId },
+          409,
+        );
+      }
+      return c.json({ entry: outcome.entry }, 201);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to create roster entry";
+      return c.json({ error: message }, 400);
+    }
+  },
+);
+
+app.patch(
+  "/:id/roster/:rosterId",
+  zValidator(
+    "json",
+    z
+      .object({
+        displayName: z.string().trim().min(1).max(120).optional(),
+        phone: z
+          .string()
+          .trim()
+          .regex(INVITE_TARGET_PHONE_REGEX, "phone must be E.164 (e.g. +1234567890)")
+          .nullable()
+          .optional(),
+        email: z.string().trim().email().nullable().optional(),
+        claimedByUserId: z.string().min(1).nullable().optional(),
+      })
+      .refine((v) => Object.keys(v).length > 0, {
+        message: "At least one field must be provided",
+      }),
+  ),
+  async (c) => {
+    const id = c.req.param("id");
+    const rosterId = c.req.param("rosterId");
+    const mismatched = assertInCurrentGroup(c, id, "Group not found");
+    if (mismatched) return mismatched;
+
+    const denied = requireOrganizer(c);
+    if (denied) return denied;
+
+    const patch = c.req.valid("json");
+
+    try {
+      const entry = await getGroupService().updateRosterEntry(rosterId, id, {
+        displayName: patch.displayName,
+        phone: patch.phone,
+        email: patch.email,
+        claimedByUserId: patch.claimedByUserId,
+      });
+      return c.json({ entry });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to update roster entry";
+      return c.json({ error: message }, 400);
+    }
+  },
+);
+
+app.delete(
+  "/:id/roster/:rosterId",
+  zValidator("query", z.object({ force: z.enum(["true", "false"]).optional() })),
+  async (c) => {
+  const id = c.req.param("id");
+  const rosterId = c.req.param("rosterId");
+  const mismatched = assertInCurrentGroup(c, id, "Group not found");
+  if (mismatched) return mismatched;
+
+  const denied = requireOrganizer(c);
+  if (denied) return denied;
+
+  const force = c.req.valid("query").force === "true";
+
+  try {
+    const outcome = await getGroupService().deleteRosterEntry(rosterId, id, { force });
+    if (!outcome.deleted) {
+      return c.json(
+        {
+          error: outcome.reason,
+          referencingSignupCount: outcome.referencingSignupCount,
+        },
+        409,
+      );
+    }
+    return c.json({ success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to delete roster entry";
+    return c.json({ error: message }, 404);
+  }
+  },
+);
+
 app.post(
   "/:id/transfer-ownership",
   zValidator("json", z.object({ toUserId: z.string().min(1) })),

--- a/apps/api/src/routes/matches.ts
+++ b/apps/api/src/routes/matches.ts
@@ -259,21 +259,33 @@ app.post("/:id/signup", async (c) => {
   }
 });
 
-// Add a guest to a match
+// Add a guest to a match. Accepts either `{rosterId}` (existing ghost) or
+// `{guestName, phone?, email?}` (inline create). The service backs every
+// guest signup with a roster entry — Phase 4.
 app.post(
   "/:id/guest",
   zValidator(
     "json",
-    z.object({
-      matchId: z.string(),
-      guestName: z.string().min(1, "Guest name is required"),
-      guestEmail: z.string().email().optional(),
-      status: z.enum(["PENDING", "PAID", "SUBSTITUTE"]).default("PENDING"),
-    })
+    z.union([
+      z.object({
+        rosterId: z.string().min(1),
+        status: z.enum(["PENDING", "PAID", "SUBSTITUTE"]).default("PENDING"),
+      }),
+      z.object({
+        guestName: z.string().trim().min(1, "Guest name is required"),
+        phone: z
+          .string()
+          .trim()
+          .regex(/^\+[1-9]\d{6,14}$/, "phone must be E.164 (e.g. +1234567890)")
+          .optional(),
+        email: z.string().trim().email().optional(),
+        status: z.enum(["PENDING", "PAID", "SUBSTITUTE"]).default("PENDING"),
+      }),
+    ])
   ),
   async (c) => {
     const matchId = c.req.param("id");
-    const guestData = c.req.valid("json");
+    const body = c.req.valid("json");
     const sessionUser = requireUser(c);
     const user = sessionUserToUser(sessionUser);
     const current = requireCurrentGroup(c);
@@ -282,13 +294,7 @@ app.post(
       const signup = await getMatchService().addGuestPlayer(
         current.id,
         matchId,
-        {
-          ...guestData,
-          matchId,
-          ownerUserId: user.id,
-          ownerName: user.name,
-          ownerEmail: user.email,
-        },
+        body,
         user,
       );
       return c.json({ signup }, 201);

--- a/apps/api/src/routes/matches.ts
+++ b/apps/api/src/routes/matches.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { getServiceFactory } from "@repo/shared/services";
 import { getRepositoryFactory } from "@repo/shared/repositories";
 import { type AppVariables, sessionUserToUser, requireUser } from "../middleware/security";
+import { INVITE_TARGET_PHONE_REGEX } from "./groups";
 import { groupContextMiddleware, requireCurrentGroup } from "../middleware/group-context";
 import { isCurrentOrganizer, requireOrganizer } from "../middleware/authz";
 import {
@@ -261,7 +262,7 @@ app.post("/:id/signup", async (c) => {
 
 // Add a guest to a match. Accepts either `{rosterId}` (existing ghost) or
 // `{guestName, phone?, email?}` (inline create). The service backs every
-// guest signup with a roster entry — Phase 4.
+// guest signup with a roster entry.
 app.post(
   "/:id/guest",
   zValidator(
@@ -276,7 +277,7 @@ app.post(
         phone: z
           .string()
           .trim()
-          .regex(/^\+[1-9]\d{6,14}$/, "phone must be E.164 (e.g. +1234567890)")
+          .regex(INVITE_TARGET_PHONE_REGEX, "phone must be E.164 (e.g. +1234567890)")
           .optional(),
         email: z.string().trim().email().optional(),
         status: z.enum(["PENDING", "PAID", "SUBSTITUTE"]).default("PENDING"),

--- a/apps/api/src/routes/matches.ts
+++ b/apps/api/src/routes/matches.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { getServiceFactory } from "@repo/shared/services";
+import { getServiceFactory, RosterMemberCollisionError } from "@repo/shared/services";
 import { getRepositoryFactory } from "@repo/shared/repositories";
 import { type AppVariables, sessionUserToUser, requireUser } from "../middleware/security";
 import { INVITE_TARGET_PHONE_REGEX } from "./groups";
@@ -287,6 +287,14 @@ app.post(
   async (c) => {
     const matchId = c.req.param("id");
     const body = c.req.valid("json");
+
+    // Organizer-only: the `rosterId` branch could be safely open to members,
+    // but the `guestName` branch writes to `group_roster`, which is an
+    // organizer-managed table. Gating the whole endpoint keeps roster
+    // authorship consistent with the rest of the roster CRUD.
+    const denied = requireOrganizer(c);
+    if (denied) return denied;
+
     const sessionUser = requireUser(c);
     const user = sessionUserToUser(sessionUser);
     const current = requireCurrentGroup(c);
@@ -300,6 +308,9 @@ app.post(
       );
       return c.json({ signup }, 201);
     } catch (error) {
+      if (error instanceof RosterMemberCollisionError) {
+        return c.json({ error: "already_member", userId: error.userId }, 409);
+      }
       const message = error instanceof Error ? error.message : "Failed to add guest";
       return c.json({ error: message }, 400);
     }

--- a/apps/mobile-web/app/(tabs)/admin/_layout.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/_layout.tsx
@@ -64,6 +64,21 @@ export default function AdminLayout() {
           title: t("groups.create.title"),
         }}
       />
+      <Stack.Screen
+        name="roster"
+        options={{
+          title: t("groups.roster.title"),
+          headerBackVisible: false,
+          headerLeft: () => (
+            <Pressable
+              onPress={() => router.navigate("/(tabs)/admin")}
+              style={{ marginLeft: 8 }}
+            >
+              <ChevronLeft size={28} color={theme.color?.val} />
+            </Pressable>
+          ),
+        }}
+      />
     </Stack>
   );
 }

--- a/apps/mobile-web/app/(tabs)/admin/index.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/index.tsx
@@ -190,6 +190,15 @@ export default function OrganizerScreen() {
             >
               {t("settings.title")}
             </Button>
+            <Button
+              flex={1}
+              size="$3"
+              variant="outline"
+              onPress={() => router.push("/(tabs)/admin/roster")}
+              testID="admin-tab-roster"
+            >
+              {t("groups.roster.title")}
+            </Button>
           </XStack>
         </YStack>
 

--- a/apps/mobile-web/app/(tabs)/admin/roster.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/roster.tsx
@@ -71,10 +71,11 @@ export default function AdminRosterScreen() {
   const [editPhone, setEditPhone] = useState("");
   const [editEmail, setEditEmail] = useState("");
 
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState<GroupRosterEntry | null>(null);
-  const [forcePrompt, setForcePrompt] = useState<{
+  // `referencingSignupCount` present ⇒ we already hit the 409 and the user
+  // is confirming the force-delete path; absent ⇒ first-time confirm.
+  const [deleteState, setDeleteState] = useState<{
     entry: GroupRosterEntry;
-    referencingSignupCount: number;
+    referencingSignupCount?: number;
   } | null>(null);
 
   const [linkingEntry, setLinkingEntry] = useState<GroupRosterEntry | null>(null);
@@ -141,19 +142,17 @@ export default function AdminRosterScreen() {
 
   function requestDelete(entry: GroupRosterEntry) {
     setEditing(null);
-    setShowDeleteConfirm(entry);
+    setDeleteState({ entry });
   }
 
   async function runDelete(entry: GroupRosterEntry, force: boolean) {
     try {
       await deleteMutation.mutateAsync({ rosterId: entry.id, force });
-      setShowDeleteConfirm(null);
-      setForcePrompt(null);
+      setDeleteState(null);
     } catch (err) {
       const info = apiErrorInfo(err);
       if (info.reason === "referenced" && typeof info.referencingSignupCount === "number") {
-        setShowDeleteConfirm(null);
-        setForcePrompt({
+        setDeleteState({
           entry,
           referencingSignupCount: info.referencingSignupCount,
         });
@@ -394,43 +393,36 @@ export default function AdminRosterScreen() {
         </YStack>
       </Dialog>
 
-      {/* Plain delete confirm (no signups referencing) */}
       <AlertDialog
-        open={!!showDeleteConfirm}
-        onOpenChange={(open) => !open && setShowDeleteConfirm(null)}
+        open={!!deleteState}
+        onOpenChange={(open) => !open && setDeleteState(null)}
         title={t("groups.roster.deleteTitle")}
         description={
-          showDeleteConfirm
-            ? t("groups.roster.deleteConfirm", {
-                name: showDeleteConfirm.displayName,
-              })
+          deleteState
+            ? deleteState.referencingSignupCount !== undefined
+              ? t("groups.roster.forceDeleteConfirm", {
+                  name: deleteState.entry.displayName,
+                  count: deleteState.referencingSignupCount,
+                })
+              : t("groups.roster.deleteConfirm", {
+                  name: deleteState.entry.displayName,
+                })
             : undefined
         }
-        confirmText={t("groups.roster.deleteCta")}
+        confirmText={
+          deleteState?.referencingSignupCount !== undefined
+            ? t("groups.roster.forceDeleteCta")
+            : t("groups.roster.deleteCta")
+        }
         cancelText={t("shared.cancel")}
         variant="destructive"
         onConfirm={() =>
-          showDeleteConfirm && runDelete(showDeleteConfirm, false)
+          deleteState &&
+          runDelete(
+            deleteState.entry,
+            deleteState.referencingSignupCount !== undefined,
+          )
         }
-      />
-
-      {/* Force-delete confirm (signups still reference this ghost) */}
-      <AlertDialog
-        open={!!forcePrompt}
-        onOpenChange={(open) => !open && setForcePrompt(null)}
-        title={t("groups.roster.deleteTitle")}
-        description={
-          forcePrompt
-            ? t("groups.roster.forceDeleteConfirm", {
-                name: forcePrompt.entry.displayName,
-                count: forcePrompt.referencingSignupCount,
-              })
-            : undefined
-        }
-        confirmText={t("groups.roster.forceDeleteCta")}
-        cancelText={t("shared.cancel")}
-        variant="destructive"
-        onConfirm={() => forcePrompt && runDelete(forcePrompt.entry, true)}
       />
     </Container>
   );

--- a/apps/mobile-web/app/(tabs)/admin/roster.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/roster.tsx
@@ -1,0 +1,437 @@
+// @ts-nocheck - Tamagui type recursion workaround
+import {
+  type GroupRosterEntry,
+  useCreateRosterEntry,
+  useCurrentGroup,
+  useDeleteRosterEntry,
+  useGroupMembers,
+  useGroupRoster,
+  useUpdateRosterEntry,
+} from "@repo/api-client";
+import {
+  AlertDialog,
+  Badge,
+  Button,
+  Card,
+  Container,
+  Dialog,
+  Input,
+  Spinner,
+  Text,
+  YStack,
+  XStack,
+} from "@repo/ui";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Alert, ScrollView } from "react-native";
+
+function apiErrorInfo(err: unknown): {
+  reason?: string;
+  message: string;
+  referencingSignupCount?: number;
+  userId?: string;
+} {
+  if (err && typeof err === "object" && "data" in err) {
+    const data = (err as { data?: Record<string, unknown> }).data;
+    if (data && typeof data === "object") {
+      const reason = typeof data.error === "string" ? data.error : undefined;
+      const referencingSignupCount =
+        typeof data.referencingSignupCount === "number"
+          ? data.referencingSignupCount
+          : undefined;
+      const userId = typeof data.userId === "string" ? data.userId : undefined;
+      return {
+        reason,
+        message: reason ?? "Something went wrong",
+        referencingSignupCount,
+        userId,
+      };
+    }
+  }
+  return {
+    message: err instanceof Error ? err.message : String(err),
+  };
+}
+
+export default function AdminRosterScreen() {
+  const { t } = useTranslation();
+  const { groupId } = useCurrentGroup();
+  const rosterQuery = useGroupRoster(groupId);
+  const membersQuery = useGroupMembers(groupId);
+  const createMutation = useCreateRosterEntry(groupId ?? "");
+  const updateMutation = useUpdateRosterEntry(groupId ?? "");
+  const deleteMutation = useDeleteRosterEntry(groupId ?? "");
+
+  const [newName, setNewName] = useState("");
+  const [newPhone, setNewPhone] = useState("");
+  const [newEmail, setNewEmail] = useState("");
+
+  const [editing, setEditing] = useState<GroupRosterEntry | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editPhone, setEditPhone] = useState("");
+  const [editEmail, setEditEmail] = useState("");
+
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState<GroupRosterEntry | null>(null);
+  const [forcePrompt, setForcePrompt] = useState<{
+    entry: GroupRosterEntry;
+    referencingSignupCount: number;
+  } | null>(null);
+
+  const [linkingEntry, setLinkingEntry] = useState<GroupRosterEntry | null>(null);
+  const [linkSearch, setLinkSearch] = useState("");
+
+  const roster = rosterQuery.data ?? [];
+
+  async function handleCreate() {
+    if (!newName.trim()) return;
+    try {
+      await createMutation.mutateAsync({
+        displayName: newName.trim(),
+        phone: newPhone.trim() || undefined,
+        email: newEmail.trim() || undefined,
+      });
+      setNewName("");
+      setNewPhone("");
+      setNewEmail("");
+    } catch (err) {
+      const info = apiErrorInfo(err);
+      if (info.reason === "already_member") {
+        Alert.alert(
+          t("groups.roster.title"),
+          t("groups.roster.alreadyMemberError"),
+        );
+      } else {
+        Alert.alert(t("groups.roster.title"), info.message);
+      }
+    }
+  }
+
+  function openEdit(entry: GroupRosterEntry) {
+    setEditing(entry);
+    setEditName(entry.displayName);
+    setEditPhone(entry.phone ?? "");
+    setEditEmail(entry.email ?? "");
+  }
+
+  async function handleSaveEdit() {
+    if (!editing) return;
+    const patch: {
+      displayName?: string;
+      phone?: string | null;
+      email?: string | null;
+    } = {};
+    if (editName.trim() !== editing.displayName) patch.displayName = editName.trim();
+    const phoneVal = editPhone.trim();
+    const prevPhone = editing.phone ?? "";
+    if (phoneVal !== prevPhone) patch.phone = phoneVal || null;
+    const emailVal = editEmail.trim();
+    const prevEmail = editing.email ?? "";
+    if (emailVal !== prevEmail) patch.email = emailVal || null;
+    if (Object.keys(patch).length === 0) {
+      setEditing(null);
+      return;
+    }
+    try {
+      await updateMutation.mutateAsync({ rosterId: editing.id, patch });
+      setEditing(null);
+    } catch (err) {
+      Alert.alert(t("groups.roster.title"), apiErrorInfo(err).message);
+    }
+  }
+
+  function requestDelete(entry: GroupRosterEntry) {
+    setEditing(null);
+    setShowDeleteConfirm(entry);
+  }
+
+  async function runDelete(entry: GroupRosterEntry, force: boolean) {
+    try {
+      await deleteMutation.mutateAsync({ rosterId: entry.id, force });
+      setShowDeleteConfirm(null);
+      setForcePrompt(null);
+    } catch (err) {
+      const info = apiErrorInfo(err);
+      if (info.reason === "referenced" && typeof info.referencingSignupCount === "number") {
+        setShowDeleteConfirm(null);
+        setForcePrompt({
+          entry,
+          referencingSignupCount: info.referencingSignupCount,
+        });
+      } else {
+        Alert.alert(t("groups.roster.title"), info.message);
+      }
+    }
+  }
+
+  async function handleUnlink(entry: GroupRosterEntry) {
+    try {
+      await updateMutation.mutateAsync({
+        rosterId: entry.id,
+        patch: { claimedByUserId: null },
+      });
+      setEditing(null);
+    } catch (err) {
+      Alert.alert(t("groups.roster.title"), apiErrorInfo(err).message);
+    }
+  }
+
+  async function handleLink(userId: string) {
+    if (!linkingEntry) return;
+    try {
+      await updateMutation.mutateAsync({
+        rosterId: linkingEntry.id,
+        patch: { claimedByUserId: userId },
+      });
+      setLinkingEntry(null);
+      setEditing(null);
+    } catch (err) {
+      Alert.alert(t("groups.roster.title"), apiErrorInfo(err).message);
+    }
+  }
+
+  const members = membersQuery.data ?? [];
+  const filteredMembers = useMemo(() => {
+    const q = linkSearch.trim().toLowerCase();
+    if (!q) return members;
+    return members.filter((m: any) => {
+      const name = m.user?.name ?? m.userId ?? "";
+      return String(name).toLowerCase().includes(q);
+    });
+  }, [members, linkSearch]);
+
+  return (
+    <Container variant="padded">
+      <ScrollView>
+        <YStack gap="$4" paddingBottom="$6">
+          <Card>
+            <YStack padding="$4" gap="$3">
+              <Text fontSize="$5" fontWeight="600">
+                {t("groups.roster.add")}
+              </Text>
+              <Input
+                label={t("groups.roster.displayName")}
+                value={newName}
+                onChangeText={setNewName}
+                placeholder={t("groups.roster.displayName")}
+                testID="roster-add-name"
+              />
+              <Input
+                label={t("groups.roster.phone")}
+                value={newPhone}
+                onChangeText={setNewPhone}
+                placeholder="+1234567890"
+                keyboardType="phone-pad"
+                testID="roster-add-phone"
+              />
+              <Input
+                label={t("groups.roster.email")}
+                value={newEmail}
+                onChangeText={setNewEmail}
+                placeholder="name@example.com"
+                autoCapitalize="none"
+                keyboardType="email-address"
+                testID="roster-add-email"
+              />
+              <Button
+                variant="primary"
+                onPress={handleCreate}
+                disabled={!newName.trim() || createMutation.isPending}
+                testID="roster-add-submit"
+              >
+                {createMutation.isPending ? <Spinner /> : t("groups.roster.add")}
+              </Button>
+            </YStack>
+          </Card>
+
+          {rosterQuery.isLoading ? (
+            <YStack padding="$4" alignItems="center">
+              <Spinner />
+            </YStack>
+          ) : roster.length === 0 ? (
+            <Text color="$gray11" textAlign="center" padding="$4">
+              {t("groups.roster.empty")}
+            </Text>
+          ) : (
+            roster.map((entry) => (
+              <Card
+                key={entry.id}
+                onPress={() => openEdit(entry)}
+                testID={`roster-row-${entry.id}`}
+              >
+                <XStack padding="$3" alignItems="center" gap="$3">
+                  <YStack flex={1} gap="$1">
+                    <Text fontSize="$4" fontWeight="600">
+                      {entry.displayName}
+                    </Text>
+                    {entry.claimedByUser ? (
+                      <Text fontSize="$2" color="$gray11">
+                        {t("groups.roster.linkedTo", {
+                          name: entry.claimedByUser.name,
+                        })}
+                      </Text>
+                    ) : entry.phone || entry.email ? (
+                      <Text fontSize="$2" color="$gray11" numberOfLines={1}>
+                        {entry.phone ?? entry.email}
+                      </Text>
+                    ) : null}
+                  </YStack>
+                  <Badge
+                    variant={entry.claimedByUserId ? "success" : "secondary"}
+                  >
+                    {entry.claimedByUserId
+                      ? t("groups.roster.claimed")
+                      : t("groups.roster.unclaimed")}
+                  </Badge>
+                </XStack>
+              </Card>
+            ))
+          )}
+        </YStack>
+      </ScrollView>
+
+      {/* Edit dialog */}
+      <Dialog
+        open={!!editing}
+        onOpenChange={(open) => !open && setEditing(null)}
+        title={t("groups.roster.editTitle")}
+        confirmText={updateMutation.isPending ? <Spinner /> : t("shared.save")}
+        cancelText={t("shared.cancel")}
+        onConfirm={handleSaveEdit}
+        onCancel={() => setEditing(null)}
+      >
+        {editing ? (
+          <YStack gap="$3" padding="$4">
+            <Input
+              label={t("groups.roster.displayName")}
+              value={editName}
+              onChangeText={setEditName}
+            />
+            <Input
+              label={t("groups.roster.phone")}
+              value={editPhone}
+              onChangeText={setEditPhone}
+              keyboardType="phone-pad"
+              placeholder="+1234567890"
+            />
+            <Input
+              label={t("groups.roster.email")}
+              value={editEmail}
+              onChangeText={setEditEmail}
+              autoCapitalize="none"
+              keyboardType="email-address"
+            />
+            {editing.claimedByUser ? (
+              <Button
+                variant="outline"
+                onPress={() => handleUnlink(editing)}
+                testID="roster-edit-unlink"
+              >
+                {t("groups.roster.unlinkFromMember", {
+                  name: editing.claimedByUser.name,
+                })}
+              </Button>
+            ) : (
+              <Button
+                variant="outline"
+                onPress={() => {
+                  setLinkingEntry(editing);
+                  setLinkSearch("");
+                }}
+                testID="roster-edit-link"
+              >
+                {t("groups.roster.linkToMember")}
+              </Button>
+            )}
+            <Button
+              variant="danger"
+              onPress={() => requestDelete(editing)}
+              testID="roster-edit-delete"
+            >
+              {t("groups.roster.deleteCta")}
+            </Button>
+          </YStack>
+        ) : null}
+      </Dialog>
+
+      {/* Link-to-member picker */}
+      <Dialog
+        open={!!linkingEntry}
+        onOpenChange={(open) => !open && setLinkingEntry(null)}
+        title={t("groups.roster.linkToMember")}
+        showActions={false}
+      >
+        <YStack gap="$3" padding="$4" maxHeight={480}>
+          <Input
+            placeholder={t("groups.roster.searchMembers")}
+            value={linkSearch}
+            onChangeText={setLinkSearch}
+          />
+          <ScrollView style={{ maxHeight: 320 }}>
+            <YStack gap="$2">
+              {filteredMembers.map((m: any) => {
+                const name = m.user?.name ?? m.userId;
+                return (
+                  <Button
+                    key={m.id}
+                    variant="outline"
+                    onPress={() => handleLink(m.userId)}
+                    testID={`roster-link-member-${m.userId}`}
+                  >
+                    {name}
+                  </Button>
+                );
+              })}
+              {filteredMembers.length === 0 ? (
+                <Text color="$gray11" textAlign="center">
+                  {t("groups.roster.noMembersFound")}
+                </Text>
+              ) : null}
+            </YStack>
+          </ScrollView>
+          <Button variant="outline" onPress={() => setLinkingEntry(null)}>
+            {t("shared.cancel")}
+          </Button>
+        </YStack>
+      </Dialog>
+
+      {/* Plain delete confirm (no signups referencing) */}
+      <AlertDialog
+        open={!!showDeleteConfirm}
+        onOpenChange={(open) => !open && setShowDeleteConfirm(null)}
+        title={t("groups.roster.deleteTitle")}
+        description={
+          showDeleteConfirm
+            ? t("groups.roster.deleteConfirm", {
+                name: showDeleteConfirm.displayName,
+              })
+            : undefined
+        }
+        confirmText={t("groups.roster.deleteCta")}
+        cancelText={t("shared.cancel")}
+        variant="destructive"
+        onConfirm={() =>
+          showDeleteConfirm && runDelete(showDeleteConfirm, false)
+        }
+      />
+
+      {/* Force-delete confirm (signups still reference this ghost) */}
+      <AlertDialog
+        open={!!forcePrompt}
+        onOpenChange={(open) => !open && setForcePrompt(null)}
+        title={t("groups.roster.deleteTitle")}
+        description={
+          forcePrompt
+            ? t("groups.roster.forceDeleteConfirm", {
+                name: forcePrompt.entry.displayName,
+                count: forcePrompt.referencingSignupCount,
+              })
+            : undefined
+        }
+        confirmText={t("groups.roster.forceDeleteCta")}
+        cancelText={t("shared.cancel")}
+        variant="destructive"
+        onConfirm={() => forcePrompt && runDelete(forcePrompt.entry, true)}
+      />
+    </Container>
+  );
+}

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -41,7 +41,7 @@ import {
   ChevronRight,
 } from "@tamagui/lucide-icons";
 import { useLocalSearchParams, router } from "expo-router";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import {
   Platform,
@@ -132,6 +132,15 @@ export default function MatchDetailScreen() {
   const [guestSearch, setGuestSearch] = useState("");
   const { groupId: currentGroupId } = useCurrentGroup();
   const rosterForGuest = useGroupRoster(showGuestDialog ? currentGroupId : null);
+  const filteredRoster = useMemo(() => {
+    const entries = rosterForGuest.data ?? [];
+    const q = guestSearch.trim().toLowerCase();
+    return q
+      ? entries.filter((e: GroupRosterEntry) =>
+          e.displayName.toLowerCase().includes(q),
+        )
+      : entries;
+  }, [rosterForGuest.data, guestSearch]);
   const [showCancelAlert, setShowCancelAlert] = useState(false);
   const [showRulesModal, setShowRulesModal] = useState(false);
   const [signupToCancel, setSignupToCancel] = useState<{
@@ -1001,7 +1010,7 @@ export default function MatchDetailScreen() {
         </YStack>
       </Dialog>
 
-      {/* Guest Signup Dialog — Phase 4: pick from roster OR quick-add ghost */}
+      {/* Guest Signup Dialog: pick from group roster OR quick-add a ghost */}
       <Dialog
         open={showGuestDialog}
         onOpenChange={(open) => {
@@ -1046,27 +1055,18 @@ export default function MatchDetailScreen() {
               />
               <ScrollView style={{ maxHeight: 320 }}>
                 <YStack gap="$2">
-                  {(rosterForGuest.data ?? [])
-                    .filter((e: GroupRosterEntry) =>
-                      guestSearch.trim()
-                        ? e.displayName
-                            .toLowerCase()
-                            .includes(guestSearch.trim().toLowerCase())
-                        : true,
-                    )
-                    .map((e: GroupRosterEntry) => (
-                      <Button
-                        key={e.id}
-                        variant="outline"
-                        onPress={() => addGuestMutation.mutate({ rosterId: e.id })}
-                        disabled={addGuestMutation.isPending}
-                        testID={`guest-roster-pick-${e.id}`}
-                      >
-                        {e.displayName}
-                      </Button>
-                    ))}
-                  {(rosterForGuest.data ?? []).length === 0 &&
-                  !rosterForGuest.isLoading ? (
+                  {filteredRoster.map((e: GroupRosterEntry) => (
+                    <Button
+                      key={e.id}
+                      variant="outline"
+                      onPress={() => addGuestMutation.mutate({ rosterId: e.id })}
+                      disabled={addGuestMutation.isPending}
+                      testID={`guest-roster-pick-${e.id}`}
+                    >
+                      {e.displayName}
+                    </Button>
+                  ))}
+                  {filteredRoster.length === 0 && !rosterForGuest.isLoading ? (
                     <Text color="$gray11" textAlign="center">
                       {t("groups.roster.guestPickerEmpty")}
                     </Text>

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -130,8 +130,13 @@ export default function MatchDetailScreen() {
   const [guestPhone, setGuestPhone] = useState("");
   const [guestEmail, setGuestEmail] = useState("");
   const [guestSearch, setGuestSearch] = useState("");
-  const { groupId: currentGroupId } = useCurrentGroup();
-  const rosterForGuest = useGroupRoster(showGuestDialog ? currentGroupId : null);
+  const { groupId: currentGroupId, myRole } = useCurrentGroup();
+  const isOrganizer =
+    myRole === "organizer" || session?.user?.role === "superadmin";
+  // Roster list is organizer-only; don't trigger a 403 for regular members.
+  const rosterForGuest = useGroupRoster(
+    showGuestDialog && isOrganizer ? currentGroupId : null,
+  );
   const filteredRoster = useMemo(() => {
     const entries = rosterForGuest.data ?? [];
     const q = guestSearch.trim().toLowerCase();
@@ -839,9 +844,8 @@ export default function MatchDetailScreen() {
                     {t("players.title")} ({match.signups?.length || 0})
                   </Text>
                   {!isPlayed &&
-                    match.availableSpots > 0 &&
-                    (match.userSignup?.status === "PAID" ||
-                      match.userSignup?.status === "PENDING") && (
+                    isOrganizer &&
+                    match.availableSpots > 0 && (
                       <Button
                         variant="outline"
                         size="$3"

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -5,6 +5,9 @@ import {
   useQueryClient,
   client,
   useSession,
+  useCurrentGroup,
+  useGroupRoster,
+  type GroupRosterEntry,
 } from "@repo/api-client";
 import {
   Container,
@@ -122,7 +125,13 @@ export default function MatchDetailScreen() {
   const [showJoinModal, setShowJoinModal] = useState(false);
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
   const [showGuestDialog, setShowGuestDialog] = useState(false);
+  const [guestMode, setGuestMode] = useState<"pick" | "quick">("pick");
   const [guestName, setGuestName] = useState("");
+  const [guestPhone, setGuestPhone] = useState("");
+  const [guestEmail, setGuestEmail] = useState("");
+  const [guestSearch, setGuestSearch] = useState("");
+  const { groupId: currentGroupId } = useCurrentGroup();
+  const rosterForGuest = useGroupRoster(showGuestDialog ? currentGroupId : null);
   const [showCancelAlert, setShowCancelAlert] = useState(false);
   const [showRulesModal, setShowRulesModal] = useState(false);
   const [signupToCancel, setSignupToCancel] = useState<{
@@ -232,14 +241,14 @@ export default function MatchDetailScreen() {
   });
 
   const addGuestMutation = useMutation({
-    mutationFn: async (name: string) => {
+    mutationFn: async (
+      input:
+        | { rosterId: string }
+        | { guestName: string; phone?: string; email?: string },
+    ) => {
       const res = await client.api.matches[":id"].guest.$post({
         param: { id: matchId! },
-        json: {
-          matchId: matchId!,
-          guestName: name,
-          status: "PENDING",
-        },
+        json: { ...input, status: "PENDING" },
       });
       if (!res.ok) {
         const data = await res.json();
@@ -253,6 +262,8 @@ export default function MatchDetailScreen() {
       queryClient.invalidateQueries({ queryKey: ["match", matchId] });
       setShowGuestDialog(false);
       setGuestName("");
+      setGuestPhone("");
+      setGuestEmail("");
       toast.show(t("matchDetail.guestAddSuccess"), { duration: 3000, customData: { variant: "success" } });
     },
     onError: (err: Error) => {
@@ -990,41 +1001,123 @@ export default function MatchDetailScreen() {
         </YStack>
       </Dialog>
 
-      {/* Guest Signup Dialog */}
+      {/* Guest Signup Dialog — Phase 4: pick from roster OR quick-add ghost */}
       <Dialog
         open={showGuestDialog}
-        onOpenChange={setShowGuestDialog}
+        onOpenChange={(open) => {
+          setShowGuestDialog(open);
+          if (!open) {
+            setGuestMode("pick");
+            setGuestName("");
+            setGuestPhone("");
+            setGuestEmail("");
+            setGuestSearch("");
+          }
+        }}
         title={t("guest.title")}
         showActions={false}
       >
-        <YStack gap="$4" padding="$4">
-          <Input
-            label={t("guest.label")}
-            placeholder={t("guest.placeholder")}
-            value={guestName}
-            onChangeText={setGuestName}
-          />
+        <YStack gap="$3" padding="$4" maxHeight={560}>
           <XStack gap="$2">
             <Button
-              variant="outline"
               flex={1}
-              onPress={() => setShowGuestDialog(false)}
+              variant={guestMode === "pick" ? "primary" : "outline"}
+              onPress={() => setGuestMode("pick")}
+              testID="guest-mode-pick"
             >
-              {t("shared.cancel")}
+              {t("groups.roster.guestPickerTitle")}
             </Button>
             <Button
-              variant="primary"
               flex={1}
-              onPress={() => {
-                if (guestName.trim()) {
-                  addGuestMutation.mutate(guestName.trim());
-                }
-              }}
-              disabled={!guestName.trim() || addGuestMutation.isPending}
+              variant={guestMode === "quick" ? "primary" : "outline"}
+              onPress={() => setGuestMode("quick")}
+              testID="guest-mode-quick"
             >
-              {addGuestMutation.isPending ? t("guest.adding") : t("guest.add")}
+              {t("groups.roster.quickAddTitle")}
             </Button>
           </XStack>
+
+          {guestMode === "pick" ? (
+            <>
+              <Input
+                placeholder={t("groups.roster.guestPickerSearch")}
+                value={guestSearch}
+                onChangeText={setGuestSearch}
+              />
+              <ScrollView style={{ maxHeight: 320 }}>
+                <YStack gap="$2">
+                  {(rosterForGuest.data ?? [])
+                    .filter((e: GroupRosterEntry) =>
+                      guestSearch.trim()
+                        ? e.displayName
+                            .toLowerCase()
+                            .includes(guestSearch.trim().toLowerCase())
+                        : true,
+                    )
+                    .map((e: GroupRosterEntry) => (
+                      <Button
+                        key={e.id}
+                        variant="outline"
+                        onPress={() => addGuestMutation.mutate({ rosterId: e.id })}
+                        disabled={addGuestMutation.isPending}
+                        testID={`guest-roster-pick-${e.id}`}
+                      >
+                        {e.displayName}
+                      </Button>
+                    ))}
+                  {(rosterForGuest.data ?? []).length === 0 &&
+                  !rosterForGuest.isLoading ? (
+                    <Text color="$gray11" textAlign="center">
+                      {t("groups.roster.guestPickerEmpty")}
+                    </Text>
+                  ) : null}
+                </YStack>
+              </ScrollView>
+            </>
+          ) : (
+            <YStack gap="$3">
+              <Text fontSize="$2" color="$gray11">
+                {t("groups.roster.quickAddHint")}
+              </Text>
+              <Input
+                label={t("guest.label")}
+                placeholder={t("guest.placeholder")}
+                value={guestName}
+                onChangeText={setGuestName}
+              />
+              <Input
+                label={t("groups.roster.phone")}
+                value={guestPhone}
+                onChangeText={setGuestPhone}
+                placeholder="+1234567890"
+                keyboardType="phone-pad"
+              />
+              <Input
+                label={t("groups.roster.email")}
+                value={guestEmail}
+                onChangeText={setGuestEmail}
+                placeholder="name@example.com"
+                autoCapitalize="none"
+                keyboardType="email-address"
+              />
+              <Button
+                variant="primary"
+                onPress={() =>
+                  addGuestMutation.mutate({
+                    guestName: guestName.trim(),
+                    phone: guestPhone.trim() || undefined,
+                    email: guestEmail.trim() || undefined,
+                  })
+                }
+                disabled={!guestName.trim() || addGuestMutation.isPending}
+              >
+                {addGuestMutation.isPending ? t("guest.adding") : t("guest.add")}
+              </Button>
+            </YStack>
+          )}
+          <Button variant="outline" onPress={() => setShowGuestDialog(false)}>
+            {t("shared.cancel")}
+          </Button>
         </YStack>
       </Dialog>
 

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -795,6 +795,33 @@
       "loadErrorBody": "Check your connection and try again.",
       "acceptFailedTitle": "Couldn't join the group",
       "acceptFailedBody": "Something went wrong. Please try again."
+    },
+    "roster": {
+      "title": "Roster",
+      "add": "Add ghost",
+      "empty": "No ghosts yet — add one to bring guests to matches.",
+      "displayName": "Display name",
+      "phone": "Phone (optional)",
+      "email": "Email (optional)",
+      "claimed": "Claimed",
+      "unclaimed": "Unclaimed",
+      "linkedTo": "Linked to {{name}}",
+      "linkToMember": "Link to existing member",
+      "unlinkFromMember": "Unlink from {{name}}",
+      "searchMembers": "Search members…",
+      "noMembersFound": "No members match your search.",
+      "editTitle": "Edit ghost",
+      "deleteTitle": "Delete ghost",
+      "deleteCta": "Delete",
+      "deleteConfirm": "Permanently delete \"{{name}}\" from this group's roster?",
+      "forceDeleteCta": "Delete anyway",
+      "forceDeleteConfirm": "\"{{name}}\" is still linked to {{count}} signup(s). Deleting will keep the signup history but unlink it from this ghost. Continue?",
+      "alreadyMemberError": "A member with that phone or email is already in this group — invite them directly instead of adding a ghost.",
+      "guestPickerTitle": "Pick a guest",
+      "guestPickerSearch": "Search roster…",
+      "guestPickerEmpty": "No roster entries yet.",
+      "quickAddTitle": "Quick add + sign up",
+      "quickAddHint": "Name-only. Phone/email optional. A ghost will be created in this group and signed up for the match."
     }
   }
 }

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -798,6 +798,33 @@
       "loadErrorBody": "Revisá tu conexión e intentá de nuevo.",
       "acceptFailedTitle": "No pudimos unirte al grupo",
       "acceptFailedBody": "Algo salió mal. Intentá de nuevo."
+    },
+    "roster": {
+      "title": "Plantel",
+      "add": "Agregar invitado",
+      "empty": "Todavía no hay invitados — agregá uno para sumarlo a los partidos.",
+      "displayName": "Nombre para mostrar",
+      "phone": "Teléfono (opcional)",
+      "email": "Email (opcional)",
+      "claimed": "Vinculado",
+      "unclaimed": "Sin vincular",
+      "linkedTo": "Vinculado a {{name}}",
+      "linkToMember": "Vincular a un miembro existente",
+      "unlinkFromMember": "Desvincular de {{name}}",
+      "searchMembers": "Buscar miembros…",
+      "noMembersFound": "Ningún miembro coincide con la búsqueda.",
+      "editTitle": "Editar invitado",
+      "deleteTitle": "Eliminar invitado",
+      "deleteCta": "Eliminar",
+      "deleteConfirm": "¿Eliminar definitivamente \"{{name}}\" del plantel de este grupo?",
+      "forceDeleteCta": "Eliminar igual",
+      "forceDeleteConfirm": "\"{{name}}\" todavía está vinculado a {{count}} inscripción(es). Al eliminar se conserva el historial pero se desvincula el nombre del invitado. ¿Continuar?",
+      "alreadyMemberError": "Ya hay un miembro con ese teléfono o email en este grupo — invitalo directamente en lugar de agregarlo como invitado.",
+      "guestPickerTitle": "Elegir invitado",
+      "guestPickerSearch": "Buscar en el plantel…",
+      "guestPickerEmpty": "Todavía no hay invitados cargados.",
+      "quickAddTitle": "Agregado rápido + inscripción",
+      "quickAddHint": "Solo el nombre. Teléfono/email opcionales. Se creará un invitado en este grupo y se lo anotará al partido."
     }
   }
 }

--- a/migrations/20260423120000-convert-legacy-guests-to-ghosts.ts
+++ b/migrations/20260423120000-convert-legacy-guests-to-ghosts.ts
@@ -1,0 +1,157 @@
+// Migration: convert-legacy-guests-to-ghosts
+// Phase 4 data migration. For every legacy no-user signup in grp_legacy —
+// identified by `signups.user_id IS NULL AND roster_id IS NULL` — create a
+// corresponding `group_roster` entry (deduplicated per
+// `(owner_id, player_name)` tuple, where owner_id =
+// COALESCE(guest_owner_id, added_by_user_id)) and point `signups.roster_id`
+// at it. Covers both `guest` signups and `admin_added` signups that don't
+// link to a real user. `guest_owner_id` is retained as an audit column.
+//
+// Idempotency: existence checks on both the ghost insert and the signup
+// update let this migration be re-run safely. The down migration undoes
+// the signup link and deletes the ghosts we produced; we identify them via
+// `phone IS NULL AND email IS NULL AND group_id = 'grp_legacy'` plus
+// matching `(display_name, created_by_user_id)` — guests migrated from
+// legacy data never carry contact info.
+//
+// See docs/superpowers/plans/2026-04-22-group-oriented-scoping.md Phase 4.
+
+import { sql } from "kysely";
+import type { Kysely, Migration } from "kysely";
+import { randomBytes } from "node:crypto";
+
+const LEGACY_GROUP_ID = "grp_legacy";
+
+function newRosterId(): string {
+  return `rst_${randomBytes(8).toString("hex")}`;
+}
+
+export const up: Migration["up"] = async (db: Kysely<any>) => {
+  const legacyGuests = await db
+    .selectFrom("signups")
+    .select((eb) => [
+      eb.fn
+        .coalesce("guest_owner_id", "added_by_user_id")
+        .as("owner_id"),
+      "player_name",
+    ])
+    .where("user_id", "is", null)
+    .where("roster_id", "is", null)
+    .where("group_id", "=", LEGACY_GROUP_ID)
+    .distinct()
+    .execute();
+
+  if (legacyGuests.length === 0) {
+    console.log("✅ convert-legacy-guests-to-ghosts: nothing to migrate");
+    return;
+  }
+
+  let createdGhosts = 0;
+  let linkedSignups = 0;
+
+  for (const row of legacyGuests) {
+    const ownerId = row.owner_id as string | null;
+    const playerName = row.player_name as string | null;
+    if (!ownerId || !playerName) continue;
+
+    const existingGhost = await db
+      .selectFrom("group_roster")
+      .select("id")
+      .where("group_id", "=", LEGACY_GROUP_ID)
+      .where("display_name", "=", playerName)
+      .where("created_by_user_id", "=", ownerId)
+      .where("phone", "is", null)
+      .where("email", "is", null)
+      .executeTakeFirst();
+
+    const rosterId = existingGhost?.id ?? newRosterId();
+    if (!existingGhost) {
+      await db
+        .insertInto("group_roster")
+        .values({
+          id: rosterId,
+          group_id: LEGACY_GROUP_ID,
+          display_name: playerName,
+          phone: null,
+          email: null,
+          created_by_user_id: ownerId,
+        })
+        .execute();
+      createdGhosts++;
+    }
+
+    const result = await db
+      .updateTable("signups")
+      .set({ roster_id: rosterId })
+      .where("user_id", "is", null)
+      .where("roster_id", "is", null)
+      .where("group_id", "=", LEGACY_GROUP_ID)
+      .where((eb) =>
+        eb.or([
+          eb("guest_owner_id", "=", ownerId),
+          eb.and([
+            eb("guest_owner_id", "is", null),
+            eb("added_by_user_id", "=", ownerId),
+          ]),
+        ]),
+      )
+      .where("player_name", "=", playerName)
+      .executeTakeFirst();
+    linkedSignups += Number(result.numUpdatedRows ?? 0);
+  }
+
+  console.log(
+    `✅ convert-legacy-guests-to-ghosts: created ${createdGhosts} ghosts, linked ${linkedSignups} signups`,
+  );
+};
+
+export const down: Migration["down"] = async (db: Kysely<any>) => {
+  // Unlink signups first so we don't leave dangling roster_id FKs.
+  const unlinked = await db
+    .updateTable("signups")
+    .set({ roster_id: null })
+    .where("group_id", "=", LEGACY_GROUP_ID)
+    .where("user_id", "is", null)
+    .where("roster_id", "is not", null)
+    .where((eb) =>
+      eb(
+        "roster_id",
+        "in",
+        eb
+          .selectFrom("group_roster")
+          .select("id")
+          .where("group_id", "=", LEGACY_GROUP_ID)
+          .where("phone", "is", null)
+          .where("email", "is", null),
+      ),
+    )
+    .executeTakeFirst();
+
+  // Then delete the migration-created ghosts. Contact-less ghosts in the
+  // legacy group with a matching (display_name, created_by_user_id) tuple
+  // against a still-present signup are our targets. After unlinking above
+  // the signup has roster_id NULL, so we use guest_owner_id/player_name
+  // for the predicate.
+  const deleted = await sql<{ count: number }>`
+    DELETE FROM group_roster
+    WHERE group_id = ${LEGACY_GROUP_ID}
+      AND phone IS NULL
+      AND email IS NULL
+      AND EXISTS (
+        SELECT 1 FROM signups s
+        WHERE s.group_id = ${LEGACY_GROUP_ID}
+          AND s.user_id IS NULL
+          AND s.player_name = group_roster.display_name
+          AND (
+            s.guest_owner_id = group_roster.created_by_user_id
+            OR (s.guest_owner_id IS NULL AND s.added_by_user_id = group_roster.created_by_user_id)
+          )
+      )
+  `.execute(db);
+
+  console.log(
+    `✅ convert-legacy-guests-to-ghosts (down): unlinked ${Number(
+      unlinked.numUpdatedRows ?? 0,
+    )} signups, deleted ${deleted.numAffectedRows ?? "?"} ghosts`,
+  );
+};

--- a/migrations/20260423120000-convert-legacy-guests-to-ghosts.ts
+++ b/migrations/20260423120000-convert-legacy-guests-to-ghosts.ts
@@ -1,11 +1,11 @@
 // Migration: convert-legacy-guests-to-ghosts
-// Phase 4 data migration. For every legacy no-user signup in grp_legacy —
-// identified by `signups.user_id IS NULL AND roster_id IS NULL` — create a
-// corresponding `group_roster` entry (deduplicated per
-// `(owner_id, player_name)` tuple, where owner_id =
-// COALESCE(guest_owner_id, added_by_user_id)) and point `signups.roster_id`
-// at it. Covers both `guest` signups and `admin_added` signups that don't
-// link to a real user. `guest_owner_id` is retained as an audit column.
+// For every legacy no-user signup in grp_legacy — identified by
+// `signups.user_id IS NULL AND roster_id IS NULL` — create a corresponding
+// `group_roster` entry (deduplicated per `(owner_id, player_name)` tuple,
+// where owner_id = COALESCE(guest_owner_id, added_by_user_id)) and point
+// `signups.roster_id` at it. Covers both `guest` signups and `admin_added`
+// signups that don't link to a real user. `guest_owner_id` is retained as
+// an audit column.
 //
 // Idempotency: existence checks on both the ghost insert and the signup
 // update let this migration be re-run safely. The down migration undoes
@@ -13,8 +13,6 @@
 // `phone IS NULL AND email IS NULL AND group_id = 'grp_legacy'` plus
 // matching `(display_name, created_by_user_id)` — guests migrated from
 // legacy data never carry contact info.
-//
-// See docs/superpowers/plans/2026-04-22-group-oriented-scoping.md Phase 4.
 
 import { sql } from "kysely";
 import type { Kysely, Migration } from "kysely";

--- a/packages/api-client/src/groups.ts
+++ b/packages/api-client/src/groups.ts
@@ -38,6 +38,7 @@ export const groupQueryKeys = {
   invites: (id: string) => [...groupQueryKeys.all, "invites", id] as const,
   invitePreview: (token: string) =>
     [...groupQueryKeys.all, "invite-preview", token] as const,
+  roster: (id: string) => [...groupQueryKeys.all, "roster", id] as const,
 };
 
 export interface MyGroupSummary {
@@ -355,6 +356,105 @@ export function useAcceptInvite() {
       // previously cached scoped data so the new group's responses drive UI.
       setActiveGroupId(result.groupId);
       queryClient.invalidateQueries();
+    },
+  });
+}
+
+// --- Roster (ghosts) -----------------------------------------------------
+
+export interface GroupRosterEntry {
+  id: string;
+  groupId: string;
+  displayName: string;
+  phone?: string;
+  email?: string;
+  claimedByUserId?: string;
+  createdByUserId: string;
+  createdAt: string;
+  updatedAt: string;
+  claimedByUser?: { id: string; name: string };
+}
+
+export interface CreateRosterInput {
+  displayName: string;
+  phone?: string;
+  email?: string;
+}
+
+export interface UpdateRosterInput {
+  displayName?: string;
+  phone?: string | null;
+  email?: string | null;
+  claimedByUserId?: string | null;
+}
+
+export function useGroupRoster(groupId: string | null) {
+  return useQuery({
+    queryKey: groupQueryKeys.roster(groupId ?? ""),
+    enabled: !!groupId,
+    queryFn: async () => {
+      const res = await client.api.groups[":id"].roster.$get({
+        param: { id: groupId! },
+      });
+      const data = (await res.json()) as { roster: GroupRosterEntry[] };
+      return data.roster;
+    },
+  });
+}
+
+export function useCreateRosterEntry(groupId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: CreateRosterInput) => {
+      const res = await client.api.groups[":id"].roster.$post({
+        param: { id: groupId },
+        json: input,
+      });
+      const data = (await res.json()) as { entry: GroupRosterEntry };
+      return data.entry;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: groupQueryKeys.roster(groupId) });
+    },
+  });
+}
+
+export function useUpdateRosterEntry(groupId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { rosterId: string; patch: UpdateRosterInput }) => {
+      const res = await client.api.groups[":id"].roster[":rosterId"].$patch({
+        param: { id: groupId, rosterId: input.rosterId },
+        json: input.patch,
+      });
+      const data = (await res.json()) as { entry: GroupRosterEntry };
+      return data.entry;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: groupQueryKeys.roster(groupId) });
+    },
+  });
+}
+
+export function useDeleteRosterEntry(groupId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { rosterId: string; force?: boolean }) => {
+      // Hono RPC doesn't model query params on $delete in this codebase's
+      // client typing; fall through to a raw fetch via the hc-built URL.
+      const res = await client.api.groups[":id"].roster[":rosterId"].$delete({
+        param: { id: groupId, rosterId: input.rosterId },
+        query: input.force ? { force: "true" } : {},
+      });
+      return res.json();
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: groupQueryKeys.roster(groupId) });
+      if (variables.force) {
+        // Match detail queries may have had signups unlinked from this ghost;
+        // blow the cache so re-fetches pick up the NULL roster_id.
+        queryClient.invalidateQueries();
+      }
     },
   });
 }

--- a/packages/api-client/src/groups.ts
+++ b/packages/api-client/src/groups.ts
@@ -8,6 +8,7 @@ import type {
   GroupInviteInvalidReason,
   GroupVisibility,
   MemberRole,
+  UpdateGroupRosterData,
 } from "@repo/shared/domain";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
@@ -381,12 +382,7 @@ export interface CreateRosterInput {
   email?: string;
 }
 
-export interface UpdateRosterInput {
-  displayName?: string;
-  phone?: string | null;
-  email?: string | null;
-  claimedByUserId?: string | null;
-}
+export type UpdateRosterInput = UpdateGroupRosterData;
 
 export function useGroupRoster(groupId: string | null) {
   return useQuery({
@@ -440,8 +436,6 @@ export function useDeleteRosterEntry(groupId: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (input: { rosterId: string; force?: boolean }) => {
-      // Hono RPC doesn't model query params on $delete in this codebase's
-      // client typing; fall through to a raw fetch via the hc-built URL.
       const res = await client.api.groups[":id"].roster[":rosterId"].$delete({
         param: { id: groupId, rosterId: input.rosterId },
         query: input.force ? { force: "true" } : {},
@@ -449,11 +443,13 @@ export function useDeleteRosterEntry(groupId: string) {
       return res.json();
     },
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: groupQueryKeys.roster(groupId) });
+      // Force path may have nulled signup.roster_id on linked matches; blow
+      // the entire cache so match detail queries re-fetch. Non-force path
+      // only touched the roster list.
       if (variables.force) {
-        // Match detail queries may have had signups unlinked from this ghost;
-        // blow the cache so re-fetches pick up the NULL roster_id.
         queryClient.invalidateQueries();
+      } else {
+        queryClient.invalidateQueries({ queryKey: groupQueryKeys.roster(groupId) });
       }
     },
   });

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -68,8 +68,18 @@ export {
   useRevokeInvite,
   useInvitePreview,
   useAcceptInvite,
+  useGroupRoster,
+  useCreateRosterEntry,
+  useUpdateRosterEntry,
+  useDeleteRosterEntry,
 } from "./groups";
-export type { GroupInviteSummary, GroupInvitePreviewResult } from "./groups";
+export type {
+  GroupInviteSummary,
+  GroupInvitePreviewResult,
+  GroupRosterEntry,
+  CreateRosterInput,
+  UpdateRosterInput,
+} from "./groups";
 
 // Re-export the API routes type for convenience
 export type { ApiRoutes } from "../../../apps/api/src/index";

--- a/packages/shared/src/database/audit/verify-legacy-backfill.sql
+++ b/packages/shared/src/database/audit/verify-legacy-backfill.sql
@@ -55,4 +55,7 @@ SELECT 'settings_copied' AS check_name,
 -- 7. Phase 4: every legacy guest signup has a roster_id. Post the
 -- convert-legacy-guests-to-ghosts migration this must be 0.
 SELECT 'unlinked_guest_signups' AS check_name, COUNT(*) AS expected_zero
-FROM signups WHERE user_id IS NULL AND roster_id IS NULL;
+FROM signups
+WHERE group_id = 'grp_legacy'
+  AND user_id IS NULL
+  AND roster_id IS NULL;

--- a/packages/shared/src/database/audit/verify-legacy-backfill.sql
+++ b/packages/shared/src/database/audit/verify-legacy-backfill.sql
@@ -51,3 +51,8 @@ WHERE g.id = 'grp_legacy';
 SELECT 'settings_copied' AS check_name,
        (SELECT COUNT(*) FROM settings) AS global_count,
        (SELECT COUNT(*) FROM group_settings WHERE group_id = 'grp_legacy') AS group_count;
+
+-- 7. Phase 4: every legacy guest signup has a roster_id. Post the
+-- convert-legacy-guests-to-ghosts migration this must be 0.
+SELECT 'unlinked_guest_signups' AS check_name, COUNT(*) AS expected_zero
+FROM signups WHERE user_id IS NULL AND roster_id IS NULL;

--- a/packages/shared/src/domain/types.ts
+++ b/packages/shared/src/domain/types.ts
@@ -294,7 +294,11 @@ export interface UpdateSignupData
 export interface CreateGuestSignupData {
   groupId: string;
   matchId: string;
-  guestName?: string;
+  // Required post-Phase-4: every guest signup is backed by a roster entry.
+  // The `rosterId` is the source of truth for identity; `guestName` is the
+  // display snapshot captured at signup time.
+  rosterId: string;
+  guestName: string;
   ownerUserId: string;
   ownerName: string;
   ownerEmail: string;
@@ -767,8 +771,10 @@ export interface CreateGroupRosterData {
 
 export interface UpdateGroupRosterData {
   displayName?: string;
-  phone?: string;
-  email?: string;
+  // Nullable so organizers can clear contact info — the repo distinguishes
+  // `undefined` ("don't touch") from `null` ("set to NULL").
+  phone?: string | null;
+  email?: string | null;
   claimedByUserId?: string | null;
 }
 

--- a/packages/shared/src/domain/types.ts
+++ b/packages/shared/src/domain/types.ts
@@ -294,9 +294,8 @@ export interface UpdateSignupData
 export interface CreateGuestSignupData {
   groupId: string;
   matchId: string;
-  // Required post-Phase-4: every guest signup is backed by a roster entry.
-  // The `rosterId` is the source of truth for identity; `guestName` is the
-  // display snapshot captured at signup time.
+  // Every guest signup is backed by a roster entry: `rosterId` is the
+  // identity source; `guestName` is the display snapshot at signup time.
   rosterId: string;
   guestName: string;
   ownerUserId: string;

--- a/packages/shared/src/repositories/group-repositories.ts
+++ b/packages/shared/src/repositories/group-repositories.ts
@@ -264,6 +264,34 @@ export class TursoGroupMembershipRepository {
     return row ? rowToMember(row) : null;
   }
 
+  /**
+   * Returns the user_id of an existing group member whose phone or email
+   * matches the given contact, or null. Used by roster create/quick-add
+   * paths to refuse creating a ghost that collides with a real member —
+   * organizers should invite that user, not ghost-ify them.
+   */
+  async findMemberByContact(
+    groupId: string,
+    contact: { phone?: string; email?: string },
+  ): Promise<string | null> {
+    if (!contact.phone && !contact.email) return null;
+    const row = await this.db
+      .selectFrom("user")
+      .innerJoin("group_members", "group_members.user_id", "user.id")
+      .select("user.id as id")
+      .where("group_members.group_id", "=", groupId)
+      .where((eb) => {
+        const clauses = [];
+        if (contact.phone)
+          clauses.push(eb("user.phoneNumber", "=", contact.phone));
+        if (contact.email) clauses.push(eb("user.email", "=", contact.email));
+        return eb.or(clauses);
+      })
+      .limit(1)
+      .executeTakeFirst();
+    return row?.id ?? null;
+  }
+
   async listByGroup(groupId: string): Promise<GroupMember[]> {
     const rows = await this.db
       .selectFrom("group_members")

--- a/packages/shared/src/repositories/group-repositories.ts
+++ b/packages/shared/src/repositories/group-repositories.ts
@@ -455,6 +455,15 @@ export class TursoGroupRosterRepository {
     return rowToRoster(row);
   }
 
+  async findById(id: string): Promise<GroupRoster | null> {
+    const row = await this.db
+      .selectFrom("group_roster")
+      .selectAll()
+      .where("id", "=", id)
+      .executeTakeFirst();
+    return row ? rowToRoster(row) : null;
+  }
+
   async listByGroup(groupId: string): Promise<GroupRoster[]> {
     const rows = await this.db
       .selectFrom("group_roster")

--- a/packages/shared/src/repositories/turso-repositories.ts
+++ b/packages/shared/src/repositories/turso-repositories.ts
@@ -937,13 +937,6 @@ export class TursoSignupRepository implements SignupRepository {
   async addGuest(guestData: CreateGuestSignupData): Promise<Signup> {
     const id = generateId();
     const now = new Date().toISOString();
-
-    // Compose guest display name
-    const name = guestData.guestName
-      ? `${guestData.guestName} (Guest of ${guestData.ownerName})`
-      : `Guest of ${guestData.ownerName}`;
-
-    // Generate unique guest email
     const playerEmail = `guest-${generateId()}@local`;
 
     const newSignup = {
@@ -951,12 +944,13 @@ export class TursoSignupRepository implements SignupRepository {
       group_id: guestData.groupId,
       match_id: guestData.matchId,
       user_id: null,
-      player_name: name,
+      player_name: guestData.guestName,
       player_email: playerEmail,
       status: guestData.status || "PENDING",
       signup_type: "guest" as const,
       guest_owner_id: guestData.ownerUserId,
       added_by_user_id: guestData.ownerUserId,
+      roster_id: guestData.rosterId,
       signed_up_at: now,
       updated_at: now,
     };

--- a/packages/shared/src/services/factory.ts
+++ b/packages/shared/src/services/factory.ts
@@ -32,6 +32,7 @@ export class ServiceFactory {
       repos.locations,
       repos.courts,
       repos.groupRoster,
+      repos.groupMembers,
     );
     this.courtService = new CourtService(repos.courts);
     this.playerStatsService = new PlayerStatsService(

--- a/packages/shared/src/services/factory.ts
+++ b/packages/shared/src/services/factory.ts
@@ -31,6 +31,7 @@ export class ServiceFactory {
       repos.signups,
       repos.locations,
       repos.courts,
+      repos.groupRoster,
     );
     this.courtService = new CourtService(repos.courts);
     this.playerStatsService = new PlayerStatsService(

--- a/packages/shared/src/services/group-service.ts
+++ b/packages/shared/src/services/group-service.ts
@@ -57,13 +57,20 @@ export interface RosterCreateParams {
   createdByUserId: string;
 }
 
+export type RosterCreateErrorReason = "already_member";
+export type RosterDeleteErrorReason = "referenced";
+
 export type CreateRosterOutcome =
   | { created: true; entry: GroupRoster }
-  | { created: false; reason: "already_member"; userId: string };
+  | { created: false; reason: RosterCreateErrorReason; userId: string };
 
 export type DeleteRosterOutcome =
   | { deleted: true }
-  | { deleted: false; reason: "referenced"; referencingSignupCount: number };
+  | {
+      deleted: false;
+      reason: RosterDeleteErrorReason;
+      referencingSignupCount: number;
+    };
 
 export type RosterListEntry = Omit<
   GroupRoster,
@@ -394,26 +401,26 @@ export class GroupService {
    */
   async createRosterEntry(params: RosterCreateParams): Promise<CreateRosterOutcome> {
     if (params.phone || params.email) {
-      const db = getDatabase();
-      let q = db.selectFrom("user").select(["id"]);
-      if (params.phone && params.email) {
-        q = q.where((eb) =>
-          eb.or([
-            eb("phoneNumber", "=", params.phone!),
-            eb("email", "=", params.email!),
-          ]),
-        );
-      } else if (params.phone) {
-        q = q.where("phoneNumber", "=", params.phone);
-      } else if (params.email) {
-        q = q.where("email", "=", params.email);
-      }
-      const candidates = await q.execute();
-      for (const u of candidates) {
-        const membership = await this.memberRepo.find(params.groupId, u.id);
-        if (membership) {
-          return { created: false, reason: "already_member", userId: u.id };
-        }
+      const existingMember = await getDatabase()
+        .selectFrom("user")
+        .innerJoin("group_members", "group_members.user_id", "user.id")
+        .select("user.id as id")
+        .where("group_members.group_id", "=", params.groupId)
+        .where((eb) => {
+          const clauses = [];
+          if (params.phone)
+            clauses.push(eb("user.phoneNumber", "=", params.phone));
+          if (params.email) clauses.push(eb("user.email", "=", params.email));
+          return eb.or(clauses);
+        })
+        .limit(1)
+        .executeTakeFirst();
+      if (existingMember) {
+        return {
+          created: false,
+          reason: "already_member",
+          userId: existingMember.id,
+        };
       }
     }
 
@@ -490,37 +497,5 @@ export class GroupService {
     }
     await this.rosterRepo.delete(rosterId);
     return { deleted: true };
-  }
-
-  /**
-   * Resolve a ghost to the signup shape used by `addGuestPlayer`. Used by
-   * the match-service when the organizer picks an existing ghost instead
-   * of typing a new name — keeps the "signup row mirrors ghost identity"
-   * invariant in one place.
-   */
-  async getRosterEntryForGroup(
-    rosterId: string,
-    groupId: string,
-  ): Promise<GroupRoster> {
-    const entry = await this.rosterRepo.findById(rosterId);
-    if (!entry || entry.groupId !== groupId) {
-      throw new Error("Roster entry not found");
-    }
-    return entry;
-  }
-
-  /**
-   * Convenience path for the "quick add guest + create ghost in one step"
-   * flow from match detail. No member-collision precheck here — the caller
-   * typed a name inline, not a contact, so we wouldn't catch anything.
-   */
-  async createQuickRosterEntry(params: {
-    groupId: string;
-    displayName: string;
-    phone?: string;
-    email?: string;
-    createdByUserId: string;
-  }): Promise<GroupRoster> {
-    return this.rosterRepo.create(params);
   }
 }

--- a/packages/shared/src/services/group-service.ts
+++ b/packages/shared/src/services/group-service.ts
@@ -400,28 +400,16 @@ export class GroupService {
    * surfaces the existing userId so the UI can link to an invite flow.
    */
   async createRosterEntry(params: RosterCreateParams): Promise<CreateRosterOutcome> {
-    if (params.phone || params.email) {
-      const existingMember = await getDatabase()
-        .selectFrom("user")
-        .innerJoin("group_members", "group_members.user_id", "user.id")
-        .select("user.id as id")
-        .where("group_members.group_id", "=", params.groupId)
-        .where((eb) => {
-          const clauses = [];
-          if (params.phone)
-            clauses.push(eb("user.phoneNumber", "=", params.phone));
-          if (params.email) clauses.push(eb("user.email", "=", params.email));
-          return eb.or(clauses);
-        })
-        .limit(1)
-        .executeTakeFirst();
-      if (existingMember) {
-        return {
-          created: false,
-          reason: "already_member",
-          userId: existingMember.id,
-        };
-      }
+    const collidingMemberId = await this.memberRepo.findMemberByContact(
+      params.groupId,
+      { phone: params.phone, email: params.email },
+    );
+    if (collidingMemberId) {
+      return {
+        created: false,
+        reason: "already_member",
+        userId: collidingMemberId,
+      };
     }
 
     const entry = await this.rosterRepo.create({

--- a/packages/shared/src/services/group-service.ts
+++ b/packages/shared/src/services/group-service.ts
@@ -9,8 +9,10 @@ import type {
   GroupInviteInvalidReason,
   GroupInvitePreview,
   GroupMember,
+  GroupRoster,
   MemberRole,
   UpdateGroupData,
+  UpdateGroupRosterData,
 } from "../domain/types";
 import { getDatabase } from "../database/connection";
 import type {
@@ -46,6 +48,29 @@ export type InviteAcceptOutcome =
       joined: false;
       reason: GroupInviteInvalidReason;
     };
+
+export interface RosterCreateParams {
+  groupId: string;
+  displayName: string;
+  phone?: string;
+  email?: string;
+  createdByUserId: string;
+}
+
+export type CreateRosterOutcome =
+  | { created: true; entry: GroupRoster }
+  | { created: false; reason: "already_member"; userId: string };
+
+export type DeleteRosterOutcome =
+  | { deleted: true }
+  | { deleted: false; reason: "referenced"; referencingSignupCount: number };
+
+export type RosterListEntry = Omit<
+  GroupRoster,
+  "claimedByUser" | "createdByUser"
+> & {
+  claimedByUser?: { id: string; name: string };
+};
 
 export class GroupService {
   constructor(
@@ -331,5 +356,171 @@ export class GroupService {
       claimedRosterId,
       ambiguousRosterMatches,
     };
+  }
+
+  // --- Roster (ghosts) ---------------------------------------------------
+
+  /**
+   * Organizer view of the group's roster. Hydrates `claimedByUser` with
+   * id/name via a single batched lookup so the UI can render linked-member
+   * badges without N+1 queries.
+   */
+  async listRoster(groupId: string): Promise<RosterListEntry[]> {
+    const entries = await this.rosterRepo.listByGroup(groupId);
+    const claimedIds = Array.from(
+      new Set(
+        entries.map((e) => e.claimedByUserId).filter((v): v is string => !!v),
+      ),
+    );
+    if (claimedIds.length === 0) return entries;
+
+    const users = await getDatabase()
+      .selectFrom("user")
+      .select(["id", "name"])
+      .where("id", "in", claimedIds)
+      .execute();
+    const byId = new Map(users.map((u) => [u.id, { id: u.id, name: u.name ?? "" }]));
+    return entries.map((e) => ({
+      ...e,
+      claimedByUser: e.claimedByUserId ? byId.get(e.claimedByUserId) : undefined,
+    }));
+  }
+
+  /**
+   * Creates a ghost after rejecting phone/email collisions with an existing
+   * member. This protects against the common mistake of "add a guest to the
+   * roster" when the right action is "invite them as a member" — the service
+   * surfaces the existing userId so the UI can link to an invite flow.
+   */
+  async createRosterEntry(params: RosterCreateParams): Promise<CreateRosterOutcome> {
+    if (params.phone || params.email) {
+      const db = getDatabase();
+      let q = db.selectFrom("user").select(["id"]);
+      if (params.phone && params.email) {
+        q = q.where((eb) =>
+          eb.or([
+            eb("phoneNumber", "=", params.phone!),
+            eb("email", "=", params.email!),
+          ]),
+        );
+      } else if (params.phone) {
+        q = q.where("phoneNumber", "=", params.phone);
+      } else if (params.email) {
+        q = q.where("email", "=", params.email);
+      }
+      const candidates = await q.execute();
+      for (const u of candidates) {
+        const membership = await this.memberRepo.find(params.groupId, u.id);
+        if (membership) {
+          return { created: false, reason: "already_member", userId: u.id };
+        }
+      }
+    }
+
+    const entry = await this.rosterRepo.create({
+      groupId: params.groupId,
+      displayName: params.displayName,
+      phone: params.phone,
+      email: params.email,
+      createdByUserId: params.createdByUserId,
+    });
+    return { created: true, entry };
+  }
+
+  /**
+   * Partial update + cross-group guard. If the caller is setting
+   * `claimedByUserId` to a non-null value we verify membership so we don't
+   * silently attribute signups to a non-member.
+   */
+  async updateRosterEntry(
+    rosterId: string,
+    currentGroupId: string,
+    patch: UpdateGroupRosterData,
+  ): Promise<GroupRoster> {
+    const existing = await this.rosterRepo.findById(rosterId);
+    if (!existing || existing.groupId !== currentGroupId) {
+      throw new Error("Roster entry not found");
+    }
+    if (patch.claimedByUserId) {
+      const membership = await this.memberRepo.find(
+        currentGroupId,
+        patch.claimedByUserId,
+      );
+      if (!membership) {
+        throw new Error("Target user is not a member of this group");
+      }
+    }
+    return this.rosterRepo.update(rosterId, patch);
+  }
+
+  /**
+   * Default-safe delete: refuses to drop a ghost that still appears in
+   * signups, returning the reference count so the UI can offer a force
+   * path. The force path nulls `signups.roster_id` rather than deleting
+   * the signup — we'd rather lose the attribution link than the history.
+   */
+  async deleteRosterEntry(
+    rosterId: string,
+    currentGroupId: string,
+    options: { force?: boolean } = {},
+  ): Promise<DeleteRosterOutcome> {
+    const existing = await this.rosterRepo.findById(rosterId);
+    if (!existing || existing.groupId !== currentGroupId) {
+      throw new Error("Roster entry not found");
+    }
+
+    const db = getDatabase();
+    const countRow = await db
+      .selectFrom("signups")
+      .select((eb) => eb.fn.countAll().as("c"))
+      .where("roster_id", "=", rosterId)
+      .executeTakeFirst();
+    const referencingSignupCount = Number(countRow?.c ?? 0);
+
+    if (referencingSignupCount > 0 && !options.force) {
+      return { deleted: false, reason: "referenced", referencingSignupCount };
+    }
+
+    if (referencingSignupCount > 0) {
+      await db
+        .updateTable("signups")
+        .set({ roster_id: null })
+        .where("roster_id", "=", rosterId)
+        .execute();
+    }
+    await this.rosterRepo.delete(rosterId);
+    return { deleted: true };
+  }
+
+  /**
+   * Resolve a ghost to the signup shape used by `addGuestPlayer`. Used by
+   * the match-service when the organizer picks an existing ghost instead
+   * of typing a new name — keeps the "signup row mirrors ghost identity"
+   * invariant in one place.
+   */
+  async getRosterEntryForGroup(
+    rosterId: string,
+    groupId: string,
+  ): Promise<GroupRoster> {
+    const entry = await this.rosterRepo.findById(rosterId);
+    if (!entry || entry.groupId !== groupId) {
+      throw new Error("Roster entry not found");
+    }
+    return entry;
+  }
+
+  /**
+   * Convenience path for the "quick add guest + create ghost in one step"
+   * flow from match detail. No member-collision precheck here — the caller
+   * typed a name inline, not a contact, so we wouldn't catch anything.
+   */
+  async createQuickRosterEntry(params: {
+    groupId: string;
+    displayName: string;
+    phone?: string;
+    email?: string;
+    createdByUserId: string;
+  }): Promise<GroupRoster> {
+    return this.rosterRepo.create(params);
   }
 }

--- a/packages/shared/src/services/match-service.ts
+++ b/packages/shared/src/services/match-service.ts
@@ -18,7 +18,10 @@ import type {
   LocationRepository,
   CourtRepository,
 } from "../repositories/interfaces";
-import type { TursoGroupRosterRepository } from "../repositories/group-repositories";
+import type {
+  TursoGroupMembershipRepository,
+  TursoGroupRosterRepository,
+} from "../repositories/group-repositories";
 import { getDatabase } from "../database/connection";
 
 export type AddGuestPlayerInput =
@@ -30,6 +33,21 @@ export type AddGuestPlayerInput =
       status?: PlayerStatus;
     };
 
+/**
+ * Thrown by `addGuestPlayer` when the inline `guestName` branch would create
+ * a ghost whose phone/email matches an existing group member. The route
+ * maps this to a 409 instead of the generic 400 we use for other errors,
+ * so the UI can suggest inviting the member instead.
+ */
+export class RosterMemberCollisionError extends Error {
+  readonly userId: string;
+  constructor(userId: string) {
+    super("already_member");
+    this.name = "RosterMemberCollisionError";
+    this.userId = userId;
+  }
+}
+
 export class MatchService {
   constructor(
     private matchRepository: MatchRepository,
@@ -37,6 +55,7 @@ export class MatchService {
     private locationRepository: LocationRepository,
     private courtRepository: CourtRepository,
     private rosterRepository: TursoGroupRosterRepository,
+    private memberRepository: TursoGroupMembershipRepository,
   ) {}
 
   /**
@@ -277,6 +296,15 @@ export class MatchService {
       rosterId = ghost.id;
       guestName = ghost.displayName;
     } else {
+      // Same collision precheck as GroupService.createRosterEntry so the
+      // inline-create path can't stealth-bypass the "already a member" rule.
+      const collidingMemberId = await this.memberRepository.findMemberByContact(
+        groupId,
+        { phone: input.phone, email: input.email },
+      );
+      if (collidingMemberId) {
+        throw new RosterMemberCollisionError(collidingMemberId);
+      }
       const ghost = await this.rosterRepository.create({
         groupId,
         displayName: input.guestName,

--- a/packages/shared/src/services/match-service.ts
+++ b/packages/shared/src/services/match-service.ts
@@ -8,7 +8,6 @@ import type {
   UpdateMatchData,
   MatchFilters,
   CreateSignupData,
-  CreateGuestSignupData,
   Signup,
   User,
   PlayerStatus,
@@ -19,7 +18,17 @@ import type {
   LocationRepository,
   CourtRepository,
 } from "../repositories/interfaces";
+import type { TursoGroupRosterRepository } from "../repositories/group-repositories";
 import { getDatabase } from "../database/connection";
+
+export type AddGuestPlayerInput =
+  | { rosterId: string; status?: PlayerStatus }
+  | {
+      guestName: string;
+      phone?: string;
+      email?: string;
+      status?: PlayerStatus;
+    };
 
 export class MatchService {
   constructor(
@@ -27,6 +36,7 @@ export class MatchService {
     private signupRepository: SignupRepository,
     private locationRepository: LocationRepository,
     private courtRepository: CourtRepository,
+    private rosterRepository: TursoGroupRosterRepository,
   ) {}
 
   /**
@@ -221,51 +231,69 @@ export class MatchService {
   }
 
   /**
-   * Add a guest player to a match
-   * If match is full but substitute spots are available, guest joins as SUBSTITUTE
+   * Add a guest player to a match. Accepts either an existing `rosterId`
+   * (preferred — the organizer picked an existing ghost) or a `guestName`
+   * shortcut that creates a ghost inline before creating the signup.
+   *
+   * If the match is full but substitute spots are available, the guest
+   * joins as SUBSTITUTE. Capacity is validated BEFORE any ghost insert to
+   * avoid orphaning a roster row on a rejected signup.
    */
   async addGuestPlayer(
     groupId: string,
     matchId: string,
-    guestData: Omit<CreateGuestSignupData, "groupId">,
+    input: AddGuestPlayerInput,
     addedBy: User,
   ): Promise<Signup> {
-    // Validate match exists and is in the caller's group.
     const match = await this.matchRepository.findById(matchId);
     if (!match || match.groupId !== groupId) {
       throw new Error("Match not found");
     }
-
-    // Check if match is still open
     if (match.status !== "upcoming") {
       throw new Error("Cannot add guests to this match");
     }
 
-    // Check capacity (based on paid players only)
     const isFull = await this.signupRepository.isMatchFull(
       matchId,
       match.maxPlayers,
     );
-
-    let guestStatus = guestData.status || "PENDING";
-
+    let guestStatus: PlayerStatus = input.status || "PENDING";
     if (isFull) {
-      // Match is full - check if substitute spots are available
       const substituteCount = await this.signupRepository.getSubstituteCount(matchId);
       const maxSubstitutes = match.maxSubstitutes || 0;
-
       if (substituteCount >= maxSubstitutes) {
         throw new Error("Match and substitute list are full");
       }
-
-      // Guest joins as substitute
       guestStatus = "SUBSTITUTE";
     }
 
+    let rosterId: string;
+    let guestName: string;
+    if ("rosterId" in input) {
+      const ghost = await this.rosterRepository.findById(input.rosterId);
+      if (!ghost || ghost.groupId !== groupId) {
+        throw new Error("Roster entry not found");
+      }
+      rosterId = ghost.id;
+      guestName = ghost.displayName;
+    } else {
+      const ghost = await this.rosterRepository.create({
+        groupId,
+        displayName: input.guestName,
+        phone: input.phone,
+        email: input.email,
+        createdByUserId: addedBy.id,
+      });
+      rosterId = ghost.id;
+      guestName = ghost.displayName;
+    }
+
     return this.signupRepository.addGuest({
-      ...guestData,
       groupId,
-      status: guestStatus as PlayerStatus,
+      matchId,
+      guestName,
+      rosterId,
+      status: guestStatus,
       ownerUserId: addedBy.id,
       ownerName: addedBy.name,
       ownerEmail: addedBy.email,


### PR DESCRIPTION
## Summary

Phase 4 of the group-oriented scoping refactor (stacked onto epic `feat/group-scoping`, PR #41).

- **API:** organizer-only `GET/POST/PATCH/DELETE /api/groups/:id/roster[/:rosterId]` with member-collision precheck on create, safe-by-default delete (`?force=true` nulls referencing `signups.roster_id` instead of cascading).
- **Guest signup contract:** `POST /api/matches/:id/guest` now takes a discriminated union — either `{rosterId}` (existing ghost) or `{guestName, phone?, email?}` (inline-create branch). `signups.roster_id` is populated on every guest signup.
- **Client:** new `useGroupRoster` / `useCreate/Update/DeleteRosterEntry` hooks exported from `@repo/api-client`.
- **Mobile-web:** new `admin/roster.tsx` screen (add/edit/delete + "link to existing member" picker), Roster entry point on the admin tab bar, two-mode guest dialog on match detail (pick-from-roster + quick-add).
- **Migration:** `20260423120000-convert-legacy-guests-to-ghosts.ts` converts every legacy no-user signup in `grp_legacy` (both `guest` and `admin_added`) into a `group_roster` row and links `signups.roster_id`. Idempotent up/down. Audit SQL gains an `unlinked_guest_signups` check.
