### PR TITLE
fix(matches): show same-day surcharge in cost stat card

### DIFF
--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -749,45 +749,52 @@ export default function MatchDetailScreen() {
 
           {/* Stats Card */}
           <Card variant="outlined">
-            <XStack padding="$3" justifyContent="space-around">
-              <YStack alignItems="center">
-                <Text fontSize="$3" color="$gray10" marginBottom="$1">
-                  {t("stats.availableSpots")}
-                </Text>
-                <Text
-                  fontSize="$7"
-                  fontWeight="bold"
-                  color={match.availableSpots > 0 ? "$green10" : "$color"}
-                >
-                  {match.availableSpots}
-                </Text>
-              </YStack>
-
-              <YStack alignItems="center">
-                <Text fontSize="$3" color="$gray10" marginBottom="$1">
-                  {t("stats.cost")}
-                </Text>
-                <Text fontSize="$7" fontWeight="bold">
-                  {match.costPerPlayer
-                    ? `€${totalCost}`
-                    : t("stats.free")}
-                </Text>
-                {isMatchToday && sameDayCost > 0 && (
-                  <Text fontSize="$2" color="$orange10" marginTop="$1">
-                    +€{sameDayCost} {t("matchDetail.sameDayFee").toLowerCase()}
+            <YStack padding="$3" gap="$2">
+              <XStack justifyContent="space-around">
+                <YStack alignItems="center">
+                  <Text fontSize="$3" color="$gray10" marginBottom="$1">
+                    {t("stats.availableSpots")}
                   </Text>
-                )}
-              </YStack>
+                  <Text
+                    fontSize="$7"
+                    fontWeight="bold"
+                    color={match.availableSpots > 0 ? "$green10" : "$color"}
+                  >
+                    {match.availableSpots}
+                  </Text>
+                </YStack>
 
-              <YStack alignItems="center">
-                <Text fontSize="$3" color="$gray10" marginBottom="$1">
-                  {t("stats.court")}
+                <YStack alignItems="center">
+                  <Text fontSize="$3" color="$gray10" marginBottom="$1">
+                    {t("stats.cost")}
+                  </Text>
+                  <Text fontSize="$7" fontWeight="bold">
+                    {match.costPerPlayer
+                      ? `€${totalCost}`
+                      : t("stats.free")}
+                  </Text>
+                </YStack>
+
+                <YStack alignItems="center">
+                  <Text fontSize="$3" color="$gray10" marginBottom="$1">
+                    {t("stats.court")}
+                  </Text>
+                  <Text fontSize="$7" fontWeight="bold">
+                    {match.court?.name || "-"}
+                  </Text>
+                </YStack>
+              </XStack>
+
+              {isMatchToday && sameDayCost > 0 && (
+                <Text
+                  fontSize="$2"
+                  color="$orange10"
+                  textAlign="center"
+                >
+                  +€{sameDayCost} {t("matchDetail.sameDayFee").toLowerCase()}
                 </Text>
-                <Text fontSize="$7" fontWeight="bold">
-                  {match.court?.name || "-"}
-                </Text>
-              </YStack>
-            </XStack>
+              )}
+            </YStack>
           </Card>
 
           {/* View A: Not Participating - Show CTA (only for upcoming matches) */}

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -850,7 +850,7 @@ export default function MatchDetailScreen() {
                   alignItems="center"
                 >
                   <Text fontSize="$6" fontWeight="bold">
-                    {t("players.title")} ({match.signups?.length || 0})
+                    {t("players.title")}
                   </Text>
                   {!isPlayed &&
                     isOrganizer &&

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -52,6 +52,7 @@ import {
   Linking,
 } from "react-native";
 import { Image } from "expo-image";
+import { formatMatchDate } from "@repo/shared/utils";
 
 import { formatFullDate } from "@/lib/date-utils";
 import {
@@ -600,17 +601,9 @@ export default function MatchDetailScreen() {
     match?.userSignup?.status === "PAID" ||
     match?.userSignup?.status === "PENDING";
 
-  // Check if match is today for same-day cost
+  // Check if match is today (in app timezone, not device timezone)
   const isMatchToday = match
-    ? (() => {
-        const today = new Date();
-        const matchDate = new Date(match.date + "T12:00:00");
-        return (
-          today.getFullYear() === matchDate.getFullYear() &&
-          today.getMonth() === matchDate.getMonth() &&
-          today.getDate() === matchDate.getDate()
-        );
-      })()
+    ? formatMatchDate(new Date()) === match.date
     : false;
 
   // Calculate total cost for same-day matches
@@ -776,9 +769,14 @@ export default function MatchDetailScreen() {
                 </Text>
                 <Text fontSize="$7" fontWeight="bold">
                   {match.costPerPlayer
-                    ? `€${match.costPerPlayer}`
+                    ? `€${totalCost}`
                     : t("stats.free")}
                 </Text>
+                {isMatchToday && sameDayCost > 0 && (
+                  <Text fontSize="$2" color="$orange10" marginTop="$1">
+                    +€{sameDayCost} {t("matchDetail.sameDayFee").toLowerCase()}
+                  </Text>
+                )}
               </YStack>
 
               <YStack alignItems="center">

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -791,7 +791,7 @@ export default function MatchDetailScreen() {
                   color="$orange10"
                   textAlign="center"
                 >
-                  +€{sameDayCost} {t("matchDetail.sameDayFee").toLowerCase()}
+                  {t("matchDetail.sameDayFeeHint", { amount: sameDayCost })}
                 </Text>
               )}
             </YStack>

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -67,6 +67,7 @@
     "claimSpot": "Claim it now!",
     "spotTaken": "Sorry, someone else claimed the spot",
     "sameDayFee": "Same-day fee",
+    "sameDayFeeHint": "+€{{amount}} same-day fee",
     "totalCost": "Total",
     "matchCompletelyFull": "Match and substitute list are full",
     "cancelSpotTitle": "Cancel your spot?",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -68,6 +68,7 @@
     "claimSpot": "¡Reclamalo ahora!",
     "spotTaken": "Lo siento, alguien más reclamó el lugar",
     "sameDayFee": "Recargo mismo día",
+    "sameDayFeeHint": "+€{{amount}} recargo mismo día",
     "totalCost": "Total",
     "matchCompletelyFull": "El partido y la lista de suplentes están completos",
     "cancelSpotTitle": "¿Cancelar tu lugar?",

--- a/packages/shared/src/utils/timezone.ts
+++ b/packages/shared/src/utils/timezone.ts
@@ -31,7 +31,10 @@ export function convertFromAppTimezone(
   return toZonedTime(date, targetTimezone);
 }
 
-export function formatMatchDate(date: string, timezone?: string): string {
+export function formatMatchDate(
+  date: Date | string,
+  timezone?: string,
+): string {
   return formatDateInAppTimezone(date, "yyyy-MM-dd", timezone);
 }
 


### PR DESCRIPTION
## Summary
- The prominent **Cost (p.p.)** stat card on the match detail page only showed the base `costPerPlayer`, even on match day when a same-day surcharge applies. Users saw €7 for a match that actually costs €10 — the breakdown existed in the payment-info section lower on the page, but the top-of-page price was misleading.
- Stat card now shows the effective `totalCost` (base + surcharge when same-day) with a small orange `+€N same-day fee` hint below it. Reuses the existing `isMatchToday` / `totalCost` calculations already wired up in the file.
- Replaced the device-local `isMatchToday` check with the shared `formatMatchDate` helper from `@repo/shared/utils`, so the surcharge is computed against today's date in the app timezone (Europe/Berlin) rather than the device's local calendar day. This ensures users in other timezones see the surcharge on the correct match day.

## Test plan
- [ ] Open a match scheduled for today with a non-zero `same_day_cost` → cost card shows base + surcharge total, with orange hint underneath
- [ ] Open a match scheduled for a future date → cost card shows base price only, no hint
- [ ] Open a match with no `same_day_cost` configured → cost card shows base price, no hint
- [ ] Verify the existing payment-info breakdown lower on the page still renders the same values
- [ ] Switch device timezone (e.g. America/Argentina/Buenos_Aires) on a match-day evening when Berlin is already past midnight (or vice versa) — surcharge should follow Berlin's calendar day

🤖 Generated with [Claude Code](https://claude.com/claude-code)