### PR TITLE
Phase 5b: observability + docs + empty/error polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,35 @@ This is a **Turborepo** monorepo using **pnpm workspaces** with the following st
 - Expo SecureStore for token persistence (mobile)
 - AsyncStorage + Bearer tokens for web (cross-domain auth)
 - Database stores user sessions and profiles
-- Admin role system with role-based access
+- Two-tier role model: **platform role** (on `user.role`) + **group-relative role** (see next section)
+
+### Group-oriented Scoping
+Every group-scoped resource (match, location, court, signup, setting, invite, roster) belongs to a group. The API binds the active group per-request and authz decisions are group-relative.
+
+**Platform roles** (`user.role`):
+- `user` — default; no platform-level privileges.
+- `superadmin` — full cross-group access; only one today (Ignacio). `admin` is retained as a transitional alias and may appear on legacy rows.
+
+**Group-relative roles** (`group_members.role`):
+- `member` — default; can view/join matches of the group.
+- `organizer` — can manage matches, locations, courts, invites, roster for that group. Owner (see below) is always an organizer.
+
+**Ownership**: `groups.owner_user_id` points at a single organizer member; owner is the only one who can delete the group or transfer ownership.
+
+**Active group**: client sends `X-Group-Id: <groupId>` on every scoped request. `apps/api/src/middleware/group-context.ts` resolves it to a `currentGroup: { id, role, isOwner }` via `requireCurrentGroup(c)`. The mobile client persists the active id via `packages/api-client/src/group-storage.ts`; the fetch wrapper in `client.ts` injects the header automatically.
+
+**Authz helpers** (`apps/api/src/middleware/authz.ts`) — use these at the route boundary:
+- `assertInCurrentGroup(c, id)` — 404 if the path `:id` doesn't match the active group (superadmin bypasses).
+- `requireOrganizer(c)` / `requireOwner(c)` / `requireSuperadmin(c)` — return a 403 `Response` or `null`.
+- `isSuperadmin(c)` — boolean check for field-level gating (e.g., `visibility` in PATCH /groups/:id).
+
+**Superadmin escape hatch**: superadmin passes every group-gated check regardless of group membership.
+
+**Ghost roster**: `group_roster` holds named non-users (guests added by organizers). Ghost auto-claims by phone/email when a matching user accepts an invite (`GroupService.acceptInvite`). See `docs/group-visibility.md` for the public/private flag.
+
+**Deprecated**: `match_invitations` table + `MatchInvitationRepository` are not wired to any active route or UI (only GDPR cleanup touches the table). Treat as dead code; don't build against it.
+
+**Observability**: `GroupService` emits structured JSON logs on `group.created`, `invite.accepted`, `ghost.claimed`, `group.ownership_transferred` — picked up by Cloudflare Workers logs.
 
 ### Database Configuration
 - **Primary**: Turso (LibSQL) database via `@libsql/kysely-libsql`

--- a/apps/mobile-web/app/join/[token].tsx
+++ b/apps/mobile-web/app/join/[token].tsx
@@ -62,6 +62,9 @@ export default function JoinScreen() {
         <Text color="$gray11" textAlign="center">
           {t("groups.invite.loadErrorBody")}
         </Text>
+        <Button onPress={() => router.replace("/(tabs)")}>
+          {t("groups.invite.goHome")}
+        </Button>
       </YStack>
     );
   }
@@ -76,6 +79,9 @@ export default function JoinScreen() {
         <Text color="$gray11" textAlign="center">
           {t(`groups.invite.invalidReason.${reason}`)}
         </Text>
+        <Button onPress={() => router.replace("/(tabs)")}>
+          {t("groups.invite.goHome")}
+        </Button>
       </YStack>
     );
   }

--- a/apps/mobile-web/components/no-group-onboarding.tsx
+++ b/apps/mobile-web/components/no-group-onboarding.tsx
@@ -3,32 +3,57 @@
 // returns 409 NO_GROUP, useCurrentGroup().noGroup becomes true). The CTA is
 // intentionally passive: invites arrive as links, and the user taps them to
 // join. No "paste invite" input yet — the deep-link handler already covers
-// both paths.
+// both paths. Sign-out is the only escape hatch from this screen.
 
+import { signOut } from "@repo/api-client";
+import { Users } from "@tamagui/lucide-icons";
+import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Text, YStack } from "tamagui";
+import { Button, Text, YStack } from "tamagui";
 
 export function NoGroupOnboarding() {
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
+
+  async function onSignOut() {
+    await signOut();
+    router.replace("/(auth)");
+  }
+
   return (
     <YStack
       flex={1}
       justifyContent="center"
       alignItems="center"
       padding="$6"
-      gap="$3"
+      gap="$4"
       paddingTop={insets.top + 24}
       paddingBottom={insets.bottom + 24}
       backgroundColor="$background"
     >
+      <YStack
+        width={96}
+        height={96}
+        borderRadius="$12"
+        backgroundColor="$gray4"
+        justifyContent="center"
+        alignItems="center"
+      >
+        <Users size={48} color="$gray10" />
+      </YStack>
       <Text fontSize="$7" fontWeight="700" textAlign="center">
         {t("groups.noGroup.title")}
       </Text>
       <Text fontSize="$4" color="$gray11" textAlign="center">
         {t("groups.noGroup.body")}
       </Text>
+      <Text fontSize="$3" color="$gray10" textAlign="center">
+        {t("groups.noGroup.hint")}
+      </Text>
+      <Button variant="outlined" onPress={onSignOut} marginTop="$2">
+        {t("groups.noGroup.signOut")}
+      </Button>
     </YStack>
   );
 }

--- a/apps/mobile-web/components/no-group-onboarding.tsx
+++ b/apps/mobile-web/components/no-group-onboarding.tsx
@@ -17,6 +17,15 @@ export function NoGroupOnboarding() {
   const insets = useSafeAreaInsets();
 
   async function onSignOut() {
+    // Unregister the Expo push token before clearing the session so the
+    // backend stops targeting this device. Matches the pattern in
+    // `profile/index.tsx`.
+    try {
+      const { unregisterPushToken } = await import(
+        "../lib/use-push-notifications"
+      );
+      await unregisterPushToken();
+    } catch {}
     await signOut();
     router.replace("/(auth)");
   }

--- a/docs/phone-auth-password-as-otp.md
+++ b/docs/phone-auth-password-as-otp.md
@@ -165,3 +165,12 @@ To verify the fix works:
 2. Open browser DevTools → Network tab
 3. Filter by `get-session`
 4. After login, you should see only 2-3 `get-session` calls, not continuous polling
+
+## Interaction with group invites
+
+The `user.phoneNumber` column this pattern writes is also the target key for phone-shortcut group invites:
+
+- Organizer creates an invite with `targetPhone: "+49..."` (`POST /api/groups/:id/invites`). If that phone matches an existing user's `phoneNumber`, the server sends them a push notification with the join link (best-effort, always returns the shareable link). See `apps/api/src/lib/notify.ts` `notifyGroupInviteTarget`.
+- On invite accept (`GroupService.acceptInvite`), the server also uses `user.phoneNumber` to auto-claim any unclaimed `group_roster` ghost whose `phone` field matches — a single exact match claims, multiple matches are reported as `ambiguousRosterMatches` and require a manual link.
+
+Both flows read the same `phoneNumber` column this pattern populates at sign-up time; if a user signs up via Google OAuth and never adds a phone, they simply won't match phone-targeted invites or phone-keyed ghost rows. Email-keyed ghost claim still works in that case.

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -776,7 +776,9 @@
     },
     "noGroup": {
       "title": "No group yet",
-      "body": "Ask your organizer for an invite link, then open it to join."
+      "body": "Ask your organizer for an invite link, then open it to join.",
+      "hint": "Groups are how we organize who plays together — matches, rosters and stats all belong to a group.",
+      "signOut": "Sign out"
     },
     "invite": {
       "sectionTitle": "Invites",
@@ -802,6 +804,7 @@
       "loadErrorBody": "Check your connection and try again.",
       "acceptFailedTitle": "Couldn't join the group",
       "acceptFailedBody": "Something went wrong. Please try again.",
+      "goHome": "Back to home",
       "phonePlaceholder": "+491512345678",
       "phoneHint": "Optional — if they already have an account, they'll get a push notification.",
       "phoneInvalid": "Use international format, e.g. +491512345678."

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -779,7 +779,9 @@
     },
     "noGroup": {
       "title": "Todavía sin grupo",
-      "body": "Pedile al organizador un link de invitación y abrilo para entrar."
+      "body": "Pedile al organizador un link de invitación y abrilo para entrar.",
+      "hint": "Los grupos son cómo organizamos quién juega con quién — los partidos, la plantilla y las estadísticas viven dentro de un grupo.",
+      "signOut": "Cerrar sesión"
     },
     "invite": {
       "sectionTitle": "Invitaciones",
@@ -805,6 +807,7 @@
       "loadErrorBody": "Revisá tu conexión e intentá de nuevo.",
       "acceptFailedTitle": "No pudimos unirte al grupo",
       "acceptFailedBody": "Algo salió mal. Intentá de nuevo.",
+      "goHome": "Volver al inicio",
       "phonePlaceholder": "+491512345678",
       "phoneHint": "Opcional — si ya tiene cuenta, le llega una notificación push.",
       "phoneInvalid": "Usá formato internacional, ej. +491512345678."

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -780,7 +780,7 @@
     "noGroup": {
       "title": "Todavía sin grupo",
       "body": "Pedile al organizador un link de invitación y abrilo para entrar.",
-      "hint": "Los grupos son cómo organizamos quién juega con quién — los partidos, la plantilla y las estadísticas viven dentro de un grupo.",
+      "hint": "Los grupos son como organizamos quién juega con quién — los partidos, la plantilla y las estadísticas viven dentro de un grupo.",
       "signOut": "Cerrar sesión"
     },
     "invite": {

--- a/packages/shared/src/services/group-service.ts
+++ b/packages/shared/src/services/group-service.ts
@@ -27,6 +27,14 @@ import type {
   CourtRepository,
 } from "../repositories/interfaces";
 
+// Structured log line. Cloudflare Workers ingests `console.log` output and
+// indexes on top-level JSON fields, so every event emits a single JSON line.
+function logEvent(event: string, payload: Record<string, unknown>): void {
+  console.log(
+    JSON.stringify({ event, ...payload, ts: new Date().toISOString() }),
+  );
+}
+
 export interface GroupDetails extends Group {
   members: GroupMember[];
   settings: Record<string, string>;
@@ -120,6 +128,12 @@ export class GroupService {
       userId: params.ownerUserId,
       role: "organizer",
     });
+    logEvent("group.created", {
+      groupId: group.id,
+      ownerUserId: params.ownerUserId,
+      name: group.name,
+      slug: group.slug,
+    });
     return group;
   }
 
@@ -208,6 +222,11 @@ export class GroupService {
       throw new Error("Target must be an existing organizer of this group");
     }
     await this.groupRepo.transferOwnership(groupId, toUserId);
+    logEvent("group.ownership_transferred", {
+      groupId,
+      fromUserId,
+      toUserId,
+    });
   }
 
   // --- Invites -----------------------------------------------------------
@@ -366,6 +385,21 @@ export class GroupService {
       }
     } else if (matchIds.size > 1) {
       ambiguousRosterMatches = matchIds.size;
+    }
+
+    logEvent("invite.accepted", {
+      groupId: invite.groupId,
+      userId: params.userId,
+      inviteId: invite.id,
+      newMembership: addedNewMembership,
+    });
+    if (claimedRosterId) {
+      logEvent("ghost.claimed", {
+        groupId: invite.groupId,
+        userId: params.userId,
+        rosterId: claimedRosterId,
+        inviteId: invite.id,
+      });
     }
 
     return {


### PR DESCRIPTION
## Summary

Part 2 of 2 for Phase 5. Stacked on [PR #46](https://github.com/ignaguri/football-with-friends/pull/46) (Phase 5a) — base will auto-retarget to \`feat/group-scoping\` once 5a merges.

### Observability

Structured JSON logs on four domain events in \`GroupService\`:

| Event | Payload |
|---|---|
| \`group.created\` | \`groupId\`, \`ownerUserId\`, \`name\`, \`slug\` |
| \`invite.accepted\` | \`groupId\`, \`userId\`, \`inviteId\`, \`newMembership\` |
| \`ghost.claimed\` | \`groupId\`, \`userId\`, \`rosterId\`, \`inviteId\` |
| \`group.ownership_transferred\` | \`groupId\`, \`fromUserId\`, \`toUserId\` |

Each line is a single JSON object with \`event\`, the contextual fields, and \`ts\`. Cloudflare Workers indexes on top-level JSON fields, so these are queryable in Observability without extra config.

### Documentation

- **\`CLAUDE.md\`** — new "Group-oriented Scoping" section: platform roles (\`user\`/\`superadmin\`) + group-relative roles (\`organizer\`/\`member\`), ownership semantics, \`X-Group-Id\` header, \`group-context.ts\` / \`authz.ts\` middleware helpers, ghost-roster pointer, \`match_invitations\` deprecation, observability pointer.
- **\`docs/phone-auth-password-as-otp.md\`** — appended a section on how the \`user.phoneNumber\` column this pattern populates is also the key that drives phone-shortcut invites and ghost auto-claim on invite accept.
- **\`match_invitations\`**: audited usage — only GDPR cleanup in \`profile.ts\` touches it; no routes, no UI. Treated as deprecated in \`CLAUDE.md\` (no schema/repo rip-out in this PR — leaving for a dedicated migration).

### Empty / error states

- **\`NoGroupOnboarding\`** (0-groups state) — adds an icon, a one-line explainer of what groups are, and a **Sign out** button so users with zero groups aren't trapped in a passive screen with no escape hatch.
- **\`/join/<token>\`** — \`loadError\` and \`invalid\` terminal branches now include a **Back to home** button. Previously these were dead ends.

### i18n consistency sweep

- **723 EN keys / 726 ES keys / 0 missing in ES** — full parity on translation coverage. 3 orphan keys in ES (\`nav.home\`, \`playerDrawer.status\`, \`playerDrawer.actions\`) are dead (no consumers) but left in place — cleanup is cosmetic churn.
- 17 "identical value" matches between EN and ES — all legitimate: English loanwords used in both locales (\`Social\`, \`Admin\`, \`Rankings\`, \`Multimedia\`), format strings (\`#{{rank}}\`, \`Error: {message}\`), example values (\`+49 151 234 5678\` placeholder).
- **Native-speaker review** of Phase 2–4 strings is genuinely a human task (you're the native ES speaker) — not something to auto-translate. This PR did a mechanical coverage + consistency check; any per-string tuning is for you to apply directly.

## Test plan

- [ ] \`wrangler tail\` (staging) during an invite accept → verify \`invite.accepted\` JSON line appears; if a ghost was claimed, \`ghost.claimed\` follows.
- [ ] Superadmin creates a group → verify \`group.created\` in logs.
- [ ] Owner transfers ownership → verify \`group.ownership_transferred\`.
- [ ] Sign in as a user with no group memberships → see the new onboarding UI (icon + hint + Sign out). Tap Sign out → redirects to \`/(auth)\`.
- [ ] Open \`/join/<bad-token>\` → "Back to home" CTA navigates to \`/(tabs)\`.
- [ ] Read \`CLAUDE.md\` "Group-oriented Scoping" section cold — confirm an engineer new to the repo could answer "how is authorization structured?" from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)