### PR TITLE
Phase 5a: phone-shortcut invites + copy-venues + visibility docs

### DIFF
--- a/apps/api/src/lib/notify.ts
+++ b/apps/api/src/lib/notify.ts
@@ -112,3 +112,40 @@ export async function notifyRemovedFromMatch(match: Match, userId: string): Prom
     await getNotificationService().sendToUser(userId, NotificationTemplates.removedFromMatch(info));
   });
 }
+
+async function findUserIdByPhone(phone: string): Promise<string | null> {
+  const row = await getDatabase()
+    .selectFrom("user")
+    .select("id")
+    .where("phoneNumber", "=", phone)
+    .executeTakeFirst();
+  return row?.id ?? null;
+}
+
+// Skips if the target phone is already a member of the group — a push saying
+// "you were invited" would be confusing when they're already in.
+export async function notifyGroupInviteTarget(params: {
+  targetPhone: string;
+  groupId: string;
+  groupName: string;
+  inviterName: string;
+  token: string;
+}): Promise<void> {
+  await safeNotify("group invite target", async () => {
+    const userId = await findUserIdByPhone(params.targetPhone);
+    if (!userId) return;
+    const existing = await getRepositoryFactory().groupMembers.find(
+      params.groupId,
+      userId,
+    );
+    if (existing) return;
+    await getNotificationService().sendToUser(
+      userId,
+      NotificationTemplates.groupInvite({
+        groupName: params.groupName,
+        inviterName: params.inviterName,
+        token: params.token,
+      }),
+    );
+  });
+}

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -294,13 +294,17 @@ app.post(
           : Promise.resolve(null),
       ]);
       if (body.targetPhone && group) {
-        void notifyGroupInviteTarget({
-          targetPhone: body.targetPhone,
-          groupId: id,
-          groupName: group.name,
-          inviterName: user.name,
-          token: invite.token,
-        });
+        // Cloudflare Workers terminates background promises once the response
+        // returns; `waitUntil` keeps the isolate alive until the push completes.
+        c.executionCtx?.waitUntil(
+          notifyGroupInviteTarget({
+            targetPhone: body.targetPhone,
+            groupId: id,
+            groupName: group.name,
+            inviterName: user.name,
+            token: invite.token,
+          }),
+        );
       }
       return c.json({ invite }, 201);
     } catch (error) {

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -11,6 +11,7 @@ import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import { getServiceFactory } from "@repo/shared/services";
 import { MEMBER_ROLES } from "@repo/shared/domain";
+import { notifyGroupInviteTarget } from "../lib/notify";
 import { type AppVariables, requireUser } from "../middleware/security";
 import {
   groupContextMiddleware,
@@ -279,14 +280,28 @@ app.post(
     const body = c.req.valid("json");
 
     try {
-      const invite = await getGroupService().createInvite({
-        groupId: id,
-        createdByUserId: user.id,
-        expiresInHours: body.expiresInHours,
-        maxUses: body.maxUses,
-        targetPhone: body.targetPhone,
-        targetUserId: body.targetUserId,
-      });
+      const [invite, group] = await Promise.all([
+        getGroupService().createInvite({
+          groupId: id,
+          createdByUserId: user.id,
+          expiresInHours: body.expiresInHours,
+          maxUses: body.maxUses,
+          targetPhone: body.targetPhone,
+          targetUserId: body.targetUserId,
+        }),
+        body.targetPhone
+          ? getGroupService().getGroupBasics(id)
+          : Promise.resolve(null),
+      ]);
+      if (body.targetPhone && group) {
+        void notifyGroupInviteTarget({
+          targetPhone: body.targetPhone,
+          groupId: id,
+          groupName: group.name,
+          inviterName: user.name,
+          token: invite.token,
+        });
+      }
       return c.json({ invite }, 201);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to create invite";

--- a/apps/api/src/routes/locations.ts
+++ b/apps/api/src/routes/locations.ts
@@ -124,6 +124,16 @@ app.post(
           403,
         );
       }
+    } else {
+      // Non-members (including superadmin) bypass the membership check above,
+      // so verify the source group actually exists — otherwise a typo would
+      // quietly return {0, 0} against an empty non-existent group.
+      const sourceGroup = await getRepositoryFactory().groups.findById(
+        sourceGroupId,
+      );
+      if (!sourceGroup) {
+        return c.json({ error: "Source group not found" }, 404);
+      }
     }
 
     try {

--- a/apps/api/src/routes/locations.ts
+++ b/apps/api/src/routes/locations.ts
@@ -2,9 +2,10 @@ import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import { getRepositoryFactory } from "@repo/shared/repositories";
-import { type AppVariables } from "../middleware/security";
+import { getServiceFactory } from "@repo/shared/services";
+import { requireUser, type AppVariables } from "../middleware/security";
 import { groupContextMiddleware, requireCurrentGroup } from "../middleware/group-context";
-import { requireOrganizer } from "../middleware/authz";
+import { isSuperadmin, requireOrganizer } from "../middleware/authz";
 
 const app = new Hono<{ Variables: AppVariables }>();
 
@@ -93,6 +94,49 @@ app.patch(
       return c.json({ error: message }, 400);
     }
   }
+);
+
+app.post(
+  "/copy-from/:sourceGroupId",
+  async (c) => {
+    const denied = requireOrganizer(c);
+    if (denied) return denied;
+
+    const user = requireUser(c);
+    const current = requireCurrentGroup(c);
+    const sourceGroupId = c.req.param("sourceGroupId");
+
+    if (sourceGroupId === current.id) {
+      return c.json(
+        { error: "Source and target group must differ" },
+        400,
+      );
+    }
+
+    if (!isSuperadmin(c)) {
+      const sourceMembership = await getRepositoryFactory().groupMembers.find(
+        sourceGroupId,
+        user.id,
+      );
+      if (!sourceMembership || sourceMembership.role !== "organizer") {
+        return c.json(
+          { error: "Must be an organizer of the source group" },
+          403,
+        );
+      }
+    }
+
+    try {
+      const result = await getServiceFactory().groupService.copyVenues(
+        sourceGroupId,
+        current.id,
+      );
+      return c.json(result, 200);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to copy venues";
+      return c.json({ error: message }, 400);
+    }
+  },
 );
 
 // Delete a location (organizer only)

--- a/apps/mobile-web/app/(tabs)/admin/index.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/index.tsx
@@ -821,7 +821,7 @@ function LocationsTab() {
           onOpenChange={setShowCopyDialog}
           title={t("locations.copyFromGroup")}
           onConfirm={() => {
-            if (!copyFromGroupId) return;
+            if (!copyFromGroupId || copyVenuesMutation.isPending) return;
             copyVenuesMutation.mutate(copyFromGroupId, {
               onSuccess: (data) => {
                 setShowCopyDialog(false);

--- a/apps/mobile-web/app/(tabs)/admin/index.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/index.tsx
@@ -5,6 +5,8 @@ import {
   useQueryClient,
   client,
   getAdminResetCodes,
+  useCopyVenues,
+  useCurrentGroup,
 } from "@repo/api-client";
 import {
   Container,
@@ -521,6 +523,15 @@ function LocationsTab() {
   const [deleteTarget, setDeleteTarget] = useState<Location | null>(null);
   const [name, setName] = useState("");
   const [address, setAddress] = useState("");
+  const [showCopyDialog, setShowCopyDialog] = useState(false);
+  const [copyFromGroupId, setCopyFromGroupId] = useState<string>("");
+
+  const { groupId: currentGroupId, myGroups } = useCurrentGroup();
+  const copyVenuesMutation = useCopyVenues();
+
+  const copyableGroups = myGroups.filter(
+    (g) => g.id !== currentGroupId && g.myRole === "organizer",
+  );
 
   const {
     data: locations = [],
@@ -664,6 +675,19 @@ function LocationsTab() {
           {t("locations.addLocation")}
         </Button>
 
+        {copyableGroups.length > 0 ? (
+          <Button
+            variant="outline"
+            onPress={() => {
+              setCopyFromGroupId(copyableGroups[0]?.id ?? "");
+              setShowCopyDialog(true);
+            }}
+            testID="admin-locations-copy-btn"
+          >
+            {t("locations.copyFromGroup")}
+          </Button>
+        ) : null}
+
         {/* Locations List */}
         {locations.length === 0 ? (
           <Card variant="outlined">
@@ -791,6 +815,54 @@ function LocationsTab() {
             }
           }}
         />
+
+        <Dialog
+          open={showCopyDialog}
+          onOpenChange={setShowCopyDialog}
+          title={t("locations.copyFromGroup")}
+          onConfirm={() => {
+            if (!copyFromGroupId) return;
+            copyVenuesMutation.mutate(copyFromGroupId, {
+              onSuccess: (data) => {
+                setShowCopyDialog(false);
+                toast.show(
+                  t("locations.copySuccess", {
+                    locations: data.locationsCopied,
+                    courts: data.courtsCopied,
+                  }),
+                  { duration: 4000, customData: { variant: "success" } },
+                );
+              },
+              onError: (error: Error) => {
+                toast.show(getLocalizedError(error.message, t), {
+                  duration: 4000,
+                  customData: { variant: "error" },
+                });
+              },
+            });
+          }}
+          onCancel={() => setShowCopyDialog(false)}
+          confirmText={
+            copyVenuesMutation.isPending
+              ? t("locations.copying")
+              : t("locations.copy")
+          }
+          cancelText={t("shared.cancel")}
+        >
+          <YStack gap="$3" padding="$4">
+            <Text color="$gray11">{t("locations.copyFromGroupHint")}</Text>
+            <Select
+              value={copyFromGroupId}
+              onValueChange={setCopyFromGroupId}
+              label={t("locations.sourceGroup")}
+              placeholder={t("locations.selectSourceGroup")}
+              options={copyableGroups.map((g) => ({
+                label: g.name,
+                value: g.id,
+              }))}
+            />
+          </YStack>
+        </Dialog>
       </YStack>
     </ScrollView>
   );

--- a/apps/mobile-web/app/(tabs)/profile/groups/[groupId].tsx
+++ b/apps/mobile-web/app/(tabs)/profile/groups/[groupId].tsx
@@ -11,12 +11,12 @@ import {
   useRevokeInvite,
   useSession,
 } from "@repo/api-client";
-import { AlertDialog } from "@repo/ui";
+import { AlertDialog, isValidPhoneNumber } from "@repo/ui";
 import { router, useLocalSearchParams } from "expo-router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert, Platform, ScrollView, Share } from "react-native";
-import { Button, Spinner, Text, XStack, YStack } from "tamagui";
+import { Button, Input, Spinner, Text, XStack, YStack } from "tamagui";
 
 export default function GroupDetailScreen() {
   const { t } = useTranslation();
@@ -40,6 +40,8 @@ export default function GroupDetailScreen() {
   const revokeInviteMutation = useRevokeInvite(groupId ?? "");
   const deleteMutation = useDeleteGroup();
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [invitePhone, setInvitePhone] = useState("");
+  const [phoneError, setPhoneError] = useState<string | null>(null);
 
   if (isLoading) {
     return (
@@ -95,9 +97,17 @@ export default function GroupDetailScreen() {
   }
 
   async function onCreateInvite() {
+    setPhoneError(null);
+    const phone = invitePhone.trim();
+    if (phone && !isValidPhoneNumber(phone)) {
+      setPhoneError(t("groups.invite.phoneInvalid"));
+      return;
+    }
     await createInviteMutation.mutateAsync({
       expiresInHours: 24 * 7,
+      ...(phone ? { targetPhone: phone } : {}),
     });
+    setInvitePhone("");
   }
 
   return (
@@ -125,9 +135,24 @@ export default function GroupDetailScreen() {
 
         {isOrganizerView ? (
           <YStack gap="$2">
-            <XStack justifyContent="space-between" alignItems="center">
-              <Text fontSize="$5" fontWeight="600">
-                {t("groups.invite.sectionTitle")}
+            <Text fontSize="$5" fontWeight="600">
+              {t("groups.invite.sectionTitle")}
+            </Text>
+
+            <YStack gap="$2">
+              <Input
+                value={invitePhone}
+                onChangeText={(v) => {
+                  setInvitePhone(v);
+                  if (phoneError) setPhoneError(null);
+                }}
+                placeholder={t("groups.invite.phonePlaceholder")}
+                keyboardType="phone-pad"
+                autoCapitalize="none"
+                autoCorrect={false}
+              />
+              <Text fontSize="$2" color={phoneError ? "$red10" : "$gray10"}>
+                {phoneError ?? t("groups.invite.phoneHint")}
               </Text>
               <Button
                 size="$3"
@@ -137,7 +162,7 @@ export default function GroupDetailScreen() {
               >
                 {t("groups.invite.create")}
               </Button>
-            </XStack>
+            </YStack>
 
             {invitesQuery.isLoading ? (
               <Spinner />

--- a/docs/group-visibility.md
+++ b/docs/group-visibility.md
@@ -1,0 +1,32 @@
+# Group Visibility
+
+Groups carry a `visibility` field on the `groups` table:
+
+- `private` (default) — group is invite-only; not discoverable.
+- `public` — group opts in to future public discovery (directory, browse-and-request-to-join flows).
+
+## Current state
+
+- **DB**: `groups.visibility TEXT NOT NULL DEFAULT 'private' CHECK (visibility IN ('private','public'))`.
+- **API**: `PATCH /api/groups/:id` accepts `visibility`. The field is **superadmin-gated** — only a `superadmin` can flip a group from `private` to `public` or back.
+- **UI**: No member-facing toggle. The flag is settable today only by a superadmin directly against the API.
+
+## When public discovery ships
+
+Consumers that render or filter on `visibility` should:
+
+1. Default to `private` semantics: members-only views, no listing in browse/search surfaces.
+2. Only surface a group in public discovery UIs when `visibility === "public"`.
+3. Never leak the member list, roster, or match details of a private group to non-members — the scoping middleware already enforces this; visibility is a second guard for directory endpoints.
+
+## Changing the flag
+
+Superadmin only:
+
+```
+PATCH /api/groups/:id
+X-Group-Id: <id>
+{ "visibility": "public" }
+```
+
+Non-superadmin organizers receive `403 Only superadmin can change visibility`.

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -802,7 +802,7 @@
       "loadErrorBody": "Check your connection and try again.",
       "acceptFailedTitle": "Couldn't join the group",
       "acceptFailedBody": "Something went wrong. Please try again.",
-      "phonePlaceholder": "+49 151 234 5678",
+      "phonePlaceholder": "+491512345678",
       "phoneHint": "Optional — if they already have an account, they'll get a push notification.",
       "phoneInvalid": "Use international format, e.g. +491512345678."
     },

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -508,7 +508,14 @@
     "updateError": "Failed to update location",
     "deleteSuccess": "Location deleted successfully",
     "deleteError": "Failed to delete location",
-    "error": "Failed to load locations: {message}"
+    "error": "Failed to load locations: {message}",
+    "copyFromGroup": "Copy from another group",
+    "copyFromGroupHint": "Duplicates all locations and courts from the selected group into this one. Existing venues here are kept.",
+    "sourceGroup": "Source group",
+    "selectSourceGroup": "Select a group",
+    "copy": "Copy",
+    "copying": "Copying…",
+    "copySuccess": "Copied {{locations}} locations and {{courts}} courts."
   },
   "courts": {
     "title": "Courts",
@@ -794,7 +801,10 @@
       "loadErrorTitle": "Couldn't load invite",
       "loadErrorBody": "Check your connection and try again.",
       "acceptFailedTitle": "Couldn't join the group",
-      "acceptFailedBody": "Something went wrong. Please try again."
+      "acceptFailedBody": "Something went wrong. Please try again.",
+      "phonePlaceholder": "+49 151 234 5678",
+      "phoneHint": "Optional — if they already have an account, they'll get a push notification.",
+      "phoneInvalid": "Use international format, e.g. +491512345678."
     },
     "roster": {
       "title": "Roster",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -805,7 +805,7 @@
       "loadErrorBody": "Revisá tu conexión e intentá de nuevo.",
       "acceptFailedTitle": "No pudimos unirte al grupo",
       "acceptFailedBody": "Algo salió mal. Intentá de nuevo.",
-      "phonePlaceholder": "+49 151 234 5678",
+      "phonePlaceholder": "+491512345678",
       "phoneHint": "Opcional — si ya tiene cuenta, le llega una notificación push.",
       "phoneInvalid": "Usá formato internacional, ej. +491512345678."
     },

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -511,7 +511,14 @@
     "updateError": "No se pudo actualizar el predio",
     "deleteSuccess": "Predio eliminado exitosamente",
     "deleteError": "No se pudo eliminar la ubicación",
-    "error": "No se pudieron cargar los predios: {message}"
+    "error": "No se pudieron cargar los predios: {message}",
+    "copyFromGroup": "Copiar desde otro grupo",
+    "copyFromGroupHint": "Duplica todos los predios y canchas del grupo seleccionado en éste. Los predios actuales se conservan.",
+    "sourceGroup": "Grupo de origen",
+    "selectSourceGroup": "Elegí un grupo",
+    "copy": "Copiar",
+    "copying": "Copiando…",
+    "copySuccess": "Se copiaron {{locations}} predios y {{courts}} canchas."
   },
   "courts": {
     "title": "Canchas",
@@ -797,7 +804,10 @@
       "loadErrorTitle": "No se pudo cargar la invitación",
       "loadErrorBody": "Revisá tu conexión e intentá de nuevo.",
       "acceptFailedTitle": "No pudimos unirte al grupo",
-      "acceptFailedBody": "Algo salió mal. Intentá de nuevo."
+      "acceptFailedBody": "Algo salió mal. Intentá de nuevo.",
+      "phonePlaceholder": "+49 151 234 5678",
+      "phoneHint": "Opcional — si ya tiene cuenta, le llega una notificación push.",
+      "phoneInvalid": "Usá formato internacional, ej. +491512345678."
     },
     "roster": {
       "title": "Plantel",

--- a/packages/api-client/src/groups.ts
+++ b/packages/api-client/src/groups.ts
@@ -455,6 +455,29 @@ export function useDeleteRosterEntry(groupId: string) {
   });
 }
 
+// Copies all locations + courts from `sourceGroupId` into the current group
+// (the X-Group-Id interceptor sets the target). Invalidates the locations and
+// courts query caches on success so the admin screen reflects the new rows.
+export function useCopyVenues() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (sourceGroupId: string) => {
+      const res = await client.api.locations["copy-from"][":sourceGroupId"].$post({
+        param: { sourceGroupId },
+      });
+      const data = (await res.json()) as {
+        locationsCopied: number;
+        courtsCopied: number;
+      };
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["locations"] });
+      queryClient.invalidateQueries({ queryKey: ["courts"] });
+    },
+  });
+}
+
 export function useTransferOwnership(groupId: string) {
   const queryClient = useQueryClient();
   return useMutation({

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -72,6 +72,7 @@ export {
   useCreateRosterEntry,
   useUpdateRosterEntry,
   useDeleteRosterEntry,
+  useCopyVenues,
 } from "./groups";
 export type {
   GroupInviteSummary,

--- a/packages/shared/src/domain/types.ts
+++ b/packages/shared/src/domain/types.ts
@@ -573,6 +573,7 @@ export const NOTIFICATION_TYPES = {
   PAYMENT_REMINDER: "payment_reminder",
   VOTING_OPEN: "voting_open",
   ENGAGEMENT_REMINDER: "engagement_reminder",
+  GROUP_INVITE: "group_invite",
 } as const;
 
 export type NotificationType =

--- a/packages/shared/src/services/factory.ts
+++ b/packages/shared/src/services/factory.ts
@@ -54,6 +54,8 @@ export class ServiceFactory {
       repos.groupSettings,
       repos.groupInvites,
       repos.groupRoster,
+      repos.locations,
+      repos.courts,
     );
   }
 }

--- a/packages/shared/src/services/group-service.ts
+++ b/packages/shared/src/services/group-service.ts
@@ -516,10 +516,27 @@ export class GroupService {
       throw new Error("Source and target group must differ");
     }
 
+    const sourceGroup = await this.groupRepo.findById(sourceGroupId);
+    if (!sourceGroup) {
+      throw new Error("Source group not found");
+    }
+
     const [sourceLocations, sourceCourts] = await Promise.all([
       this.locationRepo.findAll(sourceGroupId),
       this.courtRepo.findAll(sourceGroupId),
     ]);
+
+    // Derive `courtCount` from the actual courts rather than copying the
+    // source location's denormalized counter — source data may be stale, and
+    // a partial write would otherwise leave the target's counter inconsistent
+    // with its real court rows.
+    const courtsByLocationId = new Map<string, number>();
+    for (const court of sourceCourts) {
+      courtsByLocationId.set(
+        court.locationId,
+        (courtsByLocationId.get(court.locationId) ?? 0) + 1,
+      );
+    }
 
     const createdLocations = await Promise.all(
       sourceLocations.map((loc) =>
@@ -528,7 +545,7 @@ export class GroupService {
           name: loc.name,
           address: loc.address,
           coordinates: loc.coordinates,
-          courtCount: loc.courtCount,
+          courtCount: courtsByLocationId.get(loc.id) ?? 0,
         }),
       ),
     );

--- a/packages/shared/src/services/group-service.ts
+++ b/packages/shared/src/services/group-service.ts
@@ -22,6 +22,10 @@ import type {
   TursoGroupRosterRepository,
   TursoGroupSettingsRepository,
 } from "../repositories/group-repositories";
+import type {
+  LocationRepository,
+  CourtRepository,
+} from "../repositories/interfaces";
 
 export interface GroupDetails extends Group {
   members: GroupMember[];
@@ -79,6 +83,11 @@ export type RosterListEntry = Omit<
   claimedByUser?: { id: string; name: string };
 };
 
+export interface CopyVenuesOutcome {
+  locationsCopied: number;
+  courtsCopied: number;
+}
+
 export class GroupService {
   constructor(
     private groupRepo: TursoGroupRepository,
@@ -86,6 +95,8 @@ export class GroupService {
     private settingsRepo: TursoGroupSettingsRepository,
     private inviteRepo: TursoGroupInviteRepository,
     private rosterRepo: TursoGroupRosterRepository,
+    private locationRepo: LocationRepository,
+    private courtRepo: CourtRepository,
   ) {}
 
   async listMyGroups(userId: string) {
@@ -485,5 +496,66 @@ export class GroupService {
     }
     await this.rosterRepo.delete(rosterId);
     return { deleted: true };
+  }
+
+  // --- Venues (cross-group) ---------------------------------------------
+
+  /**
+   * Duplicates all locations and courts from `sourceGroupId` into
+   * `targetGroupId` with fresh ids. Auth (must be organizer/superadmin in
+   * both groups) is enforced at the route boundary; this method trusts its
+   * caller. Not transactional across repos — a partial copy may occur if a
+   * write fails halfway; organizers can clean up manually. Acceptable at
+   * current scale (setup-time tool, low frequency).
+   */
+  async copyVenues(
+    sourceGroupId: string,
+    targetGroupId: string,
+  ): Promise<CopyVenuesOutcome> {
+    if (sourceGroupId === targetGroupId) {
+      throw new Error("Source and target group must differ");
+    }
+
+    const [sourceLocations, sourceCourts] = await Promise.all([
+      this.locationRepo.findAll(sourceGroupId),
+      this.courtRepo.findAll(sourceGroupId),
+    ]);
+
+    const createdLocations = await Promise.all(
+      sourceLocations.map((loc) =>
+        this.locationRepo.create({
+          groupId: targetGroupId,
+          name: loc.name,
+          address: loc.address,
+          coordinates: loc.coordinates,
+          courtCount: loc.courtCount,
+        }),
+      ),
+    );
+    const locationIdMap = new Map<string, string>();
+    sourceLocations.forEach((loc, i) => {
+      const created = createdLocations[i];
+      if (created) locationIdMap.set(loc.id, created.id);
+    });
+
+    const courtsToCreate = sourceCourts.flatMap((court) => {
+      const newLocationId = locationIdMap.get(court.locationId);
+      if (!newLocationId) return [];
+      return [
+        this.courtRepo.create({
+          groupId: targetGroupId,
+          locationId: newLocationId,
+          name: court.name,
+          description: court.description,
+          isActive: court.isActive,
+        }),
+      ];
+    });
+    const createdCourts = await Promise.all(courtsToCreate);
+
+    return {
+      locationsCopied: locationIdMap.size,
+      courtsCopied: createdCourts.length,
+    };
   }
 }

--- a/packages/shared/src/services/notification-templates.ts
+++ b/packages/shared/src/services/notification-templates.ts
@@ -93,6 +93,22 @@ export const NotificationTemplates = {
     };
   },
 
+  groupInvite(params: {
+    groupName: string;
+    inviterName: string;
+    token: string;
+  }): NotificationPayload {
+    return {
+      title: "You're invited!",
+      body: `${params.inviterName} invited you to join ${params.groupName}.`,
+      data: {
+        type: NOTIFICATION_TYPES.GROUP_INVITE,
+        token: params.token,
+        screen: `/join/${params.token}`,
+      },
+    };
+  },
+
   engagementReminder(variant: number): NotificationPayload {
     const messages = [
       { title: "Don't Miss Out!", body: "Check out upcoming matches and join your friends!" },


### PR DESCRIPTION
## Summary

Part 1 of 2 for Phase 5 (Polish). Three user-facing features; leaves the i18n native-speaker pass, empty/error states, docs sweep, and observability for Phase 5b.

### Phone-shortcut invite
- `POST /api/groups/:id/invites` already accepted `targetPhone` (Phase 3). This PR adds the push side: if the phone matches a registered user who isn't already a member, they get an in-app notification with the join link.
- New `NOTIFICATION_TYPES.GROUP_INVITE` + `NotificationTemplates.groupInvite({ groupName, inviterName, token })`.
- Best-effort via the existing `safeNotify` wrapper in `apps/api/src/lib/notify.ts` — the link is always returned for manual sharing regardless of push outcome.
- Group name fetch (`getGroupBasics`) only runs when `targetPhone` is set — no extra query on the share-link path.
- Mobile: phone input (with `isValidPhoneNumber` from `@repo/ui`, not a fresh regex) on the organizer-only invite creation form in `profile/groups/[groupId].tsx`.

### Copy-venues helper
- `POST /api/locations/copy-from/:sourceGroupId` — organizer in both groups (or superadmin). Duplicates every location + court from source into the current group with fresh ids; preserves the location→court mapping.
- `GroupService.copyVenues` is non-transactional across repos (documented; matches the project's accepted trade-off at this scale). Per-phase `Promise.all` cuts round-trips.
- Admin Locations tab renders a "Copy from another group" button only when the caller organizes at least one other group. Picker lists those groups; success toast shows counts.

### Public visibility flag
- Backend (`PATCH /api/groups/:id` with `visibility`, superadmin-gated) was already complete from Phase 2.
- This PR adds `docs/group-visibility.md` documenting the current state and the contract future public-discovery UI must honor.
- No member-facing UI — per the plan ("Surface nothing in the member-facing UI yet").

## Test plan

- [ ] Organizer A creates an invite with `targetPhone` = registered user B's phone → B receives push with link; A sees the link in the invite list.
- [ ] Same flow but B is already a member of the group → no push sent; invite still created.
- [ ] Phone number fails regex in UI → inline error, no network call.
- [ ] Organizer with two groups opens admin Locations → "Copy from another group" button visible; picker lists the other group; confirm copies locations + courts; counts match.
- [ ] Non-organizer of source group hits `POST /locations/copy-from/:sourceId` → 403.
- [ ] Target == source → 400.
- [ ] Superadmin PATCHes `visibility: "public"` → 200; non-superadmin organizer → 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)