### PR TITLE
feat(notifications): persistent inbox with bell + retention cron

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,53 @@ Every group-scoped resource (match, location, court, signup, setting, invite, ro
 
 **Observability**: `GroupService` emits structured JSON logs on `group.created`, `invite.accepted`, `ghost.claimed`, `group.ownership_transferred` — picked up by Cloudflare Workers logs.
 
+### Notifications System
+Two layers:
+1. **Transient push** — Expo Push API (`https://exp.host/--/api/v2/push/send`). Opt-in, native-only (web returns `osStatus: "unsupported"`).
+2. **Persistent inbox** — DB-backed, group-scoped, available on web and native. Read via the bell icon in the home-screen header.
+
+**Tables**:
+- `push_tokens` — device tokens per user (`migrations/20260407120000-add-push-tokens.ts`).
+- `user_notification_prefs` — master toggle + 3 category toggles. Absent row = all on (COALESCE) (`migrations/20260428120000-add-user-notification-prefs.ts`).
+- `notifications` — inbox rows: `(id, user_id, group_id, type, category, title, body, data_json, read_at, created_at)`. Indexed on `(user_id, group_id, created_at DESC)` and `(user_id, read_at)` (`migrations/20260429120000-add-notifications-inbox.ts`).
+
+**Types and categories** (`packages/shared/src/domain/types.ts`):
+- `NOTIFICATION_TYPES` — 12 event types (match_created, match_updated, match_cancelled, player_confirmed, substitute_promoted, player_cancelled, removed_from_match, match_reminder, payment_reminder, voting_open, engagement_reminder, group_invite). **Reuse this constant; never redefine.**
+- `NOTIFICATION_CATEGORIES` — 3 opt-in categories (`new_match`, `match_reminder`, `promo_to_confirmed`) backed by `user_notification_prefs` columns.
+- **Push delivery rule**: categorized sends honor per-category opt-out; transactional sends honor only the master toggle.
+- **Inbox persistence rule**: independent of push opt-out — a user with push off still sees rows. Ensures the inbox is the canonical history.
+
+**Server modules**:
+- Templates: `packages/shared/src/services/notification-templates.ts` — every template encodes `data.type` and `data.screen` (deep-link).
+- Send service (Expo): `packages/shared/src/services/notification-service.ts`.
+- Token repo (with prefs JOIN): `packages/shared/src/repositories/push-token-repository.ts`.
+- Inbox repo: `packages/shared/src/repositories/notification-inbox-repository.ts` — `insertMany`, `listByUserAndGroup`, `unreadCount`, `markRead`, `markAllRead`, `deleteOlderThan`.
+- Inbox recorder: `apps/api/src/lib/notification-inbox.ts` (`recordForRecipients`).
+- Event helpers (the call sites): `apps/api/src/lib/notify.ts` (`notifyMatchCreated`, `notifyMatchUpdated`, `notifyMatchCancelled`, `notifyPlayerConfirmed`, `notifySubstitutePromoted`, `notifyPlayerCancelled`, `notifyRemovedFromMatch`, `notifyGroupInviteTarget`).
+- Cron senders: `apps/api/src/cron/{send-match-reminders,send-engagement-reminders,update-match-statuses,prune-inbox-notifications}.ts`. All registered in the worker's `scheduled` handler (`apps/api/src/worker.ts`) and behind manual trigger endpoints in `apps/api/src/routes/cron.ts`.
+- API routes: `apps/api/src/routes/notifications.ts` — `GET /api/notifications` (list, group-scoped), `GET /api/notifications/unread-count`, `PATCH /api/notifications/:id/read`, `POST /api/notifications/read-all`, `POST /api/notifications/send-test` (admin only). Push token + preferences endpoints stay separate at `push-tokens.ts` / `notification-preferences.ts`.
+
+**Adding a new notification** (cookbook):
+1. Add the type to `NOTIFICATION_TYPES` if it's truly new.
+2. Add a template in `notification-templates.ts` (must include `data.type` and `data.screen`).
+3. Add a helper in `apps/api/src/lib/notify.ts` that calls `recordForRecipients(...)` first, then `getNotificationService().sendToUsers(...)`. Wrap in `safeNotify`.
+4. Wire the helper at the call site (route or cron). For match-related events, recipients should be intersected with group members (see `getGroupMemberIds` / `intersect` helpers in `notify.ts`).
+5. If the deep-link logic is non-trivial, extend `getNotificationRoute(data)` in `packages/shared/src/utils/notification-routes.ts` (the shared resolver used by both push-tap and inbox-tap handling).
+6. **Group invites are intentionally NOT persisted to the inbox** — the dedicated invite-acceptance flow surfaces them and the target may not yet be a registered user.
+7. Do NOT call the Expo Push API directly from feature code.
+
+**Retention**: inbox rows older than 10 days are pruned by `pruneInboxNotifications` (runs alongside other crons every 30 min — cheap, idempotent).
+
+**Client (mobile-web)**:
+- Push setup + listeners: `apps/mobile-web/lib/use-push-notifications.ts` (lazy-loaded; web is no-op).
+- Permission UX + master toggle context: `apps/mobile-web/lib/notifications/notification-preferences-context.tsx`, `components/notifications/notification-permission-prompt.tsx`.
+- Preferences screen: `apps/mobile-web/app/(tabs)/profile/notifications.tsx` (hidden on web).
+- Inbox: bell in the home-screen header (`components/notifications/inbox-bell.tsx`) opens `app/inbox.tsx`. The list lives in `components/notifications/notification-inbox.tsx`; routing on tap goes through `getNotificationRoute(item.data)` so push-tap and inbox-tap stay in sync. **Inbox works on both web and native**; the preferences screen does not.
+- API client hooks: `useNotifications`, `useUnreadNotificationCount`, `useMarkNotificationRead`, `useMarkAllNotificationsRead` (`packages/api-client/src/notifications-inbox.ts`). Plus existing `useNotificationPreferences`/`useUpdateNotificationPreferences`.
+- i18n root: `notifications.*` (preferences UX) and `notifications.inbox.*` (inbox UX) in `locales/{en,es}/common.json`. Type labels live at `notifications.inbox.types.<NotificationType>`.
+
+**Deep-link convention**: `payload.data.screen` is the canonical route. Both the push tap handler (`use-push-notifications.ts`) and the inbox screen (`app/inbox.tsx`) navigate via `router.push(getNotificationRoute(data))`.
+
 ### Database Configuration
 - **Primary**: Turso (LibSQL) database via `@libsql/kysely-libsql`
 - Connection configured via `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN`

--- a/apps/api/scripts/seed-inbox.ts
+++ b/apps/api/scripts/seed-inbox.ts
@@ -1,0 +1,162 @@
+// One-off QA seeder: inserts one inbox row per NotificationType for the
+// target user in their active (or first-membered) group, so the inbox UI
+// can be exercised end-to-end without triggering real match/cron flows.
+//
+// Run with: bun run apps/api/scripts/seed-inbox.ts <email>
+//
+// Talks to whatever Turso DB the root .env.local points at — same DB the
+// running API uses. Idempotent in the sense that re-running just appends
+// another batch (older rows still age out via the prune cron).
+
+import { getDatabase } from "@repo/shared/database";
+import { NOTIFICATION_TYPES } from "@repo/shared/domain";
+import { getRepositoryFactory } from "@repo/shared/repositories";
+
+type SeedSpec = {
+  type: (typeof NOTIFICATION_TYPES)[keyof typeof NOTIFICATION_TYPES];
+  category: "new_match" | "match_reminder" | "promo_to_confirmed" | null;
+  title: string;
+  body: string;
+  screen?: string;
+};
+
+const SEEDS: SeedSpec[] = [
+  {
+    type: NOTIFICATION_TYPES.MATCH_CREATED,
+    category: "new_match",
+    title: "New match",
+    body: "A new match was scheduled for Saturday at 19:00",
+    screen: "/(tabs)/matches",
+  },
+  {
+    type: NOTIFICATION_TYPES.MATCH_UPDATED,
+    category: null,
+    title: "Match updated",
+    body: "Saturday's match start time changed to 20:00",
+    screen: "/(tabs)/matches",
+  },
+  {
+    type: NOTIFICATION_TYPES.MATCH_CANCELLED,
+    category: null,
+    title: "Match cancelled",
+    body: "The match scheduled for Friday has been cancelled",
+    screen: "/(tabs)/matches",
+  },
+  {
+    type: NOTIFICATION_TYPES.PLAYER_CONFIRMED,
+    category: null,
+    title: "You're in",
+    body: "You've been confirmed for Saturday's match",
+    screen: "/(tabs)/matches",
+  },
+  {
+    type: NOTIFICATION_TYPES.SUBSTITUTE_PROMOTED,
+    category: "promo_to_confirmed",
+    title: "Promoted off the waitlist",
+    body: "A spot opened — you're now confirmed for Saturday",
+    screen: "/(tabs)/matches",
+  },
+  {
+    type: NOTIFICATION_TYPES.PLAYER_CANCELLED,
+    category: null,
+    title: "Player dropped out",
+    body: "Juan cancelled their spot — first sub will be promoted",
+    screen: "/(tabs)/matches",
+  },
+  {
+    type: NOTIFICATION_TYPES.REMOVED_FROM_MATCH,
+    category: null,
+    title: "Removed from match",
+    body: "An organizer removed you from Friday's match",
+    screen: "/(tabs)/matches",
+  },
+  {
+    type: NOTIFICATION_TYPES.MATCH_REMINDER,
+    category: "match_reminder",
+    title: "Match reminder",
+    body: "Don't forget — Saturday's match starts in 2 hours",
+    screen: "/(tabs)/matches",
+  },
+  {
+    type: NOTIFICATION_TYPES.PAYMENT_REMINDER,
+    category: null,
+    title: "Payment reminder",
+    body: "You owe €5 for last week's match",
+    screen: "/(tabs)/matches",
+  },
+  {
+    type: NOTIFICATION_TYPES.VOTING_OPEN,
+    category: null,
+    title: "Vote on the match",
+    body: "Rate the players from yesterday's match",
+    screen: "/(tabs)/social",
+  },
+  {
+    type: NOTIFICATION_TYPES.ENGAGEMENT_REMINDER,
+    category: null,
+    title: "Come back!",
+    body: "We miss you — there are open spots in upcoming matches",
+    screen: "/(tabs)/matches",
+  },
+];
+
+async function main() {
+  const email = process.argv[2];
+  if (!email) {
+    console.error("Usage: bun run apps/api/scripts/seed-inbox.ts <email>");
+    process.exit(1);
+  }
+
+  const db = getDatabase();
+
+  const user = await db
+    .selectFrom("user")
+    .select(["id", "email", "name"])
+    .where("email", "=", email)
+    .executeTakeFirst();
+
+  if (!user) {
+    console.error(`User not found: ${email}`);
+    process.exit(1);
+  }
+
+  const membership = await db
+    .selectFrom("group_members")
+    .innerJoin("groups", "groups.id", "group_members.group_id")
+    .select(["groups.id as group_id", "groups.name as group_name"])
+    .where("group_members.user_id", "=", user.id)
+    .where("groups.deleted_at", "is", null)
+    .executeTakeFirst();
+
+  if (!membership) {
+    console.error(`User ${email} has no group membership.`);
+    process.exit(1);
+  }
+
+  console.log(
+    `Seeding ${SEEDS.length} inbox rows for ${user.email} (${user.id}) in group ${membership.group_name} (${membership.group_id})`,
+  );
+
+  await getRepositoryFactory().notificationInbox.insertMany(
+    SEEDS.map((s) => ({
+      userId: user.id,
+      groupId: membership.group_id,
+      type: s.type,
+      category: s.category,
+      title: s.title,
+      body: s.body,
+      data: {
+        type: s.type,
+        screen: s.screen,
+      } as never,
+    })),
+  );
+
+  console.log("Done.");
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/api/src/cron/prune-inbox-notifications.ts
+++ b/apps/api/src/cron/prune-inbox-notifications.ts
@@ -1,0 +1,33 @@
+import { getRepositoryFactory } from "@repo/shared/repositories";
+
+const RETENTION_DAYS = 10;
+
+/**
+ * Delete inbox rows older than RETENTION_DAYS to keep the notifications
+ * table small. The cron triggers run every 30 minutes; this job is cheap and
+ * idempotent (a single DELETE on a created_at index).
+ */
+export async function pruneInboxNotifications() {
+  const cutoff = new Date(
+    Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  try {
+    const deleted =
+      await getRepositoryFactory().notificationInbox.deleteOlderThan(cutoff);
+
+    console.log(
+      JSON.stringify({
+        event: "inbox.pruned",
+        cutoff,
+        deleted,
+        retentionDays: RETENTION_DAYS,
+      }),
+    );
+
+    return { deleted, cutoff };
+  } catch (error) {
+    console.error("[CRON] Error pruning inbox notifications:", error);
+    throw error;
+  }
+}

--- a/apps/api/src/cron/prune-inbox-notifications.ts
+++ b/apps/api/src/cron/prune-inbox-notifications.ts
@@ -1,13 +1,39 @@
 import { getRepositoryFactory } from "@repo/shared/repositories";
 
 const RETENTION_DAYS = 10;
+// The Workers cron fires every 30 min, but pruning a 10-day window doesn't
+// need that cadence. Run once per day in the 03:00 UTC half-hour slot — the
+// every-30-min scheduler would otherwise issue 48 redundant DELETEs.
+// `force` skips this gate (used by the manual trigger endpoint).
+const DAILY_RUN_HOUR_UTC = 3;
+
+export interface PruneResult {
+  deleted: number;
+  cutoff: string;
+  skipped?: false;
+}
+export interface PruneSkipped {
+  skipped: true;
+  reason: "outside-daily-window";
+}
 
 /**
  * Delete inbox rows older than RETENTION_DAYS to keep the notifications
- * table small. The cron triggers run every 30 minutes; this job is cheap and
- * idempotent (a single DELETE on a created_at index).
+ * table small.
  */
-export async function pruneInboxNotifications() {
+export async function pruneInboxNotifications(
+  opts: { force?: boolean } = {},
+): Promise<PruneResult | PruneSkipped> {
+  if (!opts.force) {
+    const now = new Date();
+    if (
+      now.getUTCHours() !== DAILY_RUN_HOUR_UTC ||
+      now.getUTCMinutes() >= 30
+    ) {
+      return { skipped: true, reason: "outside-daily-window" };
+    }
+  }
+
   const cutoff = new Date(
     Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000,
   ).toISOString();

--- a/apps/api/src/cron/send-match-reminders.ts
+++ b/apps/api/src/cron/send-match-reminders.ts
@@ -1,9 +1,12 @@
 import { addDays } from "date-fns";
 import { getDatabase } from "@repo/shared/database";
+import { NOTIFICATION_TYPES } from "@repo/shared/domain";
 import { getRepositoryFactory } from "@repo/shared/repositories";
 import { getServiceFactory } from "@repo/shared/services";
 import { NotificationTemplates } from "@repo/shared/services";
 import { formatDateInAppTimezone } from "@repo/shared/utils";
+
+import { recordForRecipients } from "../lib/notification-inbox";
 
 /**
  * Send match reminders for matches happening tomorrow.
@@ -50,12 +53,21 @@ export async function sendMatchReminders() {
           time: match.time,
           locationName: location?.name,
         };
+        const payload = NotificationTemplates.matchReminder(info);
 
-        await notificationService.sendToUsers(
-          userIds,
-          NotificationTemplates.matchReminder(info),
-          { category: "match_reminder" },
-        );
+        if (match.group_id) {
+          await recordForRecipients({
+            userIds,
+            groupId: match.group_id,
+            type: NOTIFICATION_TYPES.MATCH_REMINDER,
+            category: "match_reminder",
+            payload,
+          });
+        }
+
+        await notificationService.sendToUsers(userIds, payload, {
+          category: "match_reminder",
+        });
         totalSent += userIds.length;
       }
 

--- a/apps/api/src/cron/update-match-statuses.ts
+++ b/apps/api/src/cron/update-match-statuses.ts
@@ -1,5 +1,8 @@
 import { getDatabase } from "@repo/shared/database";
+import { NOTIFICATION_TYPES } from "@repo/shared/domain";
 import { getServiceFactory, NotificationTemplates } from "@repo/shared/services";
+
+import { recordForRecipients } from "../lib/notification-inbox";
 
 /**
  * Update match statuses from "upcoming" to "completed"
@@ -25,7 +28,7 @@ export async function updateMatchStatuses() {
     // Find matches that will transition (for voting reminders)
     const matchesToComplete = await db
       .selectFrom("matches")
-      .select(["id", "date", "time", "location_id"])
+      .select(["id", "date", "time", "location_id", "group_id"])
       .where("status", "=", "upcoming")
       .where("date", "<", berlinDate)
       .execute();
@@ -86,10 +89,18 @@ export async function updateMatchStatuses() {
             time: match.time,
             locationName: location?.name,
           };
-          await notificationService.sendToUsers(
-            userIds,
-            NotificationTemplates.votingOpen(info),
-          );
+          const payload = NotificationTemplates.votingOpen(info);
+
+          if (match.group_id) {
+            await recordForRecipients({
+              userIds,
+              groupId: match.group_id,
+              type: NOTIFICATION_TYPES.VOTING_OPEN,
+              payload,
+            });
+          }
+
+          await notificationService.sendToUsers(userIds, payload);
           console.log(`[CRON] Sent voting reminder for match ${match.id} to ${userIds.length} users`);
         } catch (error) {
           console.error(`[CRON] Failed to send voting reminder for match ${match.id}:`, error);

--- a/apps/api/src/lib/notification-inbox.ts
+++ b/apps/api/src/lib/notification-inbox.ts
@@ -1,0 +1,51 @@
+// Thin wrapper used by notify helpers + crons to persist inbox rows.
+// Persistence is unconditional (independent of push opt-out): a user with push
+// off should still see entries in their inbox. Failures are swallowed and
+// logged so a DB hiccup never blocks the push send path.
+
+import { getRepositoryFactory } from "@repo/shared/repositories";
+
+import type {
+  NotificationCategory,
+  NotificationPayload,
+  NotificationType,
+} from "@repo/shared/domain";
+
+export interface RecordForRecipientsInput {
+  userIds: string[];
+  groupId: string;
+  type: NotificationType;
+  category?: NotificationCategory;
+  payload: NotificationPayload;
+}
+
+export async function recordForRecipients(
+  input: RecordForRecipientsInput,
+): Promise<void> {
+  const { userIds, groupId, type, category, payload } = input;
+  if (userIds.length === 0) return;
+
+  try {
+    const repo = getRepositoryFactory().notificationInbox;
+    const rows = userIds.map((userId) => ({
+      userId,
+      groupId,
+      type,
+      category: category ?? null,
+      title: payload.title ?? null,
+      body: payload.body,
+      data: payload.data,
+    }));
+    await repo.insertMany(rows);
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        event: "inbox.record_failed",
+        type,
+        groupId,
+        recipients: userIds.length,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  }
+}

--- a/apps/api/src/lib/notify.ts
+++ b/apps/api/src/lib/notify.ts
@@ -4,6 +4,9 @@ import { getDatabase } from "@repo/shared/database";
 import { NotificationTemplates } from "@repo/shared/services";
 import type { Match } from "@repo/shared/domain";
 import type { NotificationMatchInfo } from "@repo/shared/domain";
+import { NOTIFICATION_TYPES } from "@repo/shared/domain";
+
+import { recordForRecipients } from "./notification-inbox";
 
 const getNotificationService = () => getServiceFactory().notificationService;
 
@@ -48,18 +51,38 @@ async function getAdminUserIds(): Promise<string[]> {
   return admins.map((a) => a.id);
 }
 
+// Intersect a recipient list with the active members of a group. Used to
+// avoid recording inbox rows for users who don't belong to the match's group
+// (the existing push helpers fan out across all users with push tokens).
+async function getGroupMemberIds(groupId: string): Promise<Set<string>> {
+  const members = await getRepositoryFactory().groupMembers.listByGroup(groupId);
+  return new Set(members.map((m) => m.userId));
+}
+
+function intersect(userIds: string[], allowed: Set<string>): string[] {
+  return userIds.filter((id) => allowed.has(id));
+}
+
 export async function notifyMatchCreated(match: Match, excludeUserId: string): Promise<void> {
   await safeNotify("match created", async () => {
-    const [userIds, info] = await Promise.all([
+    const [userIds, info, memberSet] = await Promise.all([
       getUserIdsWithPushTokens(excludeUserId),
       toMatchInfo(match),
+      getGroupMemberIds(match.groupId),
     ]);
-    if (userIds.length === 0) return;
-    await getNotificationService().sendToUsers(
-      userIds,
-      NotificationTemplates.matchCreated(info),
-      { category: "new_match" },
-    );
+    const recipients = intersect(userIds, memberSet);
+    if (recipients.length === 0) return;
+    const payload = NotificationTemplates.matchCreated(info);
+    await recordForRecipients({
+      userIds: recipients,
+      groupId: match.groupId,
+      type: NOTIFICATION_TYPES.MATCH_CREATED,
+      category: "new_match",
+      payload,
+    });
+    await getNotificationService().sendToUsers(recipients, payload, {
+      category: "new_match",
+    });
   });
 }
 
@@ -70,7 +93,14 @@ export async function notifyMatchUpdated(match: Match, changes: string): Promise
       toMatchInfo(match),
     ]);
     if (userIds.length === 0) return;
-    await getNotificationService().sendToUsers(userIds, NotificationTemplates.matchUpdated(info, changes));
+    const payload = NotificationTemplates.matchUpdated(info, changes);
+    await recordForRecipients({
+      userIds,
+      groupId: match.groupId,
+      type: NOTIFICATION_TYPES.MATCH_UPDATED,
+      payload,
+    });
+    await getNotificationService().sendToUsers(userIds, payload);
   });
 }
 
@@ -81,43 +111,79 @@ export async function notifyMatchCancelled(match: Match): Promise<void> {
       toMatchInfo(match),
     ]);
     if (userIds.length === 0) return;
-    await getNotificationService().sendToUsers(userIds, NotificationTemplates.matchCancelled(info));
+    const payload = NotificationTemplates.matchCancelled(info);
+    await recordForRecipients({
+      userIds,
+      groupId: match.groupId,
+      type: NOTIFICATION_TYPES.MATCH_CANCELLED,
+      payload,
+    });
+    await getNotificationService().sendToUsers(userIds, payload);
   });
 }
 
 export async function notifyPlayerConfirmed(match: Match, userId: string): Promise<void> {
   await safeNotify("player confirmed", async () => {
     const info = await toMatchInfo(match);
-    await getNotificationService().sendToUser(userId, NotificationTemplates.playerConfirmed(info));
+    const payload = NotificationTemplates.playerConfirmed(info);
+    await recordForRecipients({
+      userIds: [userId],
+      groupId: match.groupId,
+      type: NOTIFICATION_TYPES.PLAYER_CONFIRMED,
+      payload,
+    });
+    await getNotificationService().sendToUser(userId, payload);
   });
 }
 
 export async function notifySubstitutePromoted(match: Match, userId: string): Promise<void> {
   await safeNotify("substitute promoted", async () => {
     const info = await toMatchInfo(match);
-    await getNotificationService().sendToUser(
-      userId,
-      NotificationTemplates.substitutePromoted(info),
-      { category: "promo_to_confirmed" },
-    );
+    const payload = NotificationTemplates.substitutePromoted(info);
+    await recordForRecipients({
+      userIds: [userId],
+      groupId: match.groupId,
+      type: NOTIFICATION_TYPES.SUBSTITUTE_PROMOTED,
+      category: "promo_to_confirmed",
+      payload,
+    });
+    await getNotificationService().sendToUser(userId, payload, {
+      category: "promo_to_confirmed",
+    });
   });
 }
 
 export async function notifyPlayerCancelled(match: Match, playerName: string): Promise<void> {
   await safeNotify("player cancelled", async () => {
-    const [adminIds, info] = await Promise.all([
+    const [adminIds, info, memberSet] = await Promise.all([
       getAdminUserIds(),
       toMatchInfo(match),
+      getGroupMemberIds(match.groupId),
     ]);
-    if (adminIds.length === 0) return;
-    await getNotificationService().sendToUsers(adminIds, NotificationTemplates.playerCancelled(info, playerName));
+    const recipients = intersect(adminIds, memberSet);
+    if (recipients.length === 0) return;
+    const payload = NotificationTemplates.playerCancelled(info, playerName);
+    await recordForRecipients({
+      userIds: recipients,
+      groupId: match.groupId,
+      type: NOTIFICATION_TYPES.PLAYER_CANCELLED,
+      payload,
+    });
+    await getNotificationService().sendToUsers(recipients, payload);
   });
 }
 
 export async function notifyRemovedFromMatch(match: Match, userId: string): Promise<void> {
   await safeNotify("removed from match", async () => {
     const info = await toMatchInfo(match);
-    await getNotificationService().sendToUser(userId, NotificationTemplates.removedFromMatch(info));
+    const payload = NotificationTemplates.removedFromMatch(info);
+    await recordForRecipients({
+      userIds: [userId],
+      groupId: match.groupId,
+      type: NOTIFICATION_TYPES.REMOVED_FROM_MATCH,
+      payload,
+    });
+    await getNotificationService().sendToUser(userId, payload);
   });
 }
 
@@ -132,6 +198,10 @@ async function findUserIdByPhone(phone: string): Promise<string | null> {
 
 // Skips if the target phone is already a member of the group — a push saying
 // "you were invited" would be confusing when they're already in.
+//
+// Group invites are intentionally NOT persisted to the inbox. The dedicated
+// invite-acceptance UI surfaces them, and the target may not yet be a
+// platform user when the invite is sent.
 export async function notifyGroupInviteTarget(params: {
   targetPhone: string;
   groupId: string;

--- a/apps/api/src/middleware/security.ts
+++ b/apps/api/src/middleware/security.ts
@@ -54,6 +54,7 @@ export const PUBLIC_ROUTES: Array<{ method?: string; path: RegExp }> = [
   { path: /^\/api\/cron\/update-matches$/, method: "POST" },        // Cron (has own secret check)
   { path: /^\/api\/cron\/send-reminders$/, method: "POST" },        // Cron (has own secret check)
   { path: /^\/api\/cron\/send-engagement$/, method: "POST" },       // Cron (has own secret check)
+  { path: /^\/api\/cron\/prune-inbox$/, method: "POST" },           // Cron (has own secret check)
 ];
 
 // Global auth middleware — secure by default.

--- a/apps/api/src/routes/cron.ts
+++ b/apps/api/src/routes/cron.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { updateMatchStatuses } from "../cron/update-match-statuses";
 import { sendMatchReminders } from "../cron/send-match-reminders";
 import { sendEngagementReminders } from "../cron/send-engagement-reminders";
+import { pruneInboxNotifications } from "../cron/prune-inbox-notifications";
 
 const app = new Hono();
 
@@ -31,6 +32,21 @@ app.post("/send-reminders", async (c) => {
 
   try {
     const result = await sendMatchReminders();
+    return c.json({ success: true, ...result, timestamp: new Date().toISOString() });
+  } catch (error) {
+    console.error("[CRON] Manual trigger error:", error);
+    return c.json({
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }, 500);
+  }
+});
+
+app.post("/prune-inbox", async (c) => {
+  if (!verifyCronSecret(c)) return c.json({ error: "Unauthorized" }, 401);
+
+  try {
+    const result = await pruneInboxNotifications();
     return c.json({ success: true, ...result, timestamp: new Date().toISOString() });
   } catch (error) {
     console.error("[CRON] Manual trigger error:", error);

--- a/apps/api/src/routes/cron.ts
+++ b/apps/api/src/routes/cron.ts
@@ -46,7 +46,7 @@ app.post("/prune-inbox", async (c) => {
   if (!verifyCronSecret(c)) return c.json({ error: "Unauthorized" }, 401);
 
   try {
-    const result = await pruneInboxNotifications();
+    const result = await pruneInboxNotifications({ force: true });
     return c.json({ success: true, ...result, timestamp: new Date().toISOString() });
   } catch (error) {
     console.error("[CRON] Manual trigger error:", error);

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -1,15 +1,79 @@
 import { zValidator } from "@hono/zod-validator";
+import { getRepositoryFactory } from "@repo/shared/repositories";
 import { getServiceFactory } from "@repo/shared/services";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import {
+  groupContextMiddleware,
+  requireCurrentGroup,
+} from "../middleware/group-context";
 import { type AppVariables, requireUser } from "../middleware/security";
 
 const app = new Hono<{ Variables: AppVariables }>();
 
 const getNotificationService = () => getServiceFactory().notificationService;
+const getInbox = () => getRepositoryFactory().notificationInbox;
 
-// Send a test notification (admin only)
+// All inbox endpoints are scoped to the active group via X-Group-Id.
+// /send-test (admin) also runs through this — admins always have a group.
+app.use("*", groupContextMiddleware);
+
+// List inbox notifications for the current user in the current group.
+app.get(
+  "/",
+  zValidator(
+    "query",
+    z.object({
+      limit: z.coerce.number().int().positive().max(100).optional(),
+      before: z.string().min(1).max(200).optional(),
+    }),
+  ),
+  async (c) => {
+    const user = requireUser(c);
+    const current = requireCurrentGroup(c);
+    const { limit, before } = c.req.valid("query");
+
+    const list = await getInbox().listByUserAndGroup(user.id, current.id, {
+      limit,
+      before,
+    });
+
+    return c.json({
+      items: list.items,
+      hasMore: list.hasMore,
+      nextCursor: list.nextCursor,
+    });
+  },
+);
+
+// Lightweight unread count — used to drive the home-screen bell badge.
+app.get("/unread-count", async (c) => {
+  const user = requireUser(c);
+  const current = requireCurrentGroup(c);
+  const unreadCount = await getInbox().unreadCount(user.id, current.id);
+  return c.json({ unreadCount });
+});
+
+// Mark all unread rows in the current group as read.
+app.post("/read-all", async (c) => {
+  const user = requireUser(c);
+  const current = requireCurrentGroup(c);
+  const updated = await getInbox().markAllRead(user.id, current.id);
+  return c.json({ updated });
+});
+
+// Mark a single inbox row as read. 404 if it isn't owned by the caller
+// (or is already read) — ownership is enforced via the WHERE clause.
+app.patch("/:id/read", async (c) => {
+  const user = requireUser(c);
+  const id = c.req.param("id");
+  const ok = await getInbox().markRead(id, user.id);
+  if (!ok) return c.json({ error: "Notification not found" }, 404);
+  return c.json({ success: true });
+});
+
+// Send a test notification (admin only).
 app.post(
   "/send-test",
   zValidator(

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -15,13 +15,14 @@ const app = new Hono<{ Variables: AppVariables }>();
 const getNotificationService = () => getServiceFactory().notificationService;
 const getInbox = () => getRepositoryFactory().notificationInbox;
 
-// All inbox endpoints are scoped to the active group via X-Group-Id.
-// /send-test (admin) also runs through this — admins always have a group.
-app.use("*", groupContextMiddleware);
+// Group-scoping middleware applies only to inbox endpoints that read or
+// mutate group-scoped state. /send-test (admin) and /:id/read (ownership
+// by user_id) intentionally don't require a current group.
 
 // List inbox notifications for the current user in the current group.
 app.get(
   "/",
+  groupContextMiddleware,
   zValidator(
     "query",
     z.object({
@@ -48,7 +49,7 @@ app.get(
 );
 
 // Lightweight unread count — used to drive the home-screen bell badge.
-app.get("/unread-count", async (c) => {
+app.get("/unread-count", groupContextMiddleware, async (c) => {
   const user = requireUser(c);
   const current = requireCurrentGroup(c);
   const unreadCount = await getInbox().unreadCount(user.id, current.id);
@@ -56,7 +57,7 @@ app.get("/unread-count", async (c) => {
 });
 
 // Mark all unread rows in the current group as read.
-app.post("/read-all", async (c) => {
+app.post("/read-all", groupContextMiddleware, async (c) => {
   const user = requireUser(c);
   const current = requireCurrentGroup(c);
   const updated = await getInbox().markAllRead(user.id, current.id);

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -14,6 +14,7 @@ import { auth } from "./auth";
 import { updateMatchStatuses } from "./cron/update-match-statuses";
 import { sendMatchReminders } from "./cron/send-match-reminders";
 import { sendEngagementReminders } from "./cron/send-engagement-reminders";
+import { pruneInboxNotifications } from "./cron/prune-inbox-notifications";
 
 // Import shared security middleware
 import { type AppVariables, authMiddleware, rateLimitMiddleware } from "./middleware/security";
@@ -276,6 +277,7 @@ export default Sentry.withSentry(
           updateMatchStatuses(),
           sendMatchReminders(),
           sendEngagementReminders(),
+          pruneInboxNotifications(),
         ]).then((results) => {
           for (const r of results) {
             if (r.status === "rejected") {

--- a/apps/mobile-web/app/(tabs)/_layout.tsx
+++ b/apps/mobile-web/app/(tabs)/_layout.tsx
@@ -82,7 +82,6 @@ export default function TabsLayout() {
         options={{
           title: t("shared.home"),
           tabBarIcon: ({ color, size }) => <Home size={size} color={color} />,
-          headerShown: false,
         }}
       />
       <Tabs.Screen

--- a/apps/mobile-web/app/(tabs)/index.tsx
+++ b/apps/mobile-web/app/(tabs)/index.tsx
@@ -54,6 +54,7 @@ export default function HomeScreen() {
       <Stack.Screen
         options={{
           title: t("shared.home"),
+          headerTitle: "",
           headerStyle: {
             backgroundColor: theme.background?.val,
           },

--- a/apps/mobile-web/app/(tabs)/index.tsx
+++ b/apps/mobile-web/app/(tabs)/index.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from "react-i18next";
 import { Platform } from "react-native";
 import { useTheme } from "tamagui";
 
+import { InboxBell } from "../../components/notifications/inbox-bell";
 import { NotificationPermissionPrompt } from "../../components/notifications/notification-permission-prompt";
 import { useNotificationPreferencesContext } from "../../lib/notifications/notification-preferences-context";
 import { useRulesModal } from "../../lib/rules-modal-context";
@@ -58,6 +59,7 @@ export default function HomeScreen() {
           },
           headerTintColor: theme.color?.val,
           headerShadowVisible: false,
+          headerRight: isAuthenticated ? () => <InboxBell /> : undefined,
         }}
       />
       <Container variant="padded">

--- a/apps/mobile-web/app/_layout.tsx
+++ b/apps/mobile-web/app/_layout.tsx
@@ -89,6 +89,12 @@ function AppNavigation() {
           headerTitle: "",
         }}
       />
+      <Stack.Screen
+        name="inbox"
+        options={{
+          headerTitle: "",
+        }}
+      />
     </Stack>
   );
 }

--- a/apps/mobile-web/app/inbox.tsx
+++ b/apps/mobile-web/app/inbox.tsx
@@ -1,0 +1,63 @@
+// @ts-nocheck - Tamagui type recursion workaround
+import {
+  type InboxNotification,
+  useMarkAllNotificationsRead,
+  useMarkNotificationRead,
+  useUnreadNotificationCount,
+} from "@repo/api-client";
+import { getNotificationRoute } from "@repo/shared/utils";
+import { Button, Text } from "@repo/ui";
+import { router, Stack } from "expo-router";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "tamagui";
+
+import { NotificationInbox } from "../components/notifications/notification-inbox";
+
+export default function InboxScreen() {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const markRead = useMarkNotificationRead();
+  const markAllRead = useMarkAllNotificationsRead();
+  const { data: unread } = useUnreadNotificationCount();
+
+  const handleItemPress = useCallback(
+    (item: InboxNotification) => {
+      if (!item.readAt) {
+        markRead.mutate(item.id);
+      }
+      const route = getNotificationRoute(item.data);
+      // expo-router types accept string for dynamic routes; cast keeps TS quiet.
+      router.push(route as never);
+    },
+    [markRead],
+  );
+
+  const showMarkAll = (unread?.unreadCount ?? 0) > 0;
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title: t("notifications.inbox.title"),
+          headerStyle: { backgroundColor: theme.background?.val },
+          headerTintColor: theme.color?.val,
+          headerRight: () =>
+            showMarkAll ? (
+              <Button
+                size="$2"
+                variant="ghost"
+                onPress={() => markAllRead.mutate()}
+                disabled={markAllRead.isPending}
+                accessibilityLabel={t("notifications.inbox.markAllRead")}
+                testID="inbox-mark-all-read"
+              >
+                <Text fontSize="$3">{t("notifications.inbox.markAllRead")}</Text>
+              </Button>
+            ) : null,
+        }}
+      />
+      <NotificationInbox onItemPress={handleItemPress} />
+    </>
+  );
+}

--- a/apps/mobile-web/app/inbox.tsx
+++ b/apps/mobile-web/app/inbox.tsx
@@ -30,7 +30,7 @@ export default function InboxScreen() {
       // expo-router types accept string for dynamic routes; cast keeps TS quiet.
       router.push(route as never);
     },
-    [markRead],
+    [markRead.mutate],
   );
 
   const showMarkAll = (unread?.unreadCount ?? 0) > 0;

--- a/apps/mobile-web/components/notifications/inbox-bell.tsx
+++ b/apps/mobile-web/components/notifications/inbox-bell.tsx
@@ -28,7 +28,7 @@ export function InboxBell() {
       accessibilityLabel={label}
       testID="home-header-inbox"
       hitSlop={8}
-      style={{ paddingHorizontal: 8, paddingVertical: 4 }}
+      style={{ paddingLeft: 8, paddingRight: 16, paddingVertical: 4 }}
     >
       <XStack position="relative">
         <Bell size={22} color={theme.color?.val} />

--- a/apps/mobile-web/components/notifications/inbox-bell.tsx
+++ b/apps/mobile-web/components/notifications/inbox-bell.tsx
@@ -1,0 +1,56 @@
+// @ts-nocheck - Tamagui type recursion workaround
+import { useUnreadNotificationCount } from "@repo/api-client";
+import { Text, XStack } from "@repo/ui";
+import { Bell } from "@tamagui/lucide-icons";
+import { router } from "expo-router";
+import { useTranslation } from "react-i18next";
+import { Pressable } from "react-native";
+import { useTheme } from "tamagui";
+
+const MAX_VISIBLE = 99;
+
+export function InboxBell() {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const { data } = useUnreadNotificationCount();
+  const unread = Math.max(0, data?.unreadCount ?? 0);
+  const showBadge = unread > 0;
+  const badgeText = unread > MAX_VISIBLE ? `${MAX_VISIBLE}+` : String(unread);
+
+  const label = showBadge
+    ? t("a11y.openInboxWithUnread", { count: unread })
+    : t("a11y.openInbox");
+
+  return (
+    <Pressable
+      onPress={() => router.push("/inbox")}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      testID="home-header-inbox"
+      hitSlop={8}
+      style={{ paddingHorizontal: 8, paddingVertical: 4 }}
+    >
+      <XStack position="relative">
+        <Bell size={22} color={theme.color?.val} />
+        {showBadge && (
+          <XStack
+            position="absolute"
+            top={-6}
+            right={-8}
+            minWidth={18}
+            height={18}
+            borderRadius={9}
+            backgroundColor="$red10"
+            alignItems="center"
+            justifyContent="center"
+            paddingHorizontal={4}
+          >
+            <Text color="white" fontSize={10} fontWeight="700">
+              {badgeText}
+            </Text>
+          </XStack>
+        )}
+      </XStack>
+    </Pressable>
+  );
+}

--- a/apps/mobile-web/components/notifications/inbox-empty.tsx
+++ b/apps/mobile-web/components/notifications/inbox-empty.tsx
@@ -1,0 +1,31 @@
+// @ts-nocheck - Tamagui type recursion workaround
+import { Text, YStack } from "@repo/ui";
+import { Bell } from "@tamagui/lucide-icons";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "tamagui";
+
+export function InboxEmpty() {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  return (
+    <YStack
+      alignItems="center"
+      justifyContent="center"
+      paddingVertical="$10"
+      gap="$3"
+    >
+      <Bell size={48} color={theme.gray8?.val} />
+      <Text fontSize="$5" fontWeight="600" color="$gray11">
+        {t("notifications.inbox.empty")}
+      </Text>
+      <Text
+        fontSize="$3"
+        color="$gray10"
+        textAlign="center"
+        paddingHorizontal="$6"
+      >
+        {t("notifications.inbox.emptyHint")}
+      </Text>
+    </YStack>
+  );
+}

--- a/apps/mobile-web/components/notifications/inbox-row.tsx
+++ b/apps/mobile-web/components/notifications/inbox-row.tsx
@@ -1,0 +1,131 @@
+// @ts-nocheck - Tamagui type recursion workaround
+import type { InboxNotification } from "@repo/api-client";
+import { NOTIFICATION_TYPES, type NotificationType } from "@repo/shared/domain";
+import { Text, XStack, YStack } from "@repo/ui";
+import {
+  Bell,
+  CalendarPlus,
+  CalendarX,
+  CheckCircle2,
+  Clock,
+  Edit3,
+  ThumbsUp,
+  UserCheck,
+  UserMinus,
+  UserPlus,
+  UserX,
+  Wallet,
+} from "@tamagui/lucide-icons";
+import { formatDistanceToNow, parseISO } from "date-fns";
+import { useTranslation } from "react-i18next";
+import { Pressable } from "react-native";
+import { useTheme } from "tamagui";
+
+import { getLocale } from "../../lib/date-utils";
+
+const ICON_BY_TYPE: Record<NotificationType, typeof Bell> = {
+  [NOTIFICATION_TYPES.MATCH_CREATED]: CalendarPlus,
+  [NOTIFICATION_TYPES.MATCH_UPDATED]: Edit3,
+  [NOTIFICATION_TYPES.MATCH_CANCELLED]: CalendarX,
+  [NOTIFICATION_TYPES.PLAYER_CONFIRMED]: CheckCircle2,
+  [NOTIFICATION_TYPES.SUBSTITUTE_PROMOTED]: UserCheck,
+  [NOTIFICATION_TYPES.PLAYER_CANCELLED]: UserX,
+  [NOTIFICATION_TYPES.REMOVED_FROM_MATCH]: UserMinus,
+  [NOTIFICATION_TYPES.MATCH_REMINDER]: Clock,
+  [NOTIFICATION_TYPES.VOTING_OPEN]: ThumbsUp,
+  [NOTIFICATION_TYPES.ENGAGEMENT_REMINDER]: Bell,
+  [NOTIFICATION_TYPES.PAYMENT_REMINDER]: Wallet,
+  // Group invites are never persisted to the inbox, but the key is required
+  // to make this Record exhaustive — adding a new NotificationType becomes a
+  // compile error here instead of a silent fall-through to the Bell default.
+  [NOTIFICATION_TYPES.GROUP_INVITE]: UserPlus,
+};
+
+interface InboxRowProps {
+  item: InboxNotification;
+  onPress: (item: InboxNotification) => void;
+}
+
+export function InboxRow({ item, onPress }: InboxRowProps) {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const Icon = ICON_BY_TYPE[item.type] ?? Bell;
+  const isUnread = !item.readAt;
+  const locale = getLocale();
+
+  const typeLabel = t(`notifications.inbox.types.${item.type}`, {
+    defaultValue: item.title ?? "",
+  });
+  const title = item.title || typeLabel;
+
+  let relative = "";
+  try {
+    relative = formatDistanceToNow(parseISO(item.createdAt), {
+      addSuffix: true,
+      locale,
+    });
+  } catch {
+    relative = item.createdAt;
+  }
+
+  const accessibilityLabel = `${title}. ${item.body}`;
+
+  return (
+    <Pressable
+      onPress={() => onPress(item)}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityHint={t("a11y.openNotification")}
+    >
+      <XStack
+        gap="$3"
+        paddingHorizontal="$4"
+        paddingVertical="$3"
+        backgroundColor={isUnread ? "$blue2" : "$background"}
+        borderBottomWidth={1}
+        borderBottomColor="$gray5"
+        alignItems="flex-start"
+      >
+        <YStack
+          width={36}
+          height={36}
+          borderRadius={18}
+          backgroundColor={isUnread ? "$blue4" : "$gray4"}
+          alignItems="center"
+          justifyContent="center"
+          marginTop={2}
+        >
+          <Icon size={18} color={isUnread ? theme.blue11?.val : theme.gray11?.val} />
+        </YStack>
+
+        <YStack flex={1} gap="$1">
+          <XStack alignItems="center" gap="$2" justifyContent="space-between">
+            <Text
+              fontSize="$4"
+              fontWeight={isUnread ? "700" : "500"}
+              numberOfLines={1}
+            >
+              {title}
+            </Text>
+            <Text fontSize="$2" color="$gray10">
+              {relative}
+            </Text>
+          </XStack>
+          <Text fontSize="$3" color="$gray11" numberOfLines={2}>
+            {item.body}
+          </Text>
+        </YStack>
+
+        {isUnread && (
+          <YStack
+            width={8}
+            height={8}
+            borderRadius={4}
+            backgroundColor="$blue10"
+            marginTop={8}
+          />
+        )}
+      </XStack>
+    </Pressable>
+  );
+}

--- a/apps/mobile-web/components/notifications/notification-inbox.tsx
+++ b/apps/mobile-web/components/notifications/notification-inbox.tsx
@@ -1,0 +1,91 @@
+// @ts-nocheck - Tamagui type recursion workaround
+import {
+  type InboxNotification,
+  useNotifications,
+} from "@repo/api-client";
+import { Spinner, Text, YStack } from "@repo/ui";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { FlatList, RefreshControl } from "react-native";
+
+import { InboxEmpty } from "./inbox-empty";
+import { InboxRow } from "./inbox-row";
+
+interface NotificationInboxProps {
+  onItemPress: (item: InboxNotification) => void;
+}
+
+export function NotificationInbox({ onItemPress }: NotificationInboxProps) {
+  const { t } = useTranslation();
+  const {
+    data,
+    isLoading,
+    isRefetching,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useNotifications();
+
+  const items: InboxNotification[] =
+    data?.pages.flatMap((p) => p.items) ?? [];
+
+  const onEndReached = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: InboxNotification }) => (
+      <InboxRow item={item} onPress={onItemPress} />
+    ),
+    [onItemPress],
+  );
+
+  const keyExtractor = useCallback((item: InboxNotification) => item.id, []);
+
+  if (isLoading && items.length === 0) {
+    return (
+      <YStack flex={1} alignItems="center" justifyContent="center">
+        <Spinner size="large" />
+      </YStack>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <YStack
+        flex={1}
+        backgroundColor="$background"
+        // FlatList ListEmptyComponent doesn't get RefreshControl reliably on web;
+        // keeping this branch separate makes the empty state crisp.
+      >
+        <InboxEmpty />
+      </YStack>
+    );
+  }
+
+  return (
+    <FlatList
+      data={items}
+      keyExtractor={keyExtractor}
+      renderItem={renderItem}
+      onEndReached={onEndReached}
+      onEndReachedThreshold={0.3}
+      refreshControl={
+        <RefreshControl refreshing={isRefetching} onRefresh={refetch} />
+      }
+      ListFooterComponent={
+        isFetchingNextPage ? (
+          <YStack paddingVertical="$4" alignItems="center" gap="$2">
+            <Spinner />
+            <Text fontSize="$2" color="$gray10">
+              {t("notifications.inbox.loadingMore")}
+            </Text>
+          </YStack>
+        ) : null
+      }
+    />
+  );
+}

--- a/apps/mobile-web/lib/notifications/notification-preferences-context.tsx
+++ b/apps/mobile-web/lib/notifications/notification-preferences-context.tsx
@@ -68,6 +68,10 @@ export function NotificationPreferencesProvider({
     Platform.OS === "web" ? "unsupported" : "undetermined",
   );
   const [hasShownPrompt, setHasShownPrompt] = useState(false);
+  // Track AsyncStorage hydration so callers don't read `hasShownPrompt`
+  // before the prompt-shown flag has been loaded — otherwise the home-screen
+  // effect pops the prompt on every cold start.
+  const [initLoaded, setInitLoaded] = useState(Platform.OS === "web");
 
   const prefsQuery = useNotificationPreferences();
   const updateMutation = useUpdateNotificationPreferences();
@@ -93,6 +97,9 @@ export function NotificationPreferencesProvider({
       })
       .catch(() => {
         // Init failure is non-fatal — keep defaults and try again on next mount/foreground.
+      })
+      .finally(() => {
+        setInitLoaded(true);
       });
 
     const sub = AppState.addEventListener("change", (state) => {
@@ -142,7 +149,7 @@ export function NotificationPreferencesProvider({
     () => ({
       osStatus,
       prefs: prefsQuery.data,
-      isLoading: !isAuthed || prefsQuery.isLoading,
+      isLoading: !isAuthed || prefsQuery.isLoading || !initLoaded,
       hasShownPrompt,
       effectivelyEnabled,
       refreshOsStatus,
@@ -156,6 +163,7 @@ export function NotificationPreferencesProvider({
       prefsQuery.data,
       prefsQuery.isLoading,
       isAuthed,
+      initLoaded,
       hasShownPrompt,
       refreshOsStatus,
       markPromptShown,

--- a/apps/mobile-web/lib/use-push-notifications.ts
+++ b/apps/mobile-web/lib/use-push-notifications.ts
@@ -3,6 +3,7 @@ import { Platform } from "react-native";
 import { router } from "expo-router";
 import { useSession } from "@repo/api-client";
 import { api } from "@repo/api-client";
+import { getNotificationRoute } from "@repo/shared/utils";
 
 // Tracks the token registered by this session so we can deactivate it on
 // sign-out / account deletion. Set after a successful POST /push-tokens.
@@ -160,9 +161,7 @@ export function usePushNotifications() {
       const responseSub =
         Notifications.addNotificationResponseReceivedListener((response) => {
           const data = response.notification.request.content.data;
-          if (data?.screen && typeof data.screen === "string") {
-            router.push(data.screen as any);
-          }
+          router.push(getNotificationRoute(data) as never);
         });
 
       listenersRef.current = [notifSub, responseSub];

--- a/apps/mobile-web/lib/use-push-notifications.ts
+++ b/apps/mobile-web/lib/use-push-notifications.ts
@@ -161,6 +161,15 @@ export function usePushNotifications() {
       const responseSub =
         Notifications.addNotificationResponseReceivedListener((response) => {
           const data = response.notification.request.content.data;
+          // Push notifications without a deep-link target (e.g. /send-test)
+          // shouldn't navigate anywhere on tap — only follow an explicit
+          // screen. Inbox-tap uses the helper's type-based fallback because
+          // the user there always intended to open something.
+          const screen =
+            typeof data === "object" && data !== null
+              ? (data as { screen?: unknown }).screen
+              : undefined;
+          if (typeof screen !== "string" || screen.length === 0) return;
           router.push(getNotificationRoute(data) as never);
         });
 

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -454,7 +454,10 @@
     "openStats": "Open player stats",
     "openMultimedia": "Open multimedia feed",
     "openGallery": "Open gallery for {{date}}",
-    "uploadMedia": "Upload photo or video"
+    "uploadMedia": "Upload photo or video",
+    "openInbox": "Open notifications inbox",
+    "openInboxWithUnread": "Open notifications inbox, {{count}} unread",
+    "openNotification": "Open notification"
   },
   "notifications": {
     "settings": {
@@ -500,7 +503,32 @@
     "errors": {
       "generic": "Couldn't enable notifications. Please try again."
     },
-    "unsupportedWeb": "Push notifications are only available on the mobile app for now."
+    "unsupportedWeb": "Push notifications are only available on the mobile app for now.",
+    "inbox": {
+      "title": "Notifications",
+      "empty": "You're all caught up.",
+      "emptyHint": "We'll drop new matches, reminders and updates here.",
+      "markAllRead": "Mark all as read",
+      "loadingMore": "Loading…",
+      "sections": {
+        "today": "Today",
+        "yesterday": "Yesterday",
+        "earlier": "Earlier"
+      },
+      "types": {
+        "match_created": "New match",
+        "match_updated": "Match updated",
+        "match_cancelled": "Match cancelled",
+        "player_confirmed": "You're in",
+        "substitute_promoted": "Promoted off the waitlist",
+        "player_cancelled": "Player dropped out",
+        "removed_from_match": "Removed from match",
+        "match_reminder": "Match reminder",
+        "voting_open": "Vote on the match",
+        "engagement_reminder": "Come back!",
+        "payment_reminder": "Payment reminder"
+      }
+    }
   },
   "status": {
     "paid": "Paid",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -457,7 +457,10 @@
     "openStats": "Abrir estadísticas",
     "openMultimedia": "Abrir multimedia",
     "openGallery": "Abrir galería del {{date}}",
-    "uploadMedia": "Subir foto o video"
+    "uploadMedia": "Subir foto o video",
+    "openInbox": "Abrir bandeja de notificaciones",
+    "openInboxWithUnread": "Abrir bandeja de notificaciones, {{count}} sin leer",
+    "openNotification": "Abrir notificación"
   },
   "notifications": {
     "settings": {
@@ -503,7 +506,32 @@
     "errors": {
       "generic": "No pudimos activar las notificaciones. Probá de nuevo."
     },
-    "unsupportedWeb": "Las notificaciones push por ahora solo están disponibles en la app móvil."
+    "unsupportedWeb": "Las notificaciones push por ahora solo están disponibles en la app móvil.",
+    "inbox": {
+      "title": "Notificaciones",
+      "empty": "Estás al día.",
+      "emptyHint": "Acá vas a ver nuevos partidos, recordatorios y actualizaciones.",
+      "markAllRead": "Marcar todas como leídas",
+      "loadingMore": "Cargando…",
+      "sections": {
+        "today": "Hoy",
+        "yesterday": "Ayer",
+        "earlier": "Antes"
+      },
+      "types": {
+        "match_created": "Nuevo partido",
+        "match_updated": "Partido actualizado",
+        "match_cancelled": "Partido cancelado",
+        "player_confirmed": "Estás dentro",
+        "substitute_promoted": "Saliste de la lista de espera",
+        "player_cancelled": "Un jugador se bajó",
+        "removed_from_match": "Te sacaron del partido",
+        "match_reminder": "Recordatorio de partido",
+        "voting_open": "Votá el partido",
+        "engagement_reminder": "Volvé a la cancha",
+        "payment_reminder": "Recordatorio de pago"
+      }
+    }
   },
   "status": {
     "paid": "Pagado",

--- a/migrations/20260429120000-add-notifications-inbox.ts
+++ b/migrations/20260429120000-add-notifications-inbox.ts
@@ -6,46 +6,38 @@
 import { sql } from "kysely";
 import type { Kysely, Migration } from "kysely";
 
+const tableExists = async (db: Kysely<any>, table: string) => {
+  const result = await sql<{ name: string }>`
+    SELECT name FROM sqlite_master WHERE type='table' AND name=${table}
+  `.execute(db);
+  return result.rows.length > 0;
+};
+
 export const up: Migration["up"] = async (db: Kysely<any>) => {
-  const tableExists = async (table: string) => {
-    const result = await sql<{ name: string }>`
-      SELECT name FROM sqlite_master WHERE type='table' AND name=${table}
+  if (!(await tableExists(db, "notifications"))) {
+    await sql`
+      CREATE TABLE notifications (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+        group_id TEXT NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+        type TEXT NOT NULL,
+        category TEXT,
+        title TEXT,
+        body TEXT NOT NULL,
+        data_json TEXT NOT NULL,
+        read_at TEXT,
+        created_at TEXT NOT NULL
+      )
     `.execute(db);
-    return result.rows.length > 0;
-  };
 
-  if (!(await tableExists("notifications"))) {
-    await db.schema
-      .createTable("notifications")
-      .addColumn("id", "text", (col) => col.primaryKey().notNull())
-      .addColumn("user_id", "text", (col) => col.notNull())
-      .addColumn("group_id", "text", (col) => col.notNull())
-      .addColumn("type", "text", (col) => col.notNull())
-      .addColumn("category", "text")
-      .addColumn("title", "text")
-      .addColumn("body", "text", (col) => col.notNull())
-      .addColumn("data_json", "text", (col) => col.notNull())
-      .addColumn("read_at", "text")
-      .addColumn("created_at", "text", (col) => col.notNull())
-      .execute();
+    // Inbox listing (per user + group, newest first). Also the path used by
+    // unreadCount — `WHERE read_at IS NULL` filters a small subset of the
+    // already-narrowed (user_id, group_id) slice, so a separate unread index
+    // would be redundant.
+    await sql`CREATE INDEX idx_notifications_user_group_created ON notifications(user_id, group_id, created_at)`.execute(db);
 
-    await db.schema
-      .createIndex("idx_notifications_user_group_created")
-      .on("notifications")
-      .columns(["user_id", "group_id", "created_at"])
-      .execute();
-
-    await db.schema
-      .createIndex("idx_notifications_user_unread")
-      .on("notifications")
-      .columns(["user_id", "read_at"])
-      .execute();
-
-    await db.schema
-      .createIndex("idx_notifications_created_at")
-      .on("notifications")
-      .column("created_at")
-      .execute();
+    // Used only by the retention prune cron. Cheap on a 10-day-windowed table.
+    await sql`CREATE INDEX idx_notifications_created_at ON notifications(created_at)`.execute(db);
 
     console.log("✅ Created notifications table + indexes");
   } else {

--- a/migrations/20260429120000-add-notifications-inbox.ts
+++ b/migrations/20260429120000-add-notifications-inbox.ts
@@ -1,0 +1,61 @@
+// Migration: add-notifications-inbox
+// Adds the `notifications` table that backs the per-user, per-group inbox.
+// Push delivery (Expo) stays fire-and-forget; this table makes events
+// readable later (especially on web where there is no push).
+
+import { sql } from "kysely";
+import type { Kysely, Migration } from "kysely";
+
+export const up: Migration["up"] = async (db: Kysely<any>) => {
+  const tableExists = async (table: string) => {
+    const result = await sql<{ name: string }>`
+      SELECT name FROM sqlite_master WHERE type='table' AND name=${table}
+    `.execute(db);
+    return result.rows.length > 0;
+  };
+
+  if (!(await tableExists("notifications"))) {
+    await db.schema
+      .createTable("notifications")
+      .addColumn("id", "text", (col) => col.primaryKey().notNull())
+      .addColumn("user_id", "text", (col) => col.notNull())
+      .addColumn("group_id", "text", (col) => col.notNull())
+      .addColumn("type", "text", (col) => col.notNull())
+      .addColumn("category", "text")
+      .addColumn("title", "text")
+      .addColumn("body", "text", (col) => col.notNull())
+      .addColumn("data_json", "text", (col) => col.notNull())
+      .addColumn("read_at", "text")
+      .addColumn("created_at", "text", (col) => col.notNull())
+      .execute();
+
+    await db.schema
+      .createIndex("idx_notifications_user_group_created")
+      .on("notifications")
+      .columns(["user_id", "group_id", "created_at"])
+      .execute();
+
+    await db.schema
+      .createIndex("idx_notifications_user_unread")
+      .on("notifications")
+      .columns(["user_id", "read_at"])
+      .execute();
+
+    await db.schema
+      .createIndex("idx_notifications_created_at")
+      .on("notifications")
+      .column("created_at")
+      .execute();
+
+    console.log("✅ Created notifications table + indexes");
+  } else {
+    console.log("⏭️  notifications table already exists, skipping");
+  }
+
+  console.log("✅ Migration: add-notifications-inbox completed");
+};
+
+export const down: Migration["down"] = async (db: Kysely<any>) => {
+  await db.schema.dropTable("notifications").ifExists().execute();
+  console.log("↩️ Dropped notifications table");
+};

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -95,5 +95,15 @@ export type {
   NotificationPreferencesUpdate,
 } from "@repo/shared/domain";
 
+// Notifications inbox (group-scoped) — list + unread badge + mark read
+export {
+  useNotifications,
+  useUnreadNotificationCount,
+  useMarkNotificationRead,
+  useMarkAllNotificationsRead,
+  notificationInboxQueryKeys,
+} from "./notifications-inbox";
+export type { InboxNotification, InboxPage } from "./notifications-inbox";
+
 // Re-export the API routes type for convenience
 export type { ApiRoutes } from "../../../apps/api/src/index";

--- a/packages/api-client/src/notifications-inbox.ts
+++ b/packages/api-client/src/notifications-inbox.ts
@@ -134,10 +134,10 @@ export function useMarkNotificationRead() {
       if (ctx.previousUnread)
         queryClient.setQueryData(unreadKey, ctx.previousUnread);
     },
-    onSettled: () => {
-      const groupId = getActiveGroupId();
+    onSettled: (_data, _err, _id, ctx) => {
+      if (!ctx) return;
       void queryClient.invalidateQueries({
-        queryKey: notificationInboxQueryKeys.unread(groupId),
+        queryKey: notificationInboxQueryKeys.unread(ctx.groupId),
       });
     },
   });
@@ -199,10 +199,10 @@ export function useMarkAllNotificationsRead() {
       if (ctx.previousUnread)
         queryClient.setQueryData(unreadKey, ctx.previousUnread);
     },
-    onSettled: () => {
-      const groupId = getActiveGroupId();
+    onSettled: (_data, _err, _vars, ctx) => {
+      if (!ctx) return;
       void queryClient.invalidateQueries({
-        queryKey: notificationInboxQueryKeys.unread(groupId),
+        queryKey: notificationInboxQueryKeys.unread(ctx.groupId),
       });
     },
   });

--- a/packages/api-client/src/notifications-inbox.ts
+++ b/packages/api-client/src/notifications-inbox.ts
@@ -11,6 +11,7 @@ import type { InboxNotification } from "@repo/shared/domain";
 import { useSession } from "./auth";
 import { client as _client } from "./client";
 import { getActiveGroupId } from "./group-storage";
+import { useCurrentGroup } from "./groups";
 
 // Hono RPC's deep generics resolve as `unknown` across this package boundary.
 
@@ -34,7 +35,11 @@ export const notificationInboxQueryKeys = {
 
 export function useNotifications(opts: { limit?: number } = {}) {
   const { data: session } = useSession();
-  const groupId = getActiveGroupId();
+  // Use the reactive current-group hook instead of the synchronous
+  // `getActiveGroupId()` accessor — on web, AsyncStorage hydrates asynchronously,
+  // so the sync read returns null on first render and the query stays disabled
+  // forever. `useCurrentGroup` re-renders once `useMyGroups` resolves.
+  const { groupId } = useCurrentGroup();
   const limit = opts.limit ?? 30;
 
   return useInfiniteQuery<InboxPage>({
@@ -54,7 +59,7 @@ export function useNotifications(opts: { limit?: number } = {}) {
 
 export function useUnreadNotificationCount() {
   const { data: session } = useSession();
-  const groupId = getActiveGroupId();
+  const { groupId } = useCurrentGroup();
 
   return useQuery<{ unreadCount: number }>({
     queryKey: notificationInboxQueryKeys.unread(groupId),

--- a/packages/api-client/src/notifications-inbox.ts
+++ b/packages/api-client/src/notifications-inbox.ts
@@ -61,7 +61,6 @@ export function useUnreadNotificationCount() {
     enabled: !!session?.user && !!groupId,
     refetchOnWindowFocus: true,
     refetchOnMount: true,
-    refetchInterval: 60_000, // gentle background poll while the app is open
     queryFn: async () => {
       const res = await client.api.notifications["unread-count"].$get();
       return (await res.json()) as { unreadCount: number };

--- a/packages/api-client/src/notifications-inbox.ts
+++ b/packages/api-client/src/notifications-inbox.ts
@@ -1,0 +1,209 @@
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type InfiniteData,
+} from "@tanstack/react-query";
+
+import type { InboxNotification } from "@repo/shared/domain";
+
+import { useSession } from "./auth";
+import { client as _client } from "./client";
+import { getActiveGroupId } from "./group-storage";
+
+// Hono RPC's deep generics resolve as `unknown` across this package boundary.
+
+const client = _client as any;
+
+export type { InboxNotification };
+
+export interface InboxPage {
+  items: InboxNotification[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+export const notificationInboxQueryKeys = {
+  all: ["notifications-inbox"] as const,
+  list: (groupId: string | null) =>
+    [...notificationInboxQueryKeys.all, "list", groupId ?? "_none"] as const,
+  unread: (groupId: string | null) =>
+    [...notificationInboxQueryKeys.all, "unread", groupId ?? "_none"] as const,
+};
+
+export function useNotifications(opts: { limit?: number } = {}) {
+  const { data: session } = useSession();
+  const groupId = getActiveGroupId();
+  const limit = opts.limit ?? 30;
+
+  return useInfiniteQuery<InboxPage>({
+    queryKey: notificationInboxQueryKeys.list(groupId),
+    enabled: !!session?.user && !!groupId,
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore && lastPage.nextCursor ? lastPage.nextCursor : undefined,
+    queryFn: async ({ pageParam }) => {
+      const query: Record<string, string> = { limit: String(limit) };
+      if (typeof pageParam === "string") query.before = pageParam;
+      const res = await client.api.notifications.$get({ query });
+      return (await res.json()) as InboxPage;
+    },
+  });
+}
+
+export function useUnreadNotificationCount() {
+  const { data: session } = useSession();
+  const groupId = getActiveGroupId();
+
+  return useQuery<{ unreadCount: number }>({
+    queryKey: notificationInboxQueryKeys.unread(groupId),
+    enabled: !!session?.user && !!groupId,
+    refetchOnWindowFocus: true,
+    refetchOnMount: true,
+    refetchInterval: 60_000, // gentle background poll while the app is open
+    queryFn: async () => {
+      const res = await client.api.notifications["unread-count"].$get();
+      return (await res.json()) as { unreadCount: number };
+    },
+  });
+}
+
+interface MarkReadContext {
+  previousList?: InfiniteData<InboxPage>;
+  previousUnread?: { unreadCount: number };
+  groupId: string | null;
+}
+
+export function useMarkNotificationRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation<{ success: true }, Error, string, MarkReadContext>({
+    mutationFn: async (id) => {
+      const res = await client.api.notifications[":id"].read.$patch({
+        param: { id },
+      });
+      return (await res.json()) as { success: true };
+    },
+    onMutate: async (id) => {
+      const groupId = getActiveGroupId();
+      const listKey = notificationInboxQueryKeys.list(groupId);
+      const unreadKey = notificationInboxQueryKeys.unread(groupId);
+
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: listKey }),
+        queryClient.cancelQueries({ queryKey: unreadKey }),
+      ]);
+
+      const previousList =
+        queryClient.getQueryData<InfiniteData<InboxPage>>(listKey);
+      const previousUnread = queryClient.getQueryData<{ unreadCount: number }>(
+        unreadKey,
+      );
+
+      if (previousList) {
+        let didFlip = false;
+        const now = new Date().toISOString();
+        const next: InfiniteData<InboxPage> = {
+          ...previousList,
+          pages: previousList.pages.map((page) => ({
+            ...page,
+            items: page.items.map((item) => {
+              if (item.id !== id || item.readAt) return item;
+              didFlip = true;
+              return { ...item, readAt: now };
+            }),
+          })),
+        };
+        if (didFlip) queryClient.setQueryData(listKey, next);
+      }
+
+      if (previousUnread && previousUnread.unreadCount > 0) {
+        queryClient.setQueryData(unreadKey, {
+          unreadCount: Math.max(0, previousUnread.unreadCount - 1),
+        });
+      }
+
+      return { previousList, previousUnread, groupId };
+    },
+    onError: (_err, _id, ctx) => {
+      if (!ctx) return;
+      const listKey = notificationInboxQueryKeys.list(ctx.groupId);
+      const unreadKey = notificationInboxQueryKeys.unread(ctx.groupId);
+      if (ctx.previousList) queryClient.setQueryData(listKey, ctx.previousList);
+      if (ctx.previousUnread)
+        queryClient.setQueryData(unreadKey, ctx.previousUnread);
+    },
+    onSettled: () => {
+      const groupId = getActiveGroupId();
+      void queryClient.invalidateQueries({
+        queryKey: notificationInboxQueryKeys.unread(groupId),
+      });
+    },
+  });
+}
+
+interface MarkAllReadContext {
+  previousList?: InfiniteData<InboxPage>;
+  previousUnread?: { unreadCount: number };
+  groupId: string | null;
+}
+
+export function useMarkAllNotificationsRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation<{ updated: number }, Error, void, MarkAllReadContext>({
+    mutationFn: async () => {
+      const res = await client.api.notifications["read-all"].$post();
+      return (await res.json()) as { updated: number };
+    },
+    onMutate: async () => {
+      const groupId = getActiveGroupId();
+      const listKey = notificationInboxQueryKeys.list(groupId);
+      const unreadKey = notificationInboxQueryKeys.unread(groupId);
+
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: listKey }),
+        queryClient.cancelQueries({ queryKey: unreadKey }),
+      ]);
+
+      const previousList =
+        queryClient.getQueryData<InfiniteData<InboxPage>>(listKey);
+      const previousUnread = queryClient.getQueryData<{ unreadCount: number }>(
+        unreadKey,
+      );
+
+      if (previousList) {
+        const now = new Date().toISOString();
+        const next: InfiniteData<InboxPage> = {
+          ...previousList,
+          pages: previousList.pages.map((page) => ({
+            ...page,
+            items: page.items.map((item) =>
+              item.readAt ? item : { ...item, readAt: now },
+            ),
+          })),
+        };
+        queryClient.setQueryData(listKey, next);
+      }
+
+      queryClient.setQueryData(unreadKey, { unreadCount: 0 });
+
+      return { previousList, previousUnread, groupId };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (!ctx) return;
+      const listKey = notificationInboxQueryKeys.list(ctx.groupId);
+      const unreadKey = notificationInboxQueryKeys.unread(ctx.groupId);
+      if (ctx.previousList) queryClient.setQueryData(listKey, ctx.previousList);
+      if (ctx.previousUnread)
+        queryClient.setQueryData(unreadKey, ctx.previousUnread);
+    },
+    onSettled: () => {
+      const groupId = getActiveGroupId();
+      void queryClient.invalidateQueries({
+        queryKey: notificationInboxQueryKeys.unread(groupId),
+      });
+    },
+  });
+}

--- a/packages/shared/src/database/schema.ts
+++ b/packages/shared/src/database/schema.ts
@@ -203,6 +203,19 @@ export interface UserNotificationPrefsTable {
   updated_at: ColumnType<Date, string | undefined, string>;
 }
 
+export interface NotificationsTable {
+  id: string;
+  user_id: string;
+  group_id: string;
+  type: string;
+  category: string | null;
+  title: string | null;
+  body: string;
+  data_json: string;
+  read_at: string | null;
+  created_at: string;
+}
+
 // BetterAuth verification table (used for password reset codes, OTPs, etc.)
 export interface VerificationTable {
   id: string;
@@ -284,6 +297,7 @@ export interface Database {
   match_votes: MatchVotesTable;
   push_tokens: PushTokensTable;
   user_notification_prefs: UserNotificationPrefsTable;
+  notifications: NotificationsTable;
   verification: VerificationTable;
   groups: GroupsTable;
   group_members: GroupMembersTable;
@@ -357,6 +371,10 @@ export type PushTokenUpdate = Updateable<PushTokensTable>;
 export type UserNotificationPrefs = Selectable<UserNotificationPrefsTable>;
 export type NewUserNotificationPrefs = Insertable<UserNotificationPrefsTable>;
 export type UserNotificationPrefsUpdate = Updateable<UserNotificationPrefsTable>;
+
+export type NotificationRow = Selectable<NotificationsTable>;
+export type NewNotificationRow = Insertable<NotificationsTable>;
+export type NotificationRowUpdate = Updateable<NotificationsTable>;
 
 export type Group = Selectable<GroupsTable>;
 export type NewGroup = Insertable<GroupsTable>;

--- a/packages/shared/src/domain/types.ts
+++ b/packages/shared/src/domain/types.ts
@@ -616,6 +616,23 @@ export const NOTIFICATION_PREF_TO_COLUMN: Record<
   pushPromoToConfirmed: "push_promo_to_confirmed",
 };
 
+// Inbox row — persisted record of a notification we sent (or would have sent
+// if the user had push enabled). Group-scoped so an active-group switch
+// changes which rows are visible. `data` mirrors the push payload's `data`
+// field so deep-link handling is the same on tap.
+export interface InboxNotification {
+  id: string;
+  userId: string;
+  groupId: string;
+  type: NotificationType;
+  category: NotificationCategory | null;
+  title: string | null;
+  body: string;
+  data: NotificationPayload["data"];
+  readAt: string | null;
+  createdAt: string;
+}
+
 // Helper types for pagination and responses
 
 export interface PaginatedResponse<T> {

--- a/packages/shared/src/repositories/factory.ts
+++ b/packages/shared/src/repositories/factory.ts
@@ -22,6 +22,7 @@ import {
 } from "./turso-repositories";
 
 import { TursoPushTokenRepository } from "./push-token-repository";
+import { TursoNotificationInboxRepository } from "./notification-inbox-repository";
 import {
   TursoGroupRepository,
   TursoGroupMembershipRepository,
@@ -42,6 +43,7 @@ export class AppRepositoryFactory implements RepositoryFactory {
   public readonly invitations: MatchInvitationRepository;
   public readonly playerStats: PlayerStatsRepository;
   public readonly pushTokens: PushTokenRepository;
+  public readonly notificationInbox: TursoNotificationInboxRepository;
   public readonly matchMedia: TursoMatchMediaRepository;
   public readonly groups: TursoGroupRepository;
   public readonly groupMembers: TursoGroupMembershipRepository;
@@ -60,6 +62,7 @@ export class AppRepositoryFactory implements RepositoryFactory {
         this.invitations = new TursoMatchInvitationRepository();
         this.playerStats = new TursoPlayerStatsRepository();
         this.pushTokens = new TursoPushTokenRepository();
+        this.notificationInbox = new TursoNotificationInboxRepository();
         this.matchMedia = new TursoMatchMediaRepository();
         this.groups = new TursoGroupRepository();
         this.groupMembers = new TursoGroupMembershipRepository();

--- a/packages/shared/src/repositories/index.ts
+++ b/packages/shared/src/repositories/index.ts
@@ -3,4 +3,5 @@ export * from "./interfaces";
 export * from "./turso-repositories";
 export * from "./voting-repository";
 export * from "./push-token-repository";
+export * from "./notification-inbox-repository";
 export * from "./group-repositories";

--- a/packages/shared/src/repositories/notification-inbox-repository.ts
+++ b/packages/shared/src/repositories/notification-inbox-repository.ts
@@ -100,6 +100,9 @@ export class TursoNotificationInboxRepository {
 
   async insertMany(rows: NewInboxNotification[]): Promise<void> {
     if (rows.length === 0) return;
+    // Single timestamp shared by every row in this call is intentional:
+    // a fan-out is conceptually one event, and the (created_at, id) cursor
+    // tiebreaks within the slice. Don't recompute per-chunk.
     const now = new Date().toISOString();
 
     // Chunk to stay within SQLite parameter limits (~999 binds; 10 cols/row).

--- a/packages/shared/src/repositories/notification-inbox-repository.ts
+++ b/packages/shared/src/repositories/notification-inbox-repository.ts
@@ -1,0 +1,214 @@
+// Turso/LibSQL implementation of the notification inbox repository.
+// Persists every user-facing notification we send (except group invites,
+// which already have a dedicated UX) so users can see history later — even
+// on web, where push delivery is unsupported.
+
+import { nanoid } from "nanoid";
+
+import type {
+  InboxNotification,
+  NotificationCategory,
+  NotificationPayload,
+  NotificationType,
+} from "../domain/types";
+
+import { getDatabase } from "../database/connection";
+
+export interface NewInboxNotification {
+  userId: string;
+  groupId: string;
+  type: NotificationType;
+  category?: NotificationCategory | null;
+  title?: string | null;
+  body: string;
+  data: NotificationPayload["data"];
+}
+
+export interface ListInboxOptions {
+  limit?: number;
+  // Opaque cursor of the form `${created_at}|${id}`. The id tiebreaker is
+  // load-bearing: chunked inserts share a single `created_at`, so without it
+  // a page boundary that lands inside a chunk drops or duplicates rows.
+  before?: string;
+}
+
+export interface ListInboxResult {
+  items: InboxNotification[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+const DEFAULT_LIMIT = 30;
+const MAX_LIMIT = 100;
+const CURSOR_SEP = "|";
+
+function generateId(): string {
+  return nanoid();
+}
+
+function parseCursor(
+  cursor: string,
+): { createdAt: string; id: string } | null {
+  const sep = cursor.indexOf(CURSOR_SEP);
+  if (sep <= 0 || sep === cursor.length - 1) return null;
+  return {
+    createdAt: cursor.slice(0, sep),
+    id: cursor.slice(sep + 1),
+  };
+}
+
+function encodeCursor(createdAt: string, id: string): string {
+  return `${createdAt}${CURSOR_SEP}${id}`;
+}
+
+function rowToInbox(row: {
+  id: string;
+  user_id: string;
+  group_id: string;
+  type: string;
+  category: string | null;
+  title: string | null;
+  body: string;
+  data_json: string;
+  read_at: string | null;
+  created_at: string;
+}): InboxNotification {
+  let parsed: NotificationPayload["data"] = undefined;
+  try {
+    parsed = row.data_json ? JSON.parse(row.data_json) : undefined;
+  } catch {
+    parsed = undefined;
+  }
+  return {
+    id: row.id,
+    userId: row.user_id,
+    groupId: row.group_id,
+    type: row.type as NotificationType,
+    category: (row.category as NotificationCategory | null) ?? null,
+    title: row.title,
+    body: row.body,
+    data: parsed,
+    readAt: row.read_at,
+    createdAt: row.created_at,
+  };
+}
+
+export class TursoNotificationInboxRepository {
+  private get db() {
+    return getDatabase();
+  }
+
+  async insertMany(rows: NewInboxNotification[]): Promise<void> {
+    if (rows.length === 0) return;
+    const now = new Date().toISOString();
+
+    // Chunk to stay within SQLite parameter limits (~999 binds; 10 cols/row).
+    const chunkSize = 90;
+    for (let i = 0; i < rows.length; i += chunkSize) {
+      const chunk = rows.slice(i, i + chunkSize).map((r) => ({
+        id: generateId(),
+        user_id: r.userId,
+        group_id: r.groupId,
+        type: r.type,
+        category: r.category ?? null,
+        title: r.title ?? null,
+        body: r.body,
+        data_json: JSON.stringify(r.data ?? {}),
+        read_at: null,
+        created_at: now,
+      }));
+      await this.db.insertInto("notifications").values(chunk).execute();
+    }
+  }
+
+  async listByUserAndGroup(
+    userId: string,
+    groupId: string,
+    opts: ListInboxOptions = {},
+  ): Promise<ListInboxResult> {
+    const requested = opts.limit ?? DEFAULT_LIMIT;
+    const limit = Math.min(Math.max(requested, 1), MAX_LIMIT);
+
+    let query = this.db
+      .selectFrom("notifications")
+      .selectAll()
+      .where("user_id", "=", userId)
+      .where("group_id", "=", groupId)
+      .orderBy("created_at", "desc")
+      .orderBy("id", "desc")
+      .limit(limit + 1);
+
+    if (opts.before) {
+      const cursor = parseCursor(opts.before);
+      if (cursor) {
+        query = query.where((eb) =>
+          eb.or([
+            eb("created_at", "<", cursor.createdAt),
+            eb.and([
+              eb("created_at", "=", cursor.createdAt),
+              eb("id", "<", cursor.id),
+            ]),
+          ]),
+        );
+      }
+    }
+
+    const rows = await query.execute();
+    const hasMore = rows.length > limit;
+    const trimmed = hasMore ? rows.slice(0, limit) : rows;
+    const last = trimmed[trimmed.length - 1];
+    const nextCursor =
+      hasMore && last
+        ? encodeCursor(last.created_at as string, last.id as string)
+        : null;
+
+    return {
+      items: trimmed.map(rowToInbox),
+      hasMore,
+      nextCursor,
+    };
+  }
+
+  async unreadCount(userId: string, groupId: string): Promise<number> {
+    const row = await this.db
+      .selectFrom("notifications")
+      .select((eb) => eb.fn.countAll<number>().as("count"))
+      .where("user_id", "=", userId)
+      .where("group_id", "=", groupId)
+      .where("read_at", "is", null)
+      .executeTakeFirst();
+    return Number(row?.count ?? 0);
+  }
+
+  async markRead(id: string, userId: string): Promise<boolean> {
+    const now = new Date().toISOString();
+    const result = await this.db
+      .updateTable("notifications")
+      .set({ read_at: now })
+      .where("id", "=", id)
+      .where("user_id", "=", userId)
+      .where("read_at", "is", null)
+      .execute();
+    return Number(result[0]?.numUpdatedRows ?? 0) > 0;
+  }
+
+  async markAllRead(userId: string, groupId: string): Promise<number> {
+    const now = new Date().toISOString();
+    const result = await this.db
+      .updateTable("notifications")
+      .set({ read_at: now })
+      .where("user_id", "=", userId)
+      .where("group_id", "=", groupId)
+      .where("read_at", "is", null)
+      .execute();
+    return Number(result[0]?.numUpdatedRows ?? 0);
+  }
+
+  async deleteOlderThan(cutoffISO: string): Promise<number> {
+    const result = await this.db
+      .deleteFrom("notifications")
+      .where("created_at", "<", cutoffISO)
+      .execute();
+    return Number(result[0]?.numDeletedRows ?? 0);
+  }
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./display-name";
 export * from "./timezone";
+export * from "./notification-routes";

--- a/packages/shared/src/utils/notification-routes.ts
+++ b/packages/shared/src/utils/notification-routes.ts
@@ -1,0 +1,41 @@
+// Single resolver shared by push-tap (use-push-notifications.ts) and
+// inbox-tap (app/inbox.tsx). Keeps deep-link logic in one place if templates
+// ever need conditional routing — today templates already set `data.screen`,
+// so this is mostly a passthrough with type-based fallbacks.
+
+import {
+  NOTIFICATION_TYPES,
+  type NotificationPayload,
+  type NotificationType,
+} from "../domain/types";
+
+const FALLBACK_ROUTE = "/(tabs)";
+const MATCHES_ROUTE = "/(tabs)/matches";
+
+const MATCHES_FALLBACK_TYPES = new Set<NotificationType>([
+  NOTIFICATION_TYPES.MATCH_CREATED,
+  NOTIFICATION_TYPES.MATCH_UPDATED,
+  NOTIFICATION_TYPES.MATCH_CANCELLED,
+  NOTIFICATION_TYPES.MATCH_REMINDER,
+  NOTIFICATION_TYPES.PLAYER_CONFIRMED,
+  NOTIFICATION_TYPES.SUBSTITUTE_PROMOTED,
+  NOTIFICATION_TYPES.PLAYER_CANCELLED,
+  NOTIFICATION_TYPES.REMOVED_FROM_MATCH,
+  NOTIFICATION_TYPES.PAYMENT_REMINDER,
+  NOTIFICATION_TYPES.VOTING_OPEN,
+]);
+
+export function getNotificationRoute(
+  data: NotificationPayload["data"] | null | undefined,
+): string {
+  if (!data) return FALLBACK_ROUTE;
+  const screen = (data as { screen?: unknown }).screen;
+  if (typeof screen === "string" && screen.length > 0) {
+    return screen;
+  }
+  const type = (data as { type?: unknown }).type as
+    | NotificationType
+    | undefined;
+  if (type && MATCHES_FALLBACK_TYPES.has(type)) return MATCHES_ROUTE;
+  return FALLBACK_ROUTE;
+}


### PR DESCRIPTION
## Summary

Adds an in-app notifications inbox alongside the existing transient push layer. Inbox rows persist on every send (except group invites, which already have a dedicated UX), so users see history on **web** and **native**, independent of push opt-out.

- **Schema + repo**: new `notifications` table indexed on `(user_id, group_id, created_at DESC)` and `(user_id, read_at)`. `listByUserAndGroup` uses a composite `(created_at, id)` cursor so chunked inserts (which all share one `created_at`) paginate correctly.
- **API**: `GET /api/notifications`, `GET /api/notifications/unread-count`, `PATCH /:id/read`, `POST /read-all` — all scoped via `X-Group-Id`. Existing admin `POST /send-test` preserved.
- **Recorder + wire-up**: `recordForRecipients` is called from every notify helper before the push send (group invites excluded). For cross-group senders (`notifyMatchCreated`, `notifyPlayerCancelled`) the recipient list is intersected with group members for both inbox writes *and* the Expo push call. Cron match reminders + the voting-open trigger record too.
- **Retention**: `pruneInboxNotifications` deletes rows older than 10 days; registered in the `scheduled` handler alongside the other crons (cheap, idempotent) and exposed via a manual trigger.
- **Shared deep-link resolver**: `getNotificationRoute(data)` in `@repo/shared/utils` is used by both push-tap and inbox-tap so the routing logic stays in one place.
- **Mobile-web**: bell with unread badge in the home header, dedicated `/inbox` screen, presentation/navigation split (`<NotificationInbox onItemPress />` + parent screen owns navigation), optimistic mark-read / mark-all-read mutations, EN+ES copy.
- **CLAUDE.md**: new "Notifications System" section documenting both layers, invariants, and a cookbook for adding new notification types so future sessions don't need to re-investigate.

## Test plan

- [ ] `pnpm typecheck` clean across `@repo/shared`, `@repo/api-client`, and `api`.
- [ ] `pnpm -w run migrate:up` then `migrate:down` — round-trips cleanly.
- [ ] Native: create a match in group A, second user receives push **and** sees an inbox row; switch active group to B, inbox is empty (group scoping); tap row deep-links to the match; mark-all-read zeroes the badge.
- [ ] Web: trigger a match update from another session; inbox shows the new row on focus / refresh even though no push fires.
- [ ] Pagination: insert >30 inbox rows in one fan-out chunk (same `created_at`); verify the second page fetches the rest without dupes/skips (composite cursor fix).
- [ ] Retention: invoke `POST /api/cron/prune-inbox` with a fixture row dated 11 days ago + a fresh row; only the old one is deleted.
- [ ] Push tap: confirm push notifications still navigate (now via `getNotificationRoute`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)