### PR TITLE
feat(notifications): custom permission UX + per-category preferences

### DIFF
--- a/apps/api/src/api-routes.ts
+++ b/apps/api/src/api-routes.ts
@@ -14,6 +14,7 @@ import votingRoute from "./routes/voting";
 import rankingsRoute from "./routes/rankings";
 import pushTokensRoute from "./routes/push-tokens";
 import notificationsRoute from "./routes/notifications";
+import notificationPreferencesRoute from "./routes/notification-preferences";
 import matchMediaRoute from "./routes/match-media";
 import invitesRoute from "./routes/invites";
 
@@ -33,6 +34,7 @@ export function registerApiRoutes(app: Hono<any>) {
     .route("/voting", votingRoute)
     .route("/push-tokens", pushTokensRoute)
     .route("/notifications", notificationsRoute)
+    .route("/notification-preferences", notificationPreferencesRoute)
     .route("/match-media", matchMediaRoute)
     .route("/invites", invitesRoute);
 }

--- a/apps/api/src/cron/send-match-reminders.ts
+++ b/apps/api/src/cron/send-match-reminders.ts
@@ -54,6 +54,7 @@ export async function sendMatchReminders() {
         await notificationService.sendToUsers(
           userIds,
           NotificationTemplates.matchReminder(info),
+          { category: "match_reminder" },
         );
         totalSent += userIds.length;
       }

--- a/apps/api/src/lib/notify.ts
+++ b/apps/api/src/lib/notify.ts
@@ -55,7 +55,11 @@ export async function notifyMatchCreated(match: Match, excludeUserId: string): P
       toMatchInfo(match),
     ]);
     if (userIds.length === 0) return;
-    await getNotificationService().sendToUsers(userIds, NotificationTemplates.matchCreated(info));
+    await getNotificationService().sendToUsers(
+      userIds,
+      NotificationTemplates.matchCreated(info),
+      { category: "new_match" },
+    );
   });
 }
 
@@ -91,7 +95,11 @@ export async function notifyPlayerConfirmed(match: Match, userId: string): Promi
 export async function notifySubstitutePromoted(match: Match, userId: string): Promise<void> {
   await safeNotify("substitute promoted", async () => {
     const info = await toMatchInfo(match);
-    await getNotificationService().sendToUser(userId, NotificationTemplates.substitutePromoted(info));
+    await getNotificationService().sendToUser(
+      userId,
+      NotificationTemplates.substitutePromoted(info),
+      { category: "promo_to_confirmed" },
+    );
   });
 }
 

--- a/apps/api/src/routes/notification-preferences.ts
+++ b/apps/api/src/routes/notification-preferences.ts
@@ -1,0 +1,101 @@
+import { zValidator } from "@hono/zod-validator";
+import { getDatabase } from "@repo/shared/database";
+import {
+  type NotificationPreferences,
+  NOTIFICATION_PREF_TO_COLUMN,
+} from "@repo/shared/domain";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { type AppVariables, requireUser } from "../middleware/security";
+
+const app = new Hono<{ Variables: AppVariables }>();
+
+const DEFAULT_PREFS: NotificationPreferences = {
+  pushEnabled: true,
+  pushNewMatch: true,
+  pushMatchReminder: true,
+  pushPromoToConfirmed: true,
+};
+
+function rowToResponse(row: {
+  push_enabled: number;
+  push_new_match: number;
+  push_match_reminder: number;
+  push_promo_to_confirmed: number;
+}): NotificationPreferences {
+  return {
+    pushEnabled: Boolean(row.push_enabled),
+    pushNewMatch: Boolean(row.push_new_match),
+    pushMatchReminder: Boolean(row.push_match_reminder),
+    pushPromoToConfirmed: Boolean(row.push_promo_to_confirmed),
+  };
+}
+
+app.get("/", async (c) => {
+  const user = requireUser(c);
+  const row = await getDatabase()
+    .selectFrom("user_notification_prefs")
+    .selectAll()
+    .where("user_id", "=", user.id)
+    .executeTakeFirst();
+
+  if (!row) return c.json(DEFAULT_PREFS);
+  return c.json(rowToResponse(row));
+});
+
+const patchSchema = z
+  .object({
+    pushEnabled: z.boolean().optional(),
+    pushNewMatch: z.boolean().optional(),
+    pushMatchReminder: z.boolean().optional(),
+    pushPromoToConfirmed: z.boolean().optional(),
+  })
+  .refine((v) => Object.values(v).some((x) => x !== undefined), {
+    message: "At least one preference must be provided",
+  });
+
+app.patch("/", zValidator("json", patchSchema), async (c) => {
+  const user = requireUser(c);
+  const updates = c.req.valid("json");
+  const now = new Date().toISOString();
+
+  // Build the column-level patch from the camelCase payload. Insert defaults
+  // every column to "on"; update only the columns the user actually changed —
+  // a single round trip and atomic per row.
+  const columnUpdates: Record<string, number> = {};
+  for (const [key, value] of Object.entries(updates) as [
+    keyof NotificationPreferences,
+    boolean | undefined,
+  ][]) {
+    if (value === undefined) continue;
+    columnUpdates[NOTIFICATION_PREF_TO_COLUMN[key]] = value ? 1 : 0;
+  }
+
+  const db = getDatabase();
+  await db
+    .insertInto("user_notification_prefs")
+    .values({
+      user_id: user.id,
+      push_enabled: 1,
+      push_new_match: 1,
+      push_match_reminder: 1,
+      push_promo_to_confirmed: 1,
+      updated_at: now,
+      ...columnUpdates,
+    })
+    .onConflict((oc) =>
+      oc.column("user_id").doUpdateSet({ ...columnUpdates, updated_at: now }),
+    )
+    .execute();
+
+  const row = await db
+    .selectFrom("user_notification_prefs")
+    .selectAll()
+    .where("user_id", "=", user.id)
+    .executeTakeFirstOrThrow();
+
+  return c.json(rowToResponse(row));
+});
+
+export default app;

--- a/apps/mobile-web/app/(tabs)/_layout.tsx
+++ b/apps/mobile-web/app/(tabs)/_layout.tsx
@@ -2,6 +2,7 @@
 import { useCurrentGroup, useSession } from "@repo/api-client";
 import { GroupSwitcher } from "../../components/group-switcher";
 import { NoGroupOnboarding } from "../../components/no-group-onboarding";
+import { NotificationPreferencesProvider } from "../../lib/notifications/notification-preferences-context";
 import { usePushNotifications } from "../../lib/use-push-notifications";
 import {
   Home,
@@ -52,6 +53,7 @@ export default function TabsLayout() {
   const isAdmin = isPlatformAdmin || myRole === "organizer";
 
   return (
+    <NotificationPreferencesProvider>
     <YStack flex={1}>
       <GroupSwitcher />
       <Tabs
@@ -137,5 +139,6 @@ export default function TabsLayout() {
       />
       </Tabs>
     </YStack>
+    </NotificationPreferencesProvider>
   );
 }

--- a/apps/mobile-web/app/(tabs)/index.tsx
+++ b/apps/mobile-web/app/(tabs)/index.tsx
@@ -14,9 +14,13 @@ import {
 import { Calendar, Trophy, CircleUserRound } from "@tamagui/lucide-icons";
 import { router } from "expo-router";
 import { Stack } from "expo-router";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Platform } from "react-native";
 import { useTheme } from "tamagui";
 
+import { NotificationPermissionPrompt } from "../../components/notifications/notification-permission-prompt";
+import { useNotificationPreferencesContext } from "../../lib/notifications/notification-preferences-context";
 import { useRulesModal } from "../../lib/rules-modal-context";
 
 export default function HomeScreen() {
@@ -24,6 +28,17 @@ export default function HomeScreen() {
   const { t } = useTranslation();
   const theme = useTheme();
   const { showModal, dismissModal, dismissPermanently } = useRulesModal();
+
+  const notif = useNotificationPreferencesContext();
+  const [notifPromptOpen, setNotifPromptOpen] = useState(false);
+  useEffect(() => {
+    if (Platform.OS === "web") return;
+    if (!session?.user) return;
+    if (notif.isLoading) return;
+    if (notif.hasShownPrompt) return;
+    if (notif.osStatus !== "undetermined") return;
+    setNotifPromptOpen(true);
+  }, [session?.user, notif.isLoading, notif.hasShownPrompt, notif.osStatus]);
 
   const isAuthenticated = !!session?.user;
 
@@ -168,6 +183,13 @@ export default function HomeScreen() {
           </YStack>
         </YStack>
       </Dialog>
+
+      {Platform.OS !== "web" && (
+        <NotificationPermissionPrompt
+          open={notifPromptOpen}
+          onClose={() => setNotifPromptOpen(false)}
+        />
+      )}
     </>
   );
 }

--- a/apps/mobile-web/app/(tabs)/profile/_layout.tsx
+++ b/apps/mobile-web/app/(tabs)/profile/_layout.tsx
@@ -41,6 +41,14 @@ export default function ProfileLayout() {
           title: t("groups.detail.title"),
         }}
       />
+      <Stack.Screen
+        name="notifications"
+        options={{
+          title: t("notifications.settings.entry"),
+          headerBackTitle: "",
+          headerBackButtonDisplayMode: "minimal",
+        }}
+      />
     </Stack>
   );
 }

--- a/apps/mobile-web/app/(tabs)/profile/index.tsx
+++ b/apps/mobile-web/app/(tabs)/profile/index.tsx
@@ -25,7 +25,7 @@ import {
   getCountryFlag,
   getCountryName,
 } from "@repo/ui";
-import { Camera } from "@tamagui/lucide-icons";
+import { Bell, Camera, ChevronRight } from "@tamagui/lucide-icons";
 import * as ImagePicker from "expo-image-picker";
 import { Link, router, Stack } from "expo-router";
 import { useState, useEffect } from "react";
@@ -587,6 +587,27 @@ export default function ProfileScreen() {
                 <Text color="$gray11">{t("shared.toggleTheme")}</Text>
                 <ThemeToggle theme={theme} onToggle={toggleTheme} />
               </XStack>
+
+              {/* Notifications entry */}
+              <Button
+                variant="outline"
+                onPress={() => router.push("/(tabs)/profile/notifications")}
+                accessibilityLabel={t("notifications.settings.entry")}
+                testID="profile-notifications-entry"
+                marginTop="$2"
+              >
+                <XStack
+                  flex={1}
+                  alignItems="center"
+                  justifyContent="space-between"
+                >
+                  <XStack gap="$2" alignItems="center">
+                    <Bell size={18} color="$gray11" />
+                    <Text>{t("notifications.settings.entry")}</Text>
+                  </XStack>
+                  <ChevronRight size={18} color="$gray10" />
+                </XStack>
+              </Button>
 
               {/* Change Password Section */}
               {isChangingPassword ? (

--- a/apps/mobile-web/app/(tabs)/profile/index.tsx
+++ b/apps/mobile-web/app/(tabs)/profile/index.tsx
@@ -588,26 +588,27 @@ export default function ProfileScreen() {
                 <ThemeToggle theme={theme} onToggle={toggleTheme} />
               </XStack>
 
-              {/* Notifications entry */}
-              <Button
-                variant="outline"
-                onPress={() => router.push("/(tabs)/profile/notifications")}
-                accessibilityLabel={t("notifications.settings.entry")}
-                testID="profile-notifications-entry"
-                marginTop="$2"
-              >
-                <XStack
-                  flex={1}
-                  alignItems="center"
-                  justifyContent="space-between"
+              {/* Notifications entry — push is mobile-only for now */}
+              {Platform.OS !== "web" && (
+                <Button
+                  variant="outline"
+                  onPress={() => router.push("/(tabs)/profile/notifications")}
+                  testID="profile-notifications-entry"
+                  marginTop="$2"
                 >
-                  <XStack gap="$2" alignItems="center">
-                    <Bell size={18} color="$gray11" />
-                    <Text>{t("notifications.settings.entry")}</Text>
+                  <XStack
+                    flex={1}
+                    alignItems="center"
+                    justifyContent="space-between"
+                  >
+                    <XStack gap="$2" alignItems="center">
+                      <Bell size={18} color="$gray11" />
+                      <Text>{t("notifications.settings.entry")}</Text>
+                    </XStack>
+                    <ChevronRight size={18} color="$gray10" />
                   </XStack>
-                  <ChevronRight size={18} color="$gray10" />
-                </XStack>
-              </Button>
+                </Button>
+              )}
 
               {/* Change Password Section */}
               {isChangingPassword ? (

--- a/apps/mobile-web/app/(tabs)/profile/notifications.tsx
+++ b/apps/mobile-web/app/(tabs)/profile/notifications.tsx
@@ -1,0 +1,216 @@
+// @ts-nocheck - Tamagui type recursion workaround
+
+import { Card, Container, Text } from "@repo/ui";
+import { Settings } from "@tamagui/lucide-icons";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Linking, Platform, ScrollView } from "react-native";
+import { Spinner, Switch, XStack, YStack } from "tamagui";
+
+import { NotificationPermissionPrompt } from "../../../components/notifications/notification-permission-prompt";
+import {
+  type NotificationCategoryKey,
+  useNotificationPreferencesContext,
+} from "../../../lib/notifications/notification-preferences-context";
+
+const CATEGORIES: {
+  key: NotificationCategoryKey;
+  i18nKey: string;
+  testID: string;
+}[] = [
+  {
+    key: "pushNewMatch",
+    i18nKey: "newMatch",
+    testID: "profile-notifications-toggle-new-match",
+  },
+  {
+    key: "pushMatchReminder",
+    i18nKey: "matchReminder",
+    testID: "profile-notifications-toggle-match-reminder",
+  },
+  {
+    key: "pushPromoToConfirmed",
+    i18nKey: "promoToConfirmed",
+    testID: "profile-notifications-toggle-promo",
+  },
+];
+
+export default function NotificationsScreen() {
+  const { t } = useTranslation();
+  const notif = useNotificationPreferencesContext();
+  const [promptOpen, setPromptOpen] = useState(false);
+
+  if (Platform.OS === "web") {
+    return (
+      <Container variant="padded">
+        <YStack gap="$4">
+          <Text fontSize="$5" fontWeight="600">
+            {t("notifications.settings.entry")}
+          </Text>
+          <Text color="$gray11">{t("notifications.unsupportedWeb")}</Text>
+        </YStack>
+      </Container>
+    );
+  }
+
+  if (notif.isLoading) {
+    return (
+      <Container variant="centered">
+        <Spinner size="large" />
+      </Container>
+    );
+  }
+
+  const masterOn = notif.effectivelyEnabled;
+  const categoriesDisabled = !masterOn;
+
+  async function handleMasterToggle(value: boolean) {
+    if (!value) {
+      await notif.disableMaster();
+      return;
+    }
+    if (notif.osStatus === "undetermined") {
+      setPromptOpen(true);
+      return;
+    }
+    if (notif.osStatus === "denied") {
+      Linking.openSettings();
+      return;
+    }
+    await notif.enableMaster();
+  }
+
+  return (
+    <Container>
+      <ScrollView>
+        <YStack padding="$4" gap="$4">
+          <Card variant="outlined">
+            <YStack gap="$3">
+              <Text fontSize="$5" fontWeight="600">
+                {t("notifications.settings.master")}
+              </Text>
+              <Text fontSize="$3" color="$gray11">
+                {t("notifications.settings.masterHint")}
+              </Text>
+
+              <XStack
+                justifyContent="space-between"
+                alignItems="center"
+                marginTop="$2"
+              >
+                <Text color="$gray11">
+                  {t("notifications.settings.masterLabel")}
+                </Text>
+                <Switch
+                  checked={masterOn}
+                  onCheckedChange={handleMasterToggle}
+                  size="$3"
+                  testID="profile-notifications-toggle-master"
+                >
+                  <Switch.Thumb animation="quick" />
+                </Switch>
+              </XStack>
+
+              {notif.osStatus === "denied" && (
+                <YStack
+                  gap="$2"
+                  padding="$3"
+                  borderRadius="$4"
+                  backgroundColor="$yellow3"
+                  borderWidth={1}
+                  borderColor="$yellow7"
+                >
+                  <XStack gap="$2" alignItems="center">
+                    <Settings size={16} color="$yellow11" />
+                    <Text fontSize="$4" fontWeight="600" color="$yellow11">
+                      {t("notifications.denied.title")}
+                    </Text>
+                  </XStack>
+                  <Text fontSize="$3" color="$yellow11">
+                    {t("notifications.denied.body")}
+                  </Text>
+                  <Text
+                    fontSize="$3"
+                    fontWeight="600"
+                    color="$blue10"
+                    onPress={() => Linking.openSettings()}
+                    accessibilityRole="link"
+                    testID="profile-notifications-open-settings"
+                  >
+                    {t("notifications.denied.openSettings")}
+                  </Text>
+                </YStack>
+              )}
+            </YStack>
+          </Card>
+
+          <Card variant="outlined">
+            <YStack gap="$3">
+              <Text fontSize="$5" fontWeight="600">
+                {t("notifications.settings.categoriesTitle")}
+              </Text>
+
+              {CATEGORIES.map(({ key, i18nKey, testID }) => (
+                <CategoryRow
+                  key={key}
+                  label={t(`notifications.categories.${i18nKey}`)}
+                  hint={t(`notifications.categories.${i18nKey}Hint`)}
+                  checked={Boolean(notif.prefs?.[key])}
+                  disabled={categoriesDisabled}
+                  onChange={(v) => notif.setCategory(key, v)}
+                  testID={testID}
+                />
+              ))}
+            </YStack>
+          </Card>
+        </YStack>
+      </ScrollView>
+
+      <NotificationPermissionPrompt
+        open={promptOpen}
+        onClose={() => setPromptOpen(false)}
+      />
+    </Container>
+  );
+}
+
+function CategoryRow({
+  label,
+  hint,
+  checked,
+  disabled,
+  onChange,
+  testID,
+}: {
+  label: string;
+  hint: string;
+  checked: boolean;
+  disabled: boolean;
+  onChange: (v: boolean) => void;
+  testID: string;
+}) {
+  return (
+    <XStack
+      justifyContent="space-between"
+      alignItems="center"
+      gap="$3"
+      opacity={disabled ? 0.5 : 1}
+    >
+      <YStack flex={1} gap="$1">
+        <Text color="$gray12">{label}</Text>
+        <Text fontSize="$2" color="$gray10">
+          {hint}
+        </Text>
+      </YStack>
+      <Switch
+        checked={checked}
+        onCheckedChange={onChange}
+        disabled={disabled}
+        size="$3"
+        testID={testID}
+      >
+        <Switch.Thumb animation="quick" />
+      </Switch>
+    </XStack>
+  );
+}

--- a/apps/mobile-web/app/(tabs)/profile/notifications.tsx
+++ b/apps/mobile-web/app/(tabs)/profile/notifications.tsx
@@ -73,10 +73,6 @@ export default function NotificationsScreen() {
       setPromptOpen(true);
       return;
     }
-    if (notif.osStatus === "denied") {
-      Linking.openSettings();
-      return;
-    }
     await notif.enableMaster();
   }
 
@@ -104,6 +100,7 @@ export default function NotificationsScreen() {
                 <Switch
                   checked={masterOn}
                   onCheckedChange={handleMasterToggle}
+                  disabled={notif.osStatus === "denied"}
                   size="$3"
                   testID="profile-notifications-toggle-master"
                 >

--- a/apps/mobile-web/components/notifications/notification-permission-prompt.tsx
+++ b/apps/mobile-web/components/notifications/notification-permission-prompt.tsx
@@ -1,0 +1,152 @@
+// @ts-nocheck - Tamagui type recursion workaround
+
+import { Bell, CalendarPlus, Clock, UserCheck } from "@tamagui/lucide-icons";
+import { Button, Dialog } from "@repo/ui";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Alert } from "react-native";
+import { Spinner, Text, XStack, YStack } from "tamagui";
+
+import { useNotificationPreferencesContext } from "../../lib/notifications/notification-preferences-context";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const BENEFITS: { Icon: typeof Bell; i18nKey: string }[] = [
+  { Icon: CalendarPlus, i18nKey: "newMatch" },
+  { Icon: Clock, i18nKey: "matchReminder" },
+  { Icon: UserCheck, i18nKey: "promoToConfirmed" },
+];
+
+export function NotificationPermissionPrompt({ open, onClose }: Props) {
+  const { t } = useTranslation();
+  const { enableMaster, markPromptShown } = useNotificationPreferencesContext();
+  const [isWorking, setIsWorking] = useState(false);
+
+  async function handleEnable() {
+    setIsWorking(true);
+    try {
+      const { status } = await enableMaster();
+      await markPromptShown();
+      onClose();
+      if (status === "denied") {
+        Alert.alert(
+          t("notifications.denied.title"),
+          t("notifications.denied.body"),
+        );
+      }
+    } catch (e) {
+      console.error("Failed to enable notifications:", e);
+      Alert.alert(
+        t("notifications.errors.generic"),
+        e instanceof Error ? e.message : "",
+      );
+    } finally {
+      setIsWorking(false);
+    }
+  }
+
+  async function handleSkip() {
+    await markPromptShown();
+    onClose();
+  }
+
+  return (
+    <Dialog
+      modal
+      open={open}
+      onOpenChange={(v) => !v && handleSkip()}
+      showActions={false}
+      showClose={false}
+    >
+      <YStack alignItems="center" gap="$3">
+        <YStack
+          width={64}
+          height={64}
+          borderRadius="$10"
+          backgroundColor="$blue4"
+          justifyContent="center"
+          alignItems="center"
+        >
+          <Bell size={32} color="$blue10" />
+        </YStack>
+        <Text fontSize="$7" fontWeight="700" textAlign="center">
+          {t("notifications.prompt.title")}
+        </Text>
+        <Text fontSize="$4" color="$gray11" textAlign="center">
+          {t("notifications.prompt.body")}
+        </Text>
+      </YStack>
+
+      <YStack gap="$3" marginVertical="$2">
+        {BENEFITS.map(({ Icon, i18nKey }) => (
+          <Benefit
+            key={i18nKey}
+            Icon={Icon}
+            title={t(`notifications.prompt.benefits.${i18nKey}.title`)}
+            body={t(`notifications.prompt.benefits.${i18nKey}.body`)}
+          />
+        ))}
+      </YStack>
+
+      <YStack gap="$2">
+        <Button
+          variant="primary"
+          size="$5"
+          onPress={handleEnable}
+          disabled={isWorking}
+          testID="notification-prompt-enable"
+        >
+          {isWorking ? (
+            <Spinner size="small" />
+          ) : (
+            t("notifications.prompt.enable")
+          )}
+        </Button>
+        <Button
+          variant="ghost"
+          onPress={handleSkip}
+          disabled={isWorking}
+          testID="notification-prompt-skip"
+        >
+          {t("notifications.prompt.later")}
+        </Button>
+      </YStack>
+    </Dialog>
+  );
+}
+
+function Benefit({
+  Icon,
+  title,
+  body,
+}: {
+  Icon: typeof Bell;
+  title: string;
+  body: string;
+}) {
+  return (
+    <XStack gap="$3" alignItems="flex-start">
+      <YStack
+        width={36}
+        height={36}
+        borderRadius="$4"
+        backgroundColor="$gray3"
+        justifyContent="center"
+        alignItems="center"
+      >
+        <Icon size={20} color="$gray11" />
+      </YStack>
+      <YStack flex={1} gap="$1">
+        <Text fontSize="$4" fontWeight="600">
+          {title}
+        </Text>
+        <Text fontSize="$3" color="$gray11">
+          {body}
+        </Text>
+      </YStack>
+    </XStack>
+  );
+}

--- a/apps/mobile-web/components/notifications/notification-permission-prompt.tsx
+++ b/apps/mobile-web/components/notifications/notification-permission-prompt.tsx
@@ -57,7 +57,9 @@ export function NotificationPermissionPrompt({ open, onClose }: Props) {
     <Dialog
       modal
       open={open}
-      onOpenChange={(v) => !v && handleSkip()}
+      onOpenChange={(v) => {
+        if (!v) void handleSkip();
+      }}
       showActions={false}
       showClose={false}
     >

--- a/apps/mobile-web/lib/notifications/notification-preferences-context.tsx
+++ b/apps/mobile-web/lib/notifications/notification-preferences-context.tsx
@@ -86,13 +86,17 @@ export function NotificationPreferencesProvider({
     Promise.all([
       getOsPermissionStatus(),
       AsyncStorage.getItem(PROMPT_SHOWN_KEY),
-    ]).then(([status, shown]) => {
-      setOsStatus(status);
-      setHasShownPrompt(shown === "1");
-    });
+    ])
+      .then(([status, shown]) => {
+        setOsStatus(status);
+        setHasShownPrompt(shown === "1");
+      })
+      .catch(() => {
+        // Init failure is non-fatal — keep defaults and try again on next mount/foreground.
+      });
 
     const sub = AppState.addEventListener("change", (state) => {
-      if (state === "active") refreshOsStatus();
+      if (state === "active") void refreshOsStatus().catch(() => {});
     });
     return () => sub.remove();
   }, [refreshOsStatus]);

--- a/apps/mobile-web/lib/notifications/notification-preferences-context.tsx
+++ b/apps/mobile-web/lib/notifications/notification-preferences-context.tsx
@@ -1,0 +1,179 @@
+// @ts-nocheck - Tamagui type recursion workaround
+
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { AppState, Platform } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {
+  type NotificationPreferences,
+  type NotificationPreferencesUpdate,
+  useNotificationPreferences,
+  useUpdateNotificationPreferences,
+  useSession,
+} from "@repo/api-client";
+
+import {
+  type OsPermissionStatus,
+  getOsPermissionStatus,
+  requestAndRegister,
+} from "../use-push-notifications";
+
+const PROMPT_SHOWN_KEY = "notif-prompt-shown-v1";
+
+export type NotificationCategoryKey =
+  | "pushNewMatch"
+  | "pushMatchReminder"
+  | "pushPromoToConfirmed";
+
+interface NotificationPreferencesContextValue {
+  osStatus: OsPermissionStatus;
+  prefs: NotificationPreferences | undefined;
+  isLoading: boolean;
+  hasShownPrompt: boolean;
+  /** True when both OS perm is granted and master push_enabled is on. */
+  effectivelyEnabled: boolean;
+  refreshOsStatus: () => Promise<void>;
+  /** Record that the user saw the pitch — regardless of accept/skip. */
+  markPromptShown: () => Promise<void>;
+  /**
+   * Run the OS permission request, register the token, and flip backend
+   * push_enabled to true. Throws on failure so callers can show an error.
+   */
+  enableMaster: () => Promise<{ status: OsPermissionStatus }>;
+  /** Just flip backend push_enabled to false. Leaves OS permission and token alone. */
+  disableMaster: () => Promise<void>;
+  /** Set a single per-category preference. */
+  setCategory: (category: NotificationCategoryKey, value: boolean) => Promise<void>;
+}
+
+const NotificationPreferencesContext =
+  createContext<NotificationPreferencesContextValue | null>(null);
+
+export function NotificationPreferencesProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const { data: session } = useSession();
+  const isAuthed = Boolean(session?.user);
+
+  const [osStatus, setOsStatus] = useState<OsPermissionStatus>(
+    Platform.OS === "web" ? "unsupported" : "undetermined",
+  );
+  const [hasShownPrompt, setHasShownPrompt] = useState(false);
+
+  const prefsQuery = useNotificationPreferences();
+  const updateMutation = useUpdateNotificationPreferences();
+
+  const refreshOsStatus = useCallback(async () => {
+    const next = await getOsPermissionStatus();
+    setOsStatus((prev) => (prev === next ? prev : next));
+  }, []);
+
+  // Native only: read OS state + prompt-shown flag in parallel and reconcile
+  // OS state on every foreground. Web has no expo-notifications module and
+  // no AppState concept worth reacting to.
+  useEffect(() => {
+    if (Platform.OS === "web") return;
+
+    Promise.all([
+      getOsPermissionStatus(),
+      AsyncStorage.getItem(PROMPT_SHOWN_KEY),
+    ]).then(([status, shown]) => {
+      setOsStatus(status);
+      setHasShownPrompt(shown === "1");
+    });
+
+    const sub = AppState.addEventListener("change", (state) => {
+      if (state === "active") refreshOsStatus();
+    });
+    return () => sub.remove();
+  }, [refreshOsStatus]);
+
+  const markPromptShown = useCallback(async () => {
+    setHasShownPrompt(true);
+    await AsyncStorage.setItem(PROMPT_SHOWN_KEY, "1");
+  }, []);
+
+  const patch = useCallback(
+    async (update: NotificationPreferencesUpdate) => {
+      await updateMutation.mutateAsync(update);
+    },
+    [updateMutation],
+  );
+
+  const enableMaster = useCallback(async () => {
+    const result = await requestAndRegister();
+    setOsStatus((prev) => (prev === result.status ? prev : result.status));
+    if (result.status === "granted") {
+      // Even if APNs gave us no token (simulator), the backend toggle still
+      // makes sense — a real device on the same account will receive.
+      await patch({ pushEnabled: true });
+    }
+    return { status: result.status };
+  }, [patch]);
+
+  const disableMaster = useCallback(async () => {
+    await patch({ pushEnabled: false });
+  }, [patch]);
+
+  const setCategory = useCallback(
+    async (category: NotificationCategoryKey, value: boolean) => {
+      await patch({ [category]: value } as NotificationPreferencesUpdate);
+    },
+    [patch],
+  );
+
+  const effectivelyEnabled =
+    osStatus === "granted" && Boolean(prefsQuery.data?.pushEnabled);
+
+  const value = useMemo<NotificationPreferencesContextValue>(
+    () => ({
+      osStatus,
+      prefs: prefsQuery.data,
+      isLoading: !isAuthed || prefsQuery.isLoading,
+      hasShownPrompt,
+      effectivelyEnabled,
+      refreshOsStatus,
+      markPromptShown,
+      enableMaster,
+      disableMaster,
+      setCategory,
+    }),
+    [
+      osStatus,
+      prefsQuery.data,
+      prefsQuery.isLoading,
+      isAuthed,
+      hasShownPrompt,
+      refreshOsStatus,
+      markPromptShown,
+      enableMaster,
+      disableMaster,
+      setCategory,
+    ],
+  );
+
+  return (
+    <NotificationPreferencesContext.Provider value={value}>
+      {children}
+    </NotificationPreferencesContext.Provider>
+  );
+}
+
+export function useNotificationPreferencesContext() {
+  const ctx = useContext(NotificationPreferencesContext);
+  if (!ctx) {
+    throw new Error(
+      "useNotificationPreferencesContext must be used within a NotificationPreferencesProvider",
+    );
+  }
+  return ctx;
+}

--- a/apps/mobile-web/lib/use-push-notifications.ts
+++ b/apps/mobile-web/lib/use-push-notifications.ts
@@ -4,9 +4,16 @@ import { router } from "expo-router";
 import { useSession } from "@repo/api-client";
 import { api } from "@repo/api-client";
 
-// Store the last registered token so we can unregister on logout
+// Tracks the token registered by this session so we can deactivate it on
+// sign-out / account deletion. Set after a successful POST /push-tokens.
 let _lastRegisteredToken: string | null = null;
 let _notificationsConfigured = false;
+
+export type OsPermissionStatus =
+  | "granted"
+  | "denied"
+  | "undetermined"
+  | "unsupported";
 
 /**
  * Lazily load expo-notifications to avoid crashing on builds
@@ -38,18 +45,44 @@ async function configureNotificationHandler() {
   });
 }
 
-async function registerForPushNotifications(): Promise<string | null> {
-  // Skip on web — web push will be added later
-  if (Platform.OS === "web") return null;
+/**
+ * Read the current OS-level permission status without prompting. Safe to call
+ * on every mount — used by the preferences provider to reconcile UI state with
+ * the device.
+ */
+export async function getOsPermissionStatus(): Promise<OsPermissionStatus> {
+  if (Platform.OS === "web") return "unsupported";
+  const Notifications = await getNotificationsModule();
+  if (!Notifications) return "unsupported";
+
+  const { status } = await Notifications.getPermissionsAsync();
+  if (status === "granted") return "granted";
+  if (status === "denied") return "denied";
+  return "undetermined";
+}
+
+/**
+ * Trigger the native permission prompt (if not already decided), fetch the
+ * Expo push token, and register it with the backend. Caller is responsible
+ * for deciding *when* this runs — we never call it implicitly from a hook.
+ *
+ * Returns the OS status after the prompt and the token (null if denied or if
+ * APNs is unavailable, e.g. on the iOS simulator).
+ */
+export async function requestAndRegister(): Promise<{
+  status: OsPermissionStatus;
+  token: string | null;
+}> {
+  if (Platform.OS === "web") return { status: "unsupported", token: null };
 
   const Notifications = await getNotificationsModule();
-  if (!Notifications) return null;
+  if (!Notifications) return { status: "unsupported", token: null };
 
   const Constants = (await import("expo-constants")).default;
 
   const { status: existingStatus } =
     await Notifications.getPermissionsAsync();
-  let finalStatus = existingStatus;
+  let finalStatus: string = existingStatus;
 
   if (existingStatus !== "granted") {
     const { status } = await Notifications.requestPermissionsAsync();
@@ -57,65 +90,60 @@ async function registerForPushNotifications(): Promise<string | null> {
   }
 
   if (finalStatus !== "granted") {
-    console.log("Push notification permissions not granted");
-    return null;
+    return { status: finalStatus === "denied" ? "denied" : "undetermined", token: null };
   }
 
   const projectId =
     Constants.expoConfig?.extra?.eas?.projectId ??
     "fd683dbc-22ce-4809-b0be-8325693cd621";
 
+  let token: string | null = null;
   try {
     const tokenData = await Notifications.getExpoPushTokenAsync({ projectId });
-    return tokenData.data;
+    token = tokenData.data;
   } catch (error) {
-    // APNs is not available on the simulator — this is expected
+    // APNs is not available on the simulator — expected in dev.
     console.log("Could not get push token:", error);
-    return null;
   }
+
+  if (token) {
+    try {
+      await api.api["push-tokens"].$post({
+        json: {
+          token,
+          platform: Platform.OS as "ios" | "android",
+        },
+      });
+      _lastRegisteredToken = token;
+    } catch (error) {
+      console.error("Failed to register push token:", error);
+      // Keep token but don't mark as registered — caller surfaces the failure.
+    }
+  }
+
+  return { status: "granted", token };
 }
 
+/**
+ * Configures the foreground notification handler and attaches in-app
+ * listeners for received notifications and tap-throughs. **Does not** request
+ * permission or fetch a token — that's the responsibility of the
+ * NotificationPreferencesProvider, which decides when to show the
+ * pre-permission modal.
+ */
 export function usePushNotifications() {
   const { data: session } = useSession();
-  const registeredForUserRef = useRef<string | null>(null);
+  const listenersAttachedRef = useRef(false);
   const listenersRef = useRef<{ remove: () => void }[]>([]);
 
   useEffect(() => {
-    // Skip on web
     if (Platform.OS === "web") return;
+    if (!session?.user) return;
+    if (listenersAttachedRef.current) return;
+    listenersAttachedRef.current = true;
 
-    // Reset when user changes (logout/login as different user)
-    if (!session?.user) {
-      registeredForUserRef.current = null;
-      return;
-    }
-
-    // Only register once per user
-    if (registeredForUserRef.current === session.user.id) return;
-
-    registeredForUserRef.current = session.user.id;
-
-    // Configure handler + register token
     configureNotificationHandler();
 
-    registerForPushNotifications().then(async (token) => {
-      if (!token) return;
-
-      _lastRegisteredToken = token;
-
-      try {
-        await api.api["push-tokens"].$post({
-          json: {
-            token,
-            platform: Platform.OS as "ios" | "android",
-          },
-        });
-      } catch (error) {
-        console.error("Failed to register push token:", error);
-      }
-    });
-
-    // Set up listeners
     getNotificationsModule().then((Notifications) => {
       if (!Notifications) return;
 
@@ -144,6 +172,7 @@ export function usePushNotifications() {
         sub.remove();
       }
       listenersRef.current = [];
+      listenersAttachedRef.current = false;
     };
   }, [session?.user?.id]);
 }
@@ -164,3 +193,4 @@ export async function unregisterPushToken(): Promise<void> {
 
   _lastRegisteredToken = null;
 }
+

--- a/apps/mobile-web/lib/use-push-notifications.ts
+++ b/apps/mobile-web/lib/use-push-notifications.ts
@@ -116,8 +116,9 @@ export async function requestAndRegister(): Promise<{
       });
       _lastRegisteredToken = token;
     } catch (error) {
-      console.error("Failed to register push token:", error);
-      // Keep token but don't mark as registered — caller surfaces the failure.
+      throw error instanceof Error
+        ? error
+        : new Error("Failed to register push token");
     }
   }
 

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -456,6 +456,52 @@
     "openGallery": "Open gallery for {{date}}",
     "uploadMedia": "Upload photo or video"
   },
+  "notifications": {
+    "settings": {
+      "entry": "Notifications",
+      "master": "Push notifications",
+      "masterLabel": "Enabled",
+      "masterHint": "Get pinged for the things you care about. You can change this any time.",
+      "categoriesTitle": "What we'll send you"
+    },
+    "categories": {
+      "newMatch": "New matches",
+      "newMatchHint": "When an organizer schedules a new match in your group.",
+      "matchReminder": "Match reminders",
+      "matchReminderHint": "A heads-up the day before kickoff.",
+      "promoToConfirmed": "Off the waitlist",
+      "promoToConfirmedHint": "When a spot opens up and you're moved off the substitutes list."
+    },
+    "prompt": {
+      "title": "Stay in the loop",
+      "body": "Turn on push notifications so you don't miss a match.",
+      "benefits": {
+        "newMatch": {
+          "title": "New matches in your group",
+          "body": "Be the first to know when an organizer schedules one."
+        },
+        "matchReminder": {
+          "title": "Match-day reminders",
+          "body": "A nudge the day before kickoff — never miss a game."
+        },
+        "promoToConfirmed": {
+          "title": "Off the waitlist",
+          "body": "We'll tell you the moment a spot opens up for you."
+        }
+      },
+      "enable": "Enable notifications",
+      "later": "Maybe later"
+    },
+    "denied": {
+      "title": "Notifications are blocked",
+      "body": "Push notifications are turned off in your system settings. Open them to re-enable.",
+      "openSettings": "Open system settings"
+    },
+    "errors": {
+      "generic": "Couldn't enable notifications. Please try again."
+    },
+    "unsupportedWeb": "Push notifications are only available on the mobile app for now."
+  },
   "status": {
     "paid": "Paid",
     "pending": "Pending",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -459,6 +459,52 @@
     "openGallery": "Abrir galería del {{date}}",
     "uploadMedia": "Subir foto o video"
   },
+  "notifications": {
+    "settings": {
+      "entry": "Notificaciones",
+      "master": "Notificaciones push",
+      "masterLabel": "Activadas",
+      "masterHint": "Recibí avisos sobre lo que te importa. Podés cambiar esto cuando quieras.",
+      "categoriesTitle": "Qué te vamos a mandar"
+    },
+    "categories": {
+      "newMatch": "Partidos nuevos",
+      "newMatchHint": "Cuando un organizador agenda un nuevo partido en tu grupo.",
+      "matchReminder": "Recordatorio del partido",
+      "matchReminderHint": "Un aviso el día antes del partido.",
+      "promoToConfirmed": "Saliste de la lista de espera",
+      "promoToConfirmedHint": "Cuando se libera un lugar y dejás de ser suplente."
+    },
+    "prompt": {
+      "title": "No te pierdas nada",
+      "body": "Activá las notificaciones para no quedarte afuera de ningún partido.",
+      "benefits": {
+        "newMatch": {
+          "title": "Partidos nuevos en tu grupo",
+          "body": "Enterate primero cuando un organizador agenda uno."
+        },
+        "matchReminder": {
+          "title": "Aviso del día anterior",
+          "body": "Te avisamos un día antes para que no te lo olvides."
+        },
+        "promoToConfirmed": {
+          "title": "Saliste de la lista de espera",
+          "body": "Te avisamos en el momento que se libera un lugar para vos."
+        }
+      },
+      "enable": "Activar notificaciones",
+      "later": "Quizás más tarde"
+    },
+    "denied": {
+      "title": "Las notificaciones están bloqueadas",
+      "body": "Las notificaciones push están desactivadas en la configuración de tu sistema. Abrila para volver a activarlas.",
+      "openSettings": "Abrir ajustes del sistema"
+    },
+    "errors": {
+      "generic": "No pudimos activar las notificaciones. Probá de nuevo."
+    },
+    "unsupportedWeb": "Las notificaciones push por ahora solo están disponibles en la app móvil."
+  },
   "status": {
     "paid": "Pagado",
     "pending": "Pendiente",

--- a/migrations/20260428120000-add-user-notification-prefs.ts
+++ b/migrations/20260428120000-add-user-notification-prefs.ts
@@ -1,0 +1,45 @@
+// Migration: add-user-notification-prefs
+// Adds user_notification_prefs table for per-user push notification preferences
+// (master + 3 categories). Absence of a row is treated as "all on" via
+// COALESCE in the read query, so no backfill is required.
+
+import { sql } from "kysely";
+import type { Kysely, Migration } from "kysely";
+
+export const up: Migration["up"] = async (db: Kysely<any>) => {
+  const tableExists = async (table: string) => {
+    const result = await sql<{ name: string }>`
+      SELECT name FROM sqlite_master WHERE type='table' AND name=${table}
+    `.execute(db);
+    return result.rows.length > 0;
+  };
+
+  if (!(await tableExists("user_notification_prefs"))) {
+    await db.schema
+      .createTable("user_notification_prefs")
+      .addColumn("user_id", "text", (col) => col.primaryKey().notNull())
+      .addColumn("push_enabled", "integer", (col) => col.defaultTo(1).notNull())
+      .addColumn("push_new_match", "integer", (col) =>
+        col.defaultTo(1).notNull(),
+      )
+      .addColumn("push_match_reminder", "integer", (col) =>
+        col.defaultTo(1).notNull(),
+      )
+      .addColumn("push_promo_to_confirmed", "integer", (col) =>
+        col.defaultTo(1).notNull(),
+      )
+      .addColumn("updated_at", "text", (col) => col.notNull())
+      .execute();
+
+    console.log("✅ Created user_notification_prefs table");
+  } else {
+    console.log("⏭️  user_notification_prefs table already exists, skipping");
+  }
+
+  console.log("✅ Migration: add-user-notification-prefs completed");
+};
+
+export const down: Migration["down"] = async (db: Kysely<any>) => {
+  await db.schema.dropTable("user_notification_prefs").ifExists().execute();
+  console.log("↩️ Dropped user_notification_prefs table");
+};

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -85,5 +85,15 @@ export type {
   MyGroupSummary,
 } from "./groups";
 
+export {
+  useNotificationPreferences,
+  useUpdateNotificationPreferences,
+  notificationPreferencesQueryKeys,
+} from "./notification-preferences";
+export type {
+  NotificationPreferences,
+  NotificationPreferencesUpdate,
+} from "@repo/shared/domain";
+
 // Re-export the API routes type for convenience
 export type { ApiRoutes } from "../../../apps/api/src/index";

--- a/packages/api-client/src/notification-preferences.ts
+++ b/packages/api-client/src/notification-preferences.ts
@@ -1,0 +1,81 @@
+import type {
+  NotificationPreferences,
+  NotificationPreferencesUpdate,
+} from "@repo/shared/domain";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { useSession } from "./auth";
+import { client as _client } from "./client";
+
+// Same untyped escape hatch as groups.ts — Hono RPC's deep generics resolve
+// as `unknown` across this package boundary.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const client = _client as any;
+
+export type { NotificationPreferences, NotificationPreferencesUpdate };
+
+export const notificationPreferencesQueryKeys = {
+  all: ["notification-preferences"] as const,
+  me: () => [...notificationPreferencesQueryKeys.all, "me"] as const,
+};
+
+export function useNotificationPreferences() {
+  const { data: session } = useSession();
+  return useQuery<NotificationPreferences>({
+    queryKey: notificationPreferencesQueryKeys.me(),
+    enabled: !!session?.user,
+    queryFn: async () => {
+      const res = await client.api["notification-preferences"].$get();
+      return (await res.json()) as NotificationPreferences;
+    },
+  });
+}
+
+interface MutationContext {
+  previous?: NotificationPreferences;
+}
+
+export function useUpdateNotificationPreferences() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    NotificationPreferences,
+    Error,
+    NotificationPreferencesUpdate,
+    MutationContext
+  >({
+    mutationFn: async (update) => {
+      const res = await client.api["notification-preferences"].$patch({
+        json: update,
+      });
+      return (await res.json()) as NotificationPreferences;
+    },
+    onMutate: async (update) => {
+      await queryClient.cancelQueries({
+        queryKey: notificationPreferencesQueryKeys.me(),
+      });
+      const previous = queryClient.getQueryData<NotificationPreferences>(
+        notificationPreferencesQueryKeys.me(),
+      );
+      if (previous) {
+        queryClient.setQueryData<NotificationPreferences>(
+          notificationPreferencesQueryKeys.me(),
+          { ...previous, ...update },
+        );
+      }
+      return { previous };
+    },
+    onError: (_err, _update, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(
+          notificationPreferencesQueryKeys.me(),
+          ctx.previous,
+        );
+      }
+    },
+    onSuccess: (data) => {
+      // Server response is the canonical row; replace the cache directly so
+      // we don't trigger an extra refetch.
+      queryClient.setQueryData(notificationPreferencesQueryKeys.me(), data);
+    },
+  });
+}

--- a/packages/shared/src/database/schema.ts
+++ b/packages/shared/src/database/schema.ts
@@ -194,6 +194,15 @@ export interface PushTokensTable {
   updated_at: ColumnType<Date, string | undefined, string>;
 }
 
+export interface UserNotificationPrefsTable {
+  user_id: string;
+  push_enabled: number; // 0 or 1 (master)
+  push_new_match: number; // 0 or 1
+  push_match_reminder: number; // 0 or 1
+  push_promo_to_confirmed: number; // 0 or 1
+  updated_at: ColumnType<Date, string | undefined, string>;
+}
+
 // BetterAuth verification table (used for password reset codes, OTPs, etc.)
 export interface VerificationTable {
   id: string;
@@ -274,6 +283,7 @@ export interface Database {
   voting_criteria: VotingCriteriaTable;
   match_votes: MatchVotesTable;
   push_tokens: PushTokensTable;
+  user_notification_prefs: UserNotificationPrefsTable;
   verification: VerificationTable;
   groups: GroupsTable;
   group_members: GroupMembersTable;
@@ -343,6 +353,10 @@ export type MatchVoteUpdate = Updateable<MatchVotesTable>;
 export type PushToken = Selectable<PushTokensTable>;
 export type NewPushToken = Insertable<PushTokensTable>;
 export type PushTokenUpdate = Updateable<PushTokensTable>;
+
+export type UserNotificationPrefs = Selectable<UserNotificationPrefsTable>;
+export type NewUserNotificationPrefs = Insertable<UserNotificationPrefsTable>;
+export type UserNotificationPrefsUpdate = Updateable<UserNotificationPrefsTable>;
 
 export type Group = Selectable<GroupsTable>;
 export type NewGroup = Insertable<GroupsTable>;

--- a/packages/shared/src/domain/types.ts
+++ b/packages/shared/src/domain/types.ts
@@ -578,6 +578,44 @@ export const NOTIFICATION_TYPES = {
 export type NotificationType =
   (typeof NOTIFICATION_TYPES)[keyof typeof NOTIFICATION_TYPES];
 
+// Per-user opt-in/opt-out categories (subset of NOTIFICATION_TYPES that map
+// to a column in user_notification_prefs). Sends without a category bypass
+// the per-category filter and only respect the master push_enabled flag.
+export const NOTIFICATION_CATEGORIES = [
+  "new_match",
+  "match_reminder",
+  "promo_to_confirmed",
+] as const;
+export type NotificationCategory = (typeof NOTIFICATION_CATEGORIES)[number];
+
+export const CATEGORY_TO_COLUMN: Record<
+  NotificationCategory,
+  "push_new_match" | "push_match_reminder" | "push_promo_to_confirmed"
+> = {
+  new_match: "push_new_match",
+  match_reminder: "push_match_reminder",
+  promo_to_confirmed: "push_promo_to_confirmed",
+};
+
+export interface NotificationPreferences {
+  pushEnabled: boolean;
+  pushNewMatch: boolean;
+  pushMatchReminder: boolean;
+  pushPromoToConfirmed: boolean;
+}
+
+export type NotificationPreferencesUpdate = Partial<NotificationPreferences>;
+
+export const NOTIFICATION_PREF_TO_COLUMN: Record<
+  keyof NotificationPreferences,
+  "push_enabled" | "push_new_match" | "push_match_reminder" | "push_promo_to_confirmed"
+> = {
+  pushEnabled: "push_enabled",
+  pushNewMatch: "push_new_match",
+  pushMatchReminder: "push_match_reminder",
+  pushPromoToConfirmed: "push_promo_to_confirmed",
+};
+
 // Helper types for pagination and responses
 
 export interface PaginatedResponse<T> {

--- a/packages/shared/src/repositories/interfaces.ts
+++ b/packages/shared/src/repositories/interfaces.ts
@@ -28,6 +28,7 @@ import type {
   SignupWithDetails,
   PushTokenInfo,
   RegisterPushTokenData,
+  NotificationCategory,
 } from "../domain/types";
 
 // Location Repository Interface
@@ -378,8 +379,20 @@ export interface PlayerStatsRepository {
 // Push Token Repository Interface
 export interface PushTokenRepository {
   upsert(data: RegisterPushTokenData): Promise<PushTokenInfo>;
-  findActiveByUserId(userId: string): Promise<PushTokenInfo[]>;
-  findActiveByUserIds(userIds: string[]): Promise<PushTokenInfo[]>;
+  /**
+   * Find active push tokens for a user, optionally filtered by notification
+   * category preference. When `category` is provided, tokens are returned only
+   * if both the master `push_enabled` and the per-category preference are on.
+   * Missing prefs row → defaults to all-on (coalesce-based).
+   */
+  findActiveByUserId(
+    userId: string,
+    category?: NotificationCategory,
+  ): Promise<PushTokenInfo[]>;
+  findActiveByUserIds(
+    userIds: string[],
+    category?: NotificationCategory,
+  ): Promise<PushTokenInfo[]>;
   deactivateToken(token: string): Promise<void>;
   deactivateTokenForUser(token: string, userId: string): Promise<void>;
   deactivateByUserId(userId: string): Promise<void>;

--- a/packages/shared/src/repositories/push-token-repository.ts
+++ b/packages/shared/src/repositories/push-token-repository.ts
@@ -4,7 +4,12 @@ import { sql } from "kysely";
 import { nanoid } from "nanoid";
 
 import type { PushTokenRepository } from "./interfaces";
-import type { PushTokenInfo, RegisterPushTokenData } from "../domain/types";
+import type {
+  NotificationCategory,
+  PushTokenInfo,
+  RegisterPushTokenData,
+} from "../domain/types";
+import { CATEGORY_TO_COLUMN } from "../domain/types";
 
 import { getDatabase } from "../database/connection";
 
@@ -56,37 +61,80 @@ export class TursoPushTokenRepository implements PushTokenRepository {
     return dbRowToPushToken(result);
   }
 
-  async findActiveByUserId(userId: string): Promise<PushTokenInfo[]> {
-    const results = await this.db
-      .selectFrom("push_tokens")
-      .selectAll()
-      .where("user_id", "=", userId)
-      .where("active", "=", 1)
-      .execute();
+  async findActiveByUserId(
+    userId: string,
+    category?: NotificationCategory,
+  ): Promise<PushTokenInfo[]> {
+    const results = await this.applyPrefFilters(
+      this.db
+        .selectFrom("push_tokens")
+        .leftJoin(
+          "user_notification_prefs",
+          "user_notification_prefs.user_id",
+          "push_tokens.user_id",
+        )
+        .selectAll("push_tokens")
+        .where("push_tokens.user_id", "=", userId)
+        .where("push_tokens.active", "=", 1),
+      category,
+    ).execute();
 
     return results.map(dbRowToPushToken);
   }
 
-  async findActiveByUserIds(userIds: string[]): Promise<PushTokenInfo[]> {
+  async findActiveByUserIds(
+    userIds: string[],
+    category?: NotificationCategory,
+  ): Promise<PushTokenInfo[]> {
     if (userIds.length === 0) return [];
 
-    // Batch in chunks of 500 to stay within SQLite parameter limits
+    // Chunk to stay within SQLite parameter limits; each chunk is independent.
     const chunkSize = 500;
-    const allResults: PushTokenInfo[] = [];
-
+    const chunks: string[][] = [];
     for (let i = 0; i < userIds.length; i += chunkSize) {
-      const chunk = userIds.slice(i, i + chunkSize);
-      const results = await this.db
-        .selectFrom("push_tokens")
-        .selectAll()
-        .where("user_id", "in", chunk)
-        .where("active", "=", 1)
-        .execute();
-
-      allResults.push(...results.map(dbRowToPushToken));
+      chunks.push(userIds.slice(i, i + chunkSize));
     }
 
-    return allResults;
+    const chunkResults = await Promise.all(
+      chunks.map((chunk) =>
+        this.applyPrefFilters(
+          this.db
+            .selectFrom("push_tokens")
+            .leftJoin(
+              "user_notification_prefs",
+              "user_notification_prefs.user_id",
+              "push_tokens.user_id",
+            )
+            .selectAll("push_tokens")
+            .where("push_tokens.user_id", "in", chunk)
+            .where("push_tokens.active", "=", 1),
+          category,
+        ).execute(),
+      ),
+    );
+
+    return chunkResults.flat().map(dbRowToPushToken);
+  }
+
+  // Applies master push_enabled + per-category filters, defaulting to "on"
+  // when the joined prefs row is missing (COALESCE-based opt-out semantics).
+  private applyPrefFilters<T>(query: T, category?: NotificationCategory): T {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let q = query as any;
+    q = q.where(
+      sql`COALESCE(user_notification_prefs.push_enabled, 1)`,
+      "=",
+      1,
+    );
+    if (category) {
+      const column = CATEGORY_TO_COLUMN[category];
+      q = q.where(
+        sql.raw(`COALESCE(user_notification_prefs.${column}, 1)`),
+        "=",
+        1,
+      );
+    }
+    return q as T;
   }
 
   async deactivateToken(token: string): Promise<void> {

--- a/packages/shared/src/services/notification-service.ts
+++ b/packages/shared/src/services/notification-service.ts
@@ -3,10 +3,20 @@
 import type {
   ExpoPushMessage,
   ExpoPushTicket,
+  NotificationCategory,
   NotificationPayload,
   PushTokenInfo,
 } from "../domain/types";
 import type { PushTokenRepository } from "../repositories/interfaces";
+
+export interface SendOptions {
+  /**
+   * If provided, recipients are filtered by their per-category opt-in.
+   * Omit for sends that should respect only the master push_enabled flag
+   * (e.g. admin test sends, transactional confirmations).
+   */
+  category?: NotificationCategory;
+}
 
 const EXPO_PUSH_API_URL = "https://exp.host/--/api/v2/push/send";
 const EXPO_BATCH_LIMIT = 100;
@@ -40,8 +50,12 @@ export class NotificationService {
   async sendToUser(
     userId: string,
     payload: NotificationPayload,
+    options: SendOptions = {},
   ): Promise<ExpoPushTicket[]> {
-    const tokens = await this.pushTokenRepository.findActiveByUserId(userId);
+    const tokens = await this.pushTokenRepository.findActiveByUserId(
+      userId,
+      options.category,
+    );
     if (tokens.length === 0) return [];
 
     return this.sendToTokens(tokens, payload);
@@ -50,10 +64,14 @@ export class NotificationService {
   async sendToUsers(
     userIds: string[],
     payload: NotificationPayload,
+    options: SendOptions = {},
   ): Promise<ExpoPushTicket[]> {
     if (userIds.length === 0) return [];
 
-    const tokens = await this.pushTokenRepository.findActiveByUserIds(userIds);
+    const tokens = await this.pushTokenRepository.findActiveByUserIds(
+      userIds,
+      options.category,
+    );
     if (tokens.length === 0) return [];
 
     return this.sendToTokens(tokens, payload);


### PR DESCRIPTION
## Summary
- Replaces the implicit native push-permission prompt fired on first tab mount with a custom pre-permission dialog rendered on the home tab after sign-in (sells the value before the OS dialog appears).
- Adds a `user_notification_prefs` table (master + 3 categories: new match, match reminder, promo-to-confirmed) with default-on read semantics — a missing row reads as all-on via `COALESCE`, so existing users opt in without a backfill.
- Threads category through the push-token recipient lookup so `notify.ts` and the `send-match-reminders` cron filter recipients against the user's per-category preference.
- New `/api/notification-preferences` route (`GET`/`PATCH`) and `useNotificationPreferences` / `useUpdateNotificationPreferences` react-query hooks.
- New profile sub-page `/profile/notifications` with master toggle, three category switches (disabled when master is OFF or OS denied), and a "Notifications blocked — Open settings" deep link for the denied state. Header shows minimal back chevron.
- Profile entry row promoted from a small `Pressable` to a full-width outlined `Button` matching "Cambiar Contraseña" sizing.
- Master flip never deletes the registered token; re-enable is a single backend round trip with no extra OS prompt. AsyncStorage `notif-prompt-shown-v1` flag prevents the pre-permission modal from re-firing.

## Test plan
- [ ] `pnpm migrate:up` adds the `user_notification_prefs` table; existing users without a row receive notifications (read defaults all-on).
- [ ] Fresh install + sign in → home tab shows pre-permission modal; OS prompt does NOT fire until the user taps "Enable".
- [ ] "Maybe later" closes the modal without firing the OS prompt; relaunching the app does not re-prompt.
- [ ] `/profile/notifications`: master toggle ON requests OS permission; OFF only patches `push_enabled=false` and leaves token registered.
- [ ] Disable in iOS Settings → reopen app → master switch grayed + "Open settings" card visible; deep link opens system settings.
- [ ] Set `push_new_match=0` for a test user → admin creates a match in their group → no push delivered for that user; `match_reminder` cron still hits if its toggle is on.
- [ ] Sign out / delete account still calls `unregisterPushToken()`; prefs row left intact for re-login.
- [ ] Web build: `osStatus="unsupported"`, no auto-prompt, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)