### PR TITLE
feat(voting): add per-match stats screen with voting window

### DIFF
--- a/apps/api/src/routes/voting.ts
+++ b/apps/api/src/routes/voting.ts
@@ -1,15 +1,21 @@
-import type { Context } from "hono";
-import { Hono } from "hono";
-import { votingService, getServiceFactory } from "@repo/shared/services";
-import { getRepositoryFactory } from "@repo/shared/repositories";
-import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
-import { type AppVariables, requireUser } from "../middleware/security";
+import { getRepositoryFactory } from "@repo/shared/repositories";
+import { votingService, getServiceFactory } from "@repo/shared/services";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import type { Context } from "hono";
+
+import {
+  assertInCurrentGroup,
+  requireOrganizer,
+  requirePlatformAdmin,
+} from "../middleware/authz";
 import {
   groupContextMiddleware,
   requireCurrentGroup,
 } from "../middleware/group-context";
-import { assertInCurrentGroup, requirePlatformAdmin } from "../middleware/authz";
+import { type AppVariables, requireUser } from "../middleware/security";
 
 const app = new Hono<{ Variables: AppVariables }>();
 
@@ -75,31 +81,27 @@ const createCriteriaSchema = z.object({
   sortOrder: z.number().int().optional(),
 });
 
-app.post(
-  "/criteria",
-  zValidator("json", createCriteriaSchema),
-  async (c) => {
-    try {
-      const denied = requirePlatformAdmin(c);
-      if (denied) return denied;
-      const data = c.req.valid("json");
-      const criteria = await votingService.createCriteria(data);
-      return c.json({ criteria }, 201);
-    } catch (error: any) {
-      console.error("Create criteria error:", error);
-      if (error.message.includes("Admin")) {
-        return c.json({ error: error.message }, 403);
-      }
-      if (error.message.includes("authenticated")) {
-        return c.json({ error: error.message }, 401);
-      }
-      if (error.message.includes("already exists")) {
-        return c.json({ error: error.message }, 400);
-      }
-      return c.json({ error: error.message || "Failed to create criteria" }, 500);
+app.post("/criteria", zValidator("json", createCriteriaSchema), async (c) => {
+  try {
+    const denied = requirePlatformAdmin(c);
+    if (denied) return denied;
+    const data = c.req.valid("json");
+    const criteria = await votingService.createCriteria(data);
+    return c.json({ criteria }, 201);
+  } catch (error: any) {
+    console.error("Create criteria error:", error);
+    if (error.message.includes("Admin")) {
+      return c.json({ error: error.message }, 403);
     }
+    if (error.message.includes("authenticated")) {
+      return c.json({ error: error.message }, 401);
+    }
+    if (error.message.includes("already exists")) {
+      return c.json({ error: error.message }, 400);
+    }
+    return c.json({ error: error.message || "Failed to create criteria" }, 500);
   }
-);
+});
 
 // Update criteria (admin only)
 const updateCriteriaSchema = z.object({
@@ -137,9 +139,12 @@ app.patch(
       if (error.message.includes("already exists")) {
         return c.json({ error: error.message }, 400);
       }
-      return c.json({ error: error.message || "Failed to update criteria" }, 500);
+      return c.json(
+        { error: error.message || "Failed to update criteria" },
+        500,
+      );
     }
-  }
+  },
 );
 
 // Delete criteria (soft delete, admin only)
@@ -174,10 +179,7 @@ app.get("/matches/:matchId", async (c) => {
     const matchId = c.req.param("matchId");
     const notFound = await assertMatchInCurrentGroup(c, matchId);
     if (notFound) return notFound;
-    const votes = await votingService.getUserVotesForMatch(
-      matchId,
-      user.id
-    );
+    const votes = await votingService.getUserVotesForMatch(matchId, user.id);
     return c.json(votes);
   } catch (error: any) {
     console.error("Get user votes error:", error);
@@ -194,7 +196,7 @@ const submitVotesSchema = z.object({
     z.object({
       criteriaId: z.string().min(1),
       votedForUserId: z.string().min(1),
-    })
+    }),
   ),
 });
 
@@ -212,7 +214,7 @@ app.post(
       const submittedVotes = await votingService.submitVotes(
         matchId,
         user.id,
-        votes
+        votes,
       );
 
       return c.json({ votes: submittedVotes }, 201);
@@ -230,8 +232,67 @@ app.post(
       }
       return c.json({ error: error.message || "Failed to submit votes" }, 500);
     }
-  }
+  },
 );
+
+app.get("/matches/:matchId/stats", async (c) => {
+  try {
+    requireUser(c);
+    const matchId = c.req.param("matchId");
+    const notFound = await assertMatchInCurrentGroup(c, matchId);
+    if (notFound) return notFound;
+    const language = getLanguage(c.req.header("Accept-Language"));
+    const stats = await votingService.getMatchStats(matchId, language);
+    return c.json(stats);
+  } catch (error: any) {
+    console.error("Get match stats error:", error);
+    if (error.message.includes("authenticated")) {
+      return c.json({ error: error.message }, 401);
+    }
+    if (error.message.includes("not found")) {
+      return c.json({ error: error.message }, 404);
+    }
+    return c.json({ error: error.message || "Failed to get stats" }, 500);
+  }
+});
+
+app.post("/matches/:matchId/close-voting", async (c) => {
+  try {
+    requireUser(c);
+    const matchId = c.req.param("matchId");
+    const notFound = await assertMatchInCurrentGroup(c, matchId);
+    if (notFound) return notFound;
+    const denied = requireOrganizer(c);
+    if (denied) return denied;
+    await votingService.setMatchVotingState(matchId, true);
+    return c.json({ success: true });
+  } catch (error: any) {
+    console.error("Close voting error:", error);
+    if (error.message.includes("authenticated")) {
+      return c.json({ error: error.message }, 401);
+    }
+    return c.json({ error: error.message || "Failed to close voting" }, 500);
+  }
+});
+
+app.post("/matches/:matchId/reopen-voting", async (c) => {
+  try {
+    requireUser(c);
+    const matchId = c.req.param("matchId");
+    const notFound = await assertMatchInCurrentGroup(c, matchId);
+    if (notFound) return notFound;
+    const denied = requireOrganizer(c);
+    if (denied) return denied;
+    await votingService.setMatchVotingState(matchId, false);
+    return c.json({ success: true });
+  } catch (error: any) {
+    console.error("Reopen voting error:", error);
+    if (error.message.includes("authenticated")) {
+      return c.json({ error: error.message }, 401);
+    }
+    return c.json({ error: error.message || "Failed to reopen voting" }, 500);
+  }
+});
 
 // Get voting results for a match
 app.get("/matches/:matchId/results", async (c) => {
@@ -241,7 +302,10 @@ app.get("/matches/:matchId/results", async (c) => {
     const notFound = await assertMatchInCurrentGroup(c, matchId);
     if (notFound) return notFound;
     const language = getLanguage(c.req.header("Accept-Language"));
-    const results = await votingService.getMatchVotingResults(matchId, language);
+    const results = await votingService.getMatchVotingResults(
+      matchId,
+      language,
+    );
     return c.json(results);
   } catch (error: any) {
     console.error("Get voting results error:", error);
@@ -277,17 +341,17 @@ app.get("/matches/:matchId/has-voted", async (c) => {
     const matchId = c.req.param("matchId");
     const notFound = await assertMatchInCurrentGroup(c, matchId);
     if (notFound) return notFound;
-    const hasVoted = await votingService.hasUserVotedForMatch(
-      matchId,
-      user.id
-    );
+    const hasVoted = await votingService.hasUserVotedForMatch(matchId, user.id);
     return c.json({ hasVoted });
   } catch (error: any) {
     console.error("Check has voted error:", error);
     if (error.message.includes("authenticated")) {
       return c.json({ error: error.message }, 401);
     }
-    return c.json({ error: error.message || "Failed to check vote status" }, 500);
+    return c.json(
+      { error: error.message || "Failed to check vote status" },
+      500,
+    );
   }
 });
 
@@ -302,7 +366,7 @@ app.get("/leaderboard", async (c) => {
     const leaderboard = await rankingService.getVotingLeaderboard(
       current.id,
       language,
-      parseInt(topN, 10)
+      parseInt(topN, 10),
     );
     return c.json(leaderboard);
   } catch (error: any) {

--- a/apps/api/src/routes/voting.ts
+++ b/apps/api/src/routes/voting.ts
@@ -4,6 +4,7 @@ import { votingService, getServiceFactory } from "@repo/shared/services";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import type { Match } from "@repo/shared/domain";
 import type { Context } from "hono";
 
 import {
@@ -36,6 +37,18 @@ async function assertMatchInCurrentGroup(
 ): Promise<Response | null> {
   const match = await getRepositoryFactory().matches.findById(matchId);
   return assertInCurrentGroup(c, match, "Match not found");
+}
+
+// Same group-scoping check as `assertMatchInCurrentGroup`, but returns the
+// loaded match on success so the handler can avoid a second `findById`.
+async function loadMatchInCurrentGroup(
+  c: Context,
+  matchId: string,
+): Promise<{ match: Match } | { response: Response }> {
+  const match = await getRepositoryFactory().matches.findById(matchId);
+  const denied = assertInCurrentGroup(c, match, "Match not found");
+  if (denied || !match) return { response: denied! };
+  return { match };
 }
 
 // ==================== VOTING CRITERIA ====================
@@ -239,10 +252,10 @@ app.get("/matches/:matchId/stats", async (c) => {
   try {
     requireUser(c);
     const matchId = c.req.param("matchId");
-    const notFound = await assertMatchInCurrentGroup(c, matchId);
-    if (notFound) return notFound;
+    const result = await loadMatchInCurrentGroup(c, matchId);
+    if ("response" in result) return result.response;
     const language = getLanguage(c.req.header("Accept-Language"));
-    const stats = await votingService.getMatchStats(matchId, language);
+    const stats = await votingService.getMatchStats(result.match, language);
     return c.json(stats);
   } catch (error: any) {
     console.error("Get match stats error:", error);

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -16,6 +16,10 @@ import { sendMatchReminders } from "./cron/send-match-reminders";
 import { sendEngagementReminders } from "./cron/send-engagement-reminders";
 import { pruneInboxNotifications } from "./cron/prune-inbox-notifications";
 
+// Cron expressions must match `[triggers].crons` in wrangler.toml.
+const CRON_EVERY_30_MIN = "*/30 * * * *";
+const CRON_DAILY_01_UTC = "0 1 * * *";
+
 // Import shared security middleware
 import { type AppVariables, authMiddleware, rateLimitMiddleware } from "./middleware/security";
 
@@ -270,15 +274,28 @@ export default Sentry.withSentry(
   {
     fetch: app.fetch,
     async scheduled(event: any, env: Bindings, ctx: any) {
-      console.log("[CRON] Running scheduled tasks");
+      console.log(`[CRON] Running scheduled tasks for "${event.cron}"`);
       injectEnv(env);
+
+      let tasks: Array<Promise<unknown>>;
+      switch (event.cron) {
+        case CRON_EVERY_30_MIN:
+          tasks = [
+            updateMatchStatuses(),
+            sendMatchReminders(),
+            sendEngagementReminders(),
+          ];
+          break;
+        case CRON_DAILY_01_UTC:
+          tasks = [pruneInboxNotifications()];
+          break;
+        default:
+          console.warn(`[CRON] Unknown cron expression: "${event.cron}"`);
+          return;
+      }
+
       ctx.waitUntil(
-        Promise.allSettled([
-          updateMatchStatuses(),
-          sendMatchReminders(),
-          sendEngagementReminders(),
-          pruneInboxNotifications(),
-        ]).then((results) => {
+        Promise.allSettled(tasks).then((results) => {
           for (const r of results) {
             if (r.status === "rejected") {
               console.error("[CRON] Task failed:", r.reason);

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -36,9 +36,11 @@ bucket_name = "football-profile-pictures"
 binding = "MATCH_MEDIA"
 bucket_name = "football-match-media"
 
-# Cron trigger for match status updates (every 30 minutes)
+# Crons:
+#  - "*/30 * * * *": match-status / reminders / engagement (every 30 min)
+#  - "0 1 * * *":   inbox pruning, daily at 01:00 UTC (~03:00 Berlin in DST)
 [triggers]
-crons = ["*/30 * * * *"]
+crons = ["*/30 * * * *", "0 1 * * *"]
 
 # Development environment
 [env.development]
@@ -58,4 +60,4 @@ binding = "MATCH_MEDIA"
 bucket_name = "football-match-media-staging"
 
 [env.preview.triggers]
-crons = ["*/30 * * * *"]
+crons = ["*/30 * * * *", "0 1 * * *"]

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -9,6 +9,7 @@ import {
   useGroupRoster,
   type GroupRosterEntry,
 } from "@repo/api-client";
+import { formatMatchDate } from "@repo/shared/utils";
 import {
   Container,
   Card,
@@ -40,6 +41,7 @@ import {
   Image as ImageIcon,
   ChevronRight,
 } from "@tamagui/lucide-icons";
+import { Image } from "expo-image";
 import { useLocalSearchParams, router } from "expo-router";
 import { useMemo, useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
@@ -51,15 +53,13 @@ import {
   Share,
   Linking,
 } from "react-native";
-import { Image } from "expo-image";
-import { formatMatchDate } from "@repo/shared/utils";
 
-import { formatFullDate } from "@/lib/date-utils";
 import {
   generateICS as generateICSFromUtils,
   getGoogleCalendarUrl,
   openGoogleCalendar,
 } from "@/lib/calendar-utils";
+import { formatFullDate } from "@/lib/date-utils";
 
 interface Signup {
   id: string;
@@ -132,8 +132,7 @@ export default function MatchDetailScreen() {
   const [guestEmail, setGuestEmail] = useState("");
   const [guestSearch, setGuestSearch] = useState("");
   const { groupId: currentGroupId, myRole } = useCurrentGroup();
-  const isOrganizer =
-    myRole === "organizer" || session?.user?.role === "admin";
+  const isOrganizer = myRole === "organizer" || session?.user?.role === "admin";
   // Roster list is organizer-only; don't trigger a 403 for regular members.
   const rosterForGuest = useGroupRoster(
     showGuestDialog && isOrganizer ? currentGroupId : null,
@@ -227,7 +226,10 @@ export default function MatchDetailScreen() {
       setShowConfirmationModal(true);
     },
     onError: (err: Error) => {
-      toast.show(err.message, { duration: 4000, customData: { variant: "error" } });
+      toast.show(err.message, {
+        duration: 4000,
+        customData: { variant: "error" },
+      });
     },
   });
 
@@ -255,7 +257,10 @@ export default function MatchDetailScreen() {
       queryClient.invalidateQueries({ queryKey: ["match", matchId] });
     },
     onError: (err: Error) => {
-      toast.show(err.message, { duration: 4000, customData: { variant: "error" } });
+      toast.show(err.message, {
+        duration: 4000,
+        customData: { variant: "error" },
+      });
     },
   });
 
@@ -283,10 +288,16 @@ export default function MatchDetailScreen() {
       setGuestName("");
       setGuestPhone("");
       setGuestEmail("");
-      toast.show(t("matchDetail.guestAddSuccess"), { duration: 3000, customData: { variant: "success" } });
+      toast.show(t("matchDetail.guestAddSuccess"), {
+        duration: 3000,
+        customData: { variant: "success" },
+      });
     },
     onError: (err: Error) => {
-      toast.show(err.message, { duration: 4000, customData: { variant: "error" } });
+      toast.show(err.message, {
+        duration: 4000,
+        customData: { variant: "error" },
+      });
     },
   });
 
@@ -317,7 +328,10 @@ export default function MatchDetailScreen() {
       setEditedName("");
     },
     onError: (err: Error) => {
-      toast.show(err.message, { duration: 4000, customData: { variant: "error" } });
+      toast.show(err.message, {
+        duration: 4000,
+        customData: { variant: "error" },
+      });
     },
   });
 
@@ -338,7 +352,10 @@ export default function MatchDetailScreen() {
       queryClient.invalidateQueries({ queryKey: ["match", matchId] });
     },
     onError: (err: Error) => {
-      toast.show(err.message, { duration: 4000, customData: { variant: "error" } });
+      toast.show(err.message, {
+        duration: 4000,
+        customData: { variant: "error" },
+      });
     },
   });
 
@@ -402,10 +419,16 @@ export default function MatchDetailScreen() {
     const paypalUrl = settings?.paypal_url;
     if (paypalUrl) {
       Linking.openURL(paypalUrl).catch(() => {
-        toast.show(t("matchDetail.paymentOpenError"), { duration: 4000, customData: { variant: "error" } });
+        toast.show(t("matchDetail.paymentOpenError"), {
+          duration: 4000,
+          customData: { variant: "error" },
+        });
       });
     } else {
-      toast.show(t("matchDetail.noPaymentMethod"), { duration: 4000, customData: { variant: "error" } });
+      toast.show(t("matchDetail.noPaymentMethod"), {
+        duration: 4000,
+        customData: { variant: "error" },
+      });
     }
   };
 
@@ -413,7 +436,10 @@ export default function MatchDetailScreen() {
     // Open WhatsApp to notify organizer using wa.me link with phone number
     const organizerPhone = settings?.organizer_whatsapp;
     if (!organizerPhone) {
-      toast.show(t("matchDetail.noOrganizerPhone"), { duration: 4000, customData: { variant: "error" } });
+      toast.show(t("matchDetail.noOrganizerPhone"), {
+        duration: 4000,
+        customData: { variant: "error" },
+      });
       return;
     }
     const message = t("notify.whatsappMessage", {
@@ -422,7 +448,10 @@ export default function MatchDetailScreen() {
     });
     const url = `https://wa.me/${organizerPhone}?text=${encodeURIComponent(message)}`;
     Linking.openURL(url).catch(() => {
-      toast.show(t("matchDetail.whatsappError"), { duration: 4000, customData: { variant: "error" } });
+      toast.show(t("matchDetail.whatsappError"), {
+        duration: 4000,
+        customData: { variant: "error" },
+      });
     });
   };
 
@@ -457,7 +486,8 @@ export default function MatchDetailScreen() {
   const handleShareMatch = () => {
     if (!match) return;
     const baseUrl =
-      (typeof process !== "undefined" && process.env?.EXPO_PUBLIC_WEB_BASE_URL) ||
+      (typeof process !== "undefined" &&
+        process.env?.EXPO_PUBLIC_WEB_BASE_URL) ||
       "https://footballwithfriends.vercel.app";
     const matchUrl =
       Platform.OS === "web" && typeof window !== "undefined"
@@ -769,9 +799,7 @@ export default function MatchDetailScreen() {
                     {t("stats.cost")}
                   </Text>
                   <Text fontSize="$7" fontWeight="bold">
-                    {match.costPerPlayer
-                      ? `€${totalCost}`
-                      : t("stats.free")}
+                    {match.costPerPlayer ? `€${totalCost}` : t("stats.free")}
                   </Text>
                 </YStack>
 
@@ -786,11 +814,7 @@ export default function MatchDetailScreen() {
               </XStack>
 
               {isMatchToday && sameDayCost > 0 && (
-                <Text
-                  fontSize="$2"
-                  color="$orange10"
-                  textAlign="center"
-                >
+                <Text fontSize="$2" color="$orange10" textAlign="center">
                   {t("matchDetail.sameDayFeeHint", { amount: sameDayCost })}
                 </Text>
               )}
@@ -839,6 +863,24 @@ export default function MatchDetailScreen() {
             </Button>
           )}
 
+          {/* View match stats — visible to any group member once the match is played */}
+          {isPlayed && (
+            <Button
+              variant="outline"
+              onPress={() =>
+                router.push({
+                  pathname: "/(tabs)/matches/[matchId]/stats",
+                  params: { matchId: match.id },
+                })
+              }
+              accessibilityRole="button"
+              accessibilityLabel={t("a11y.viewMatchStats")}
+              testID="match-detail-view-stats-btn"
+            >
+              {t("matchStats.viewStats")}
+            </Button>
+          )}
+
           {/* View B: Participating or Played Match - Show Players Table */}
           {(isParticipating || isPlayed || isAdmin) && (
             <Card variant="elevated">
@@ -852,19 +894,17 @@ export default function MatchDetailScreen() {
                   <Text fontSize="$6" fontWeight="bold">
                     {t("players.title")}
                   </Text>
-                  {!isPlayed &&
-                    isOrganizer &&
-                    match.availableSpots > 0 && (
-                      <Button
-                        variant="outline"
-                        size="$3"
-                        onPress={() => setShowGuestDialog(true)}
-                        testID="match-detail-invite-friend-btn"
-                      >
-                        <UserPlus size={16} />
-                        <Text marginLeft="$1">{t("actions.signUpGuest")}</Text>
-                      </Button>
-                    )}
+                  {!isPlayed && isOrganizer && match.availableSpots > 0 && (
+                    <Button
+                      variant="outline"
+                      size="$3"
+                      onPress={() => setShowGuestDialog(true)}
+                      testID="match-detail-invite-friend-btn"
+                    >
+                      <UserPlus size={16} />
+                      <Text marginLeft="$1">{t("actions.signUpGuest")}</Text>
+                    </Button>
+                  )}
                 </XStack>
 
                 <PlayersTable
@@ -1072,7 +1112,9 @@ export default function MatchDetailScreen() {
                     <Button
                       key={e.id}
                       variant="outline"
-                      onPress={() => addGuestMutation.mutate({ rosterId: e.id })}
+                      onPress={() =>
+                        addGuestMutation.mutate({ rosterId: e.id })
+                      }
                       disabled={addGuestMutation.isPending}
                       testID={`guest-roster-pick-${e.id}`}
                     >
@@ -1124,7 +1166,9 @@ export default function MatchDetailScreen() {
                 }
                 disabled={!guestName.trim() || addGuestMutation.isPending}
               >
-                {addGuestMutation.isPending ? t("guest.adding") : t("guest.add")}
+                {addGuestMutation.isPending
+                  ? t("guest.adding")
+                  : t("guest.add")}
               </Button>
             </YStack>
           )}
@@ -1195,9 +1239,7 @@ export default function MatchDetailScreen() {
                   });
                 }
               }}
-              disabled={
-                !editedName.trim() || editPlayerNameMutation.isPending
-              }
+              disabled={!editedName.trim() || editPlayerNameMutation.isPending}
             >
               {editPlayerNameMutation.isPending
                 ? t("shared.saving")

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/stats.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/stats.tsx
@@ -280,44 +280,54 @@ export default function MatchStatsScreen() {
             )}
 
             {/* Post-match social stats (only when closed) */}
-            {stats.isVotingClosed && stats.playerStats.length > 0 && (
+            {stats.isVotingClosed && (
               <Card variant="elevated">
                 <YStack padding="$3" gap="$2">
                   <Text fontSize="$6" fontWeight="700">
                     {t("matchStats.social.title")}
                   </Text>
-                  {stats.playerStats.map((p) => (
-                    <XStack
-                      key={p.userId}
-                      alignItems="center"
-                      justifyContent="space-between"
-                      paddingVertical="$2"
-                      borderBottomWidth={1}
-                      borderBottomColor="$borderColor"
-                    >
-                      <Text flex={1} fontSize="$4">
-                        {p.userName}
-                      </Text>
-                      <XStack alignItems="center" gap="$3">
-                        {p.thirdTimeAttended && (
-                          <XStack alignItems="center" gap="$1">
-                            <CheckCircle2 size={16} color="$green10" />
-                            <Text fontSize="$2" color="$gray11">
-                              {t("matchStats.social.thirdTimeAttended")}
-                            </Text>
-                          </XStack>
-                        )}
-                        {p.thirdTimeBeers > 0 && (
-                          <XStack alignItems="center" gap="$1">
-                            <Beer size={16} color="$orange10" />
-                            <Text fontSize="$3" fontWeight="600">
-                              {p.thirdTimeBeers}
-                            </Text>
-                          </XStack>
-                        )}
+                  {stats.playerStats.length > 0 ? (
+                    stats.playerStats.map((p) => (
+                      <XStack
+                        key={p.userId}
+                        alignItems="center"
+                        justifyContent="space-between"
+                        paddingVertical="$2"
+                        borderBottomWidth={1}
+                        borderBottomColor="$borderColor"
+                      >
+                        <Text flex={1} fontSize="$4">
+                          {p.userName}
+                        </Text>
+                        <XStack alignItems="center" gap="$3">
+                          {p.thirdTimeAttended && (
+                            <XStack alignItems="center" gap="$1">
+                              <CheckCircle2 size={16} color="$green10" />
+                              <Text fontSize="$2" color="$gray11">
+                                {t("matchStats.social.thirdTimeAttended")}
+                              </Text>
+                            </XStack>
+                          )}
+                          {p.thirdTimeBeers > 0 && (
+                            <XStack alignItems="center" gap="$1">
+                              <Beer size={16} color="$orange10" />
+                              <Text fontSize="$3" fontWeight="600">
+                                {p.thirdTimeBeers}
+                              </Text>
+                            </XStack>
+                          )}
+                        </XStack>
                       </XStack>
-                    </XStack>
-                  ))}
+                    ))
+                  ) : (
+                    <Text
+                      color="$gray11"
+                      textAlign="center"
+                      paddingVertical="$3"
+                    >
+                      {t("matchStats.social.noEntries")}
+                    </Text>
+                  )}
                 </YStack>
               </Card>
             )}

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/stats.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/stats.tsx
@@ -1,0 +1,341 @@
+// @ts-nocheck - Tamagui type recursion workaround
+import {
+  client,
+  useQuery,
+  useMutation,
+  useQueryClient,
+  useSession,
+  useCurrentGroup,
+} from "@repo/api-client";
+import {
+  Container,
+  Card,
+  Text,
+  YStack,
+  XStack,
+  Button,
+  Spinner,
+  AwardCard,
+  useToastController,
+} from "@repo/ui";
+import { Beer, CheckCircle2, Lock, Unlock } from "@tamagui/lucide-icons";
+import { Stack, useLocalSearchParams } from "expo-router";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Alert, RefreshControl, ScrollView } from "react-native";
+
+import type { MatchStats } from "@repo/shared/domain";
+
+import { formatLocalizedDate } from "@/lib/date-utils";
+
+export default function MatchStatsScreen() {
+  const { t } = useTranslation();
+  const { matchId } = useLocalSearchParams<{ matchId: string }>();
+  const { data: session } = useSession();
+  const { myRole } = useCurrentGroup();
+  const queryClient = useQueryClient();
+  const toast = useToastController();
+
+  const isOrganizer = myRole === "organizer" || session?.user?.role === "admin";
+
+  const {
+    data: stats,
+    isLoading,
+    isRefetching,
+    refetch,
+    error,
+  } = useQuery<MatchStats>({
+    queryKey: ["match-stats", matchId],
+    queryFn: async () => {
+      const res = await client.api.voting.matches[":matchId"].stats.$get({
+        param: { matchId },
+      });
+      return res.json();
+    },
+    enabled: !!matchId,
+  });
+
+  const closeMutation = useMutation({
+    mutationFn: async () => {
+      const res = await client.api.voting.matches[":matchId"][
+        "close-voting"
+      ].$post({
+        param: { matchId },
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || t("matchStats.closeVoting.failed"));
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["match-stats", matchId] });
+      toast.show(t("matchStats.closeVoting.success"));
+    },
+    onError: (e: any) => {
+      toast.show(e?.message || t("matchStats.closeVoting.failed"));
+    },
+  });
+
+  const reopenMutation = useMutation({
+    mutationFn: async () => {
+      const res = await client.api.voting.matches[":matchId"][
+        "reopen-voting"
+      ].$post({
+        param: { matchId },
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || t("matchStats.reopenVoting.failed"));
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["match-stats", matchId] });
+      toast.show(t("matchStats.reopenVoting.success"));
+    },
+  });
+
+  const awardsByCriteria = useMemo(() => {
+    if (!stats?.results) return [];
+    const map = new Map<
+      string,
+      {
+        criteriaId: string;
+        criteriaCode: string;
+        criteriaName: string;
+        topPlayers: Array<{ userName: string; voteCount: number }>;
+      }
+    >();
+    for (const r of stats.results) {
+      let entry = map.get(r.criteriaId);
+      if (!entry) {
+        entry = {
+          criteriaId: r.criteriaId,
+          criteriaCode: r.criteriaCode,
+          criteriaName: r.criteriaName,
+          topPlayers: [],
+        };
+        map.set(r.criteriaId, entry);
+      }
+      entry.topPlayers.push({
+        userName: r.votedForUserName,
+        voteCount: r.voteCount,
+      });
+    }
+    return Array.from(map.values());
+  }, [stats]);
+
+  const confirmClose = () => {
+    Alert.alert(
+      t("matchStats.closeVoting.action"),
+      t("matchStats.closeVoting.confirm"),
+      [
+        {
+          text: t("shared.cancel", { defaultValue: "Cancel" }),
+          style: "cancel",
+        },
+        {
+          text: t("matchStats.closeVoting.action"),
+          style: "destructive",
+          onPress: () => closeMutation.mutate(),
+        },
+      ],
+    );
+  };
+
+  const confirmReopen = () => {
+    Alert.alert(
+      t("matchStats.reopenVoting.action"),
+      t("matchStats.reopenVoting.confirm"),
+      [
+        {
+          text: t("shared.cancel", { defaultValue: "Cancel" }),
+          style: "cancel",
+        },
+        {
+          text: t("matchStats.reopenVoting.action"),
+          onPress: () => reopenMutation.mutate(),
+        },
+      ],
+    );
+  };
+
+  return (
+    <Container>
+      <Stack.Screen options={{ title: t("matchStats.title") }} />
+
+      {isLoading && (
+        <YStack alignItems="center" padding="$6">
+          <Spinner size="large" />
+        </YStack>
+      )}
+
+      {error && (
+        <Card variant="outlined" backgroundColor="$red2">
+          <YStack padding="$3">
+            <Text color="$red11">
+              {t("shared.error", { defaultValue: "Something went wrong" })}
+            </Text>
+          </YStack>
+        </Card>
+      )}
+
+      {stats && (
+        <ScrollView
+          style={{ flex: 1 }}
+          refreshControl={
+            <RefreshControl refreshing={isRefetching} onRefresh={refetch} />
+          }
+        >
+          <YStack gap="$3" paddingBottom="$6">
+            {/* Status banner */}
+            <Card variant="elevated">
+              <YStack padding="$3" gap="$2">
+                <XStack alignItems="center" gap="$2">
+                  {stats.isVotingClosed ? (
+                    <Lock size={18} color="$gray10" />
+                  ) : (
+                    <Unlock size={18} color="$blue10" />
+                  )}
+                  <Text fontSize="$5" fontWeight="700">
+                    {stats.isVotingClosed
+                      ? t("matchStats.votingClosed")
+                      : t("matchStats.votingClosesIn", {
+                          when: formatLocalizedDate(
+                            stats.votingAutoCloseAt,
+                            "MMM d, yyyy",
+                          ),
+                        })}
+                  </Text>
+                </XStack>
+                {stats.isVotingClosed && (
+                  <Text color="$gray11" fontSize="$3">
+                    {t("matchStats.participation", {
+                      voted: stats.totalVoters,
+                      eligible: stats.eligibleVoterCount,
+                    })}
+                  </Text>
+                )}
+                {isOrganizer && !stats.isVotingClosed && (
+                  <Button
+                    variant="outline"
+                    size="$3"
+                    onPress={confirmClose}
+                    disabled={closeMutation.isPending}
+                    testID="match-stats-close-voting-btn"
+                  >
+                    {t("matchStats.closeVoting.action")}
+                  </Button>
+                )}
+                {isOrganizer &&
+                  stats.isVotingClosed &&
+                  stats.votingClosedAt && (
+                    <Button
+                      variant="outline"
+                      size="$3"
+                      onPress={confirmReopen}
+                      disabled={reopenMutation.isPending}
+                      testID="match-stats-reopen-voting-btn"
+                    >
+                      {t("matchStats.reopenVoting.action")}
+                    </Button>
+                  )}
+              </YStack>
+            </Card>
+
+            {/* Awards (only when closed) */}
+            {stats.isVotingClosed && (
+              <YStack gap="$3">
+                <Text fontSize="$6" fontWeight="700" paddingHorizontal="$1">
+                  {t("matchStats.awards.title")}
+                </Text>
+                {awardsByCriteria.length === 0 ? (
+                  <Card variant="outlined">
+                    <YStack padding="$4" alignItems="center">
+                      <Text color="$gray11">{t("matchStats.empty")}</Text>
+                    </YStack>
+                  </Card>
+                ) : (
+                  awardsByCriteria.map((award) => (
+                    <AwardCard
+                      key={award.criteriaId}
+                      criteriaName={t(`voting.criteria.${award.criteriaCode}`, {
+                        defaultValue: award.criteriaName,
+                      })}
+                      criteriaCode={award.criteriaCode}
+                      criteriaDescription={t(
+                        `voting.criteria.${award.criteriaCode}_desc`,
+                        { defaultValue: "" },
+                      )}
+                      topPlayers={award.topPlayers}
+                      noVotesLabel={t("matchStats.empty")}
+                      formatVotes={(count) =>
+                        t("matchStats.awards.voteCount", { count })
+                      }
+                    />
+                  ))
+                )}
+              </YStack>
+            )}
+
+            {/* Post-match social stats (only when closed) */}
+            {stats.isVotingClosed && stats.playerStats.length > 0 && (
+              <Card variant="elevated">
+                <YStack padding="$3" gap="$2">
+                  <Text fontSize="$6" fontWeight="700">
+                    {t("matchStats.social.title")}
+                  </Text>
+                  {stats.playerStats.map((p) => (
+                    <XStack
+                      key={p.userId}
+                      alignItems="center"
+                      justifyContent="space-between"
+                      paddingVertical="$2"
+                      borderBottomWidth={1}
+                      borderBottomColor="$borderColor"
+                    >
+                      <Text flex={1} fontSize="$4">
+                        {p.userName}
+                      </Text>
+                      <XStack alignItems="center" gap="$3">
+                        {p.thirdTimeAttended && (
+                          <XStack alignItems="center" gap="$1">
+                            <CheckCircle2 size={16} color="$green10" />
+                            <Text fontSize="$2" color="$gray11">
+                              {t("matchStats.social.thirdTimeAttended")}
+                            </Text>
+                          </XStack>
+                        )}
+                        {p.thirdTimeBeers > 0 && (
+                          <XStack alignItems="center" gap="$1">
+                            <Beer size={16} color="$orange10" />
+                            <Text fontSize="$3" fontWeight="600">
+                              {p.thirdTimeBeers}
+                            </Text>
+                          </XStack>
+                        )}
+                      </XStack>
+                    </XStack>
+                  ))}
+                </YStack>
+              </Card>
+            )}
+
+            {/* Open-state hint */}
+            {!stats.isVotingClosed && (
+              <Card variant="outlined">
+                <YStack padding="$4" alignItems="center" gap="$2">
+                  <Lock size={28} color="$gray9" />
+                  <Text color="$gray11" textAlign="center">
+                    {t("matchStats.openHint")}
+                  </Text>
+                </YStack>
+              </Card>
+            )}
+          </YStack>
+        </ScrollView>
+      )}
+    </Container>
+  );
+}

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/stats.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/stats.tsx
@@ -162,7 +162,7 @@ export default function MatchStatsScreen() {
   };
 
   return (
-    <Container>
+    <Container variant="padded">
       <Stack.Screen options={{ title: t("matchStats.title") }} />
 
       {isLoading && (

--- a/apps/mobile-web/lib/date-utils.ts
+++ b/apps/mobile-web/lib/date-utils.ts
@@ -14,9 +14,10 @@ function capitalizeFirst(str: string): string {
  * Date-only ISO strings (e.g. "2026-03-03") are parsed as UTC midnight,
  * which shifts to the previous day in UTC+ timezones like Europe/Berlin.
  * Appending T12:00:00 forces local-time parsing at noon, safe for any offset.
+ * Full ISO timestamps (with a "T") are parsed as-is.
  */
 function parseDate(dateString: string): Date {
-  return new Date(dateString + "T12:00:00");
+  return new Date(dateString.includes("T") ? dateString : `${dateString}T12:00:00`);
 }
 
 /**

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -458,7 +458,8 @@
     "uploadMedia": "Upload photo or video",
     "openInbox": "Open notifications inbox",
     "openInboxWithUnread": "Open notifications inbox, {{count}} unread",
-    "openNotification": "Open notification"
+    "openNotification": "Open notification",
+    "viewMatchStats": "View match stats"
   },
   "notifications": {
     "settings": {
@@ -779,6 +780,39 @@
     "createSuccess": "Voting criteria created successfully",
     "updateSuccess": "Voting criteria updated successfully",
     "duplicateSortOrder": "A criteria with this order number already exists"
+  },
+  "matchStats": {
+    "title": "Match Stats",
+    "viewStats": "View Match Stats",
+    "votingClosesIn": "Voting closes {{when}}",
+    "votingOpen": "Voting still open",
+    "votingClosed": "Voting closed",
+    "participation": "{{voted}} of {{eligible}} voted",
+    "awards": {
+      "title": "Match Awards",
+      "voteCount": "{{count}} votes",
+      "voteCount_one": "{{count}} vote"
+    },
+    "social": {
+      "title": "Post-Match Social",
+      "thirdTimeAttended": "Attended 3rd half",
+      "thirdTimeBeers": "{{count}} beers",
+      "noEntries": "No post-match stats recorded"
+    },
+    "closeVoting": {
+      "action": "Close voting now",
+      "confirm": "Close voting for this match? Results become visible to everyone.",
+      "success": "Voting closed",
+      "failed": "Failed to close voting"
+    },
+    "reopenVoting": {
+      "action": "Reopen voting",
+      "confirm": "Reopen voting? Results will be hidden again.",
+      "success": "Voting reopened",
+      "failed": "Failed to reopen voting"
+    },
+    "empty": "No votes were submitted for this match",
+    "openHint": "Results will appear here after voting closes."
   },
   "admin": {
     "addCriteria": "Add Criteria",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -461,7 +461,8 @@
     "uploadMedia": "Subir foto o video",
     "openInbox": "Abrir bandeja de notificaciones",
     "openInboxWithUnread": "Abrir bandeja de notificaciones, {{count}} sin leer",
-    "openNotification": "Abrir notificación"
+    "openNotification": "Abrir notificación",
+    "viewMatchStats": "Ver estadísticas del partido"
   },
   "notifications": {
     "settings": {
@@ -782,6 +783,39 @@
     "createSuccess": "Criterio de votación creado exitosamente",
     "updateSuccess": "Criterio de votación actualizado exitosamente",
     "duplicateSortOrder": "Ya existe un criterio con este número de orden"
+  },
+  "matchStats": {
+    "title": "Estadísticas del partido",
+    "viewStats": "Ver estadísticas",
+    "votingClosesIn": "La votación cierra {{when}}",
+    "votingOpen": "Votación abierta",
+    "votingClosed": "Votación cerrada",
+    "participation": "{{voted}} de {{eligible}} votaron",
+    "awards": {
+      "title": "Premios del partido",
+      "voteCount": "{{count}} votos",
+      "voteCount_one": "{{count}} voto"
+    },
+    "social": {
+      "title": "Tercer tiempo",
+      "thirdTimeAttended": "Asistió al tercer tiempo",
+      "thirdTimeBeers": "{{count}} cervezas",
+      "noEntries": "Sin estadísticas del tercer tiempo"
+    },
+    "closeVoting": {
+      "action": "Cerrar votación",
+      "confirm": "¿Cerrar la votación de este partido? Los resultados se harán visibles para todos.",
+      "success": "Votación cerrada",
+      "failed": "No se pudo cerrar la votación"
+    },
+    "reopenVoting": {
+      "action": "Reabrir votación",
+      "confirm": "¿Reabrir la votación? Los resultados volverán a ocultarse.",
+      "success": "Votación reabierta",
+      "failed": "No se pudo reabrir la votación"
+    },
+    "empty": "No se registraron votos para este partido",
+    "openHint": "Los resultados aparecerán aquí cuando cierre la votación."
   },
   "admin": {
     "addCriteria": "Agregar Criterio",

--- a/migrations/20260430120000-add-match-voting-closed-at.ts
+++ b/migrations/20260430120000-add-match-voting-closed-at.ts
@@ -1,0 +1,31 @@
+// Migration: add-match-voting-closed-at
+// Adds nullable voting_closed_at column to matches table for organizer-driven manual close.
+
+import { sql } from "kysely";
+import type { Kysely, Migration } from "kysely";
+
+export const up: Migration["up"] = async (db: Kysely<any>) => {
+  const columnExists = async (table: string, column: string) => {
+    const result = await sql<{ name: string }>`
+      PRAGMA table_info(${sql.raw(table)})
+    `.execute(db);
+    return result.rows.some((col: any) => col.name === column);
+  };
+
+  if (!(await columnExists("matches", "voting_closed_at"))) {
+    await db.schema
+      .alterTable("matches")
+      .addColumn("voting_closed_at", "text")
+      .execute();
+    console.log("✅ Added voting_closed_at column to matches");
+  } else {
+    console.log("⏭️  voting_closed_at column already exists, skipping");
+  }
+
+  console.log("✅ Migration: add-match-voting-closed-at completed");
+};
+
+export const down: Migration["down"] = async (db: Kysely<any>) => {
+  // SQLite doesn't support DROP COLUMN reliably; leave nullable column in place.
+  console.log("↩️ Rolled back: add-match-voting-closed-at (column remains)");
+};

--- a/migrations/20260430120000-add-match-voting-closed-at.ts
+++ b/migrations/20260430120000-add-match-voting-closed-at.ts
@@ -25,7 +25,8 @@ export const up: Migration["up"] = async (db: Kysely<any>) => {
   console.log("✅ Migration: add-match-voting-closed-at completed");
 };
 
-export const down: Migration["down"] = async (db: Kysely<any>) => {
-  // SQLite doesn't support DROP COLUMN reliably; leave nullable column in place.
-  console.log("↩️ Rolled back: add-match-voting-closed-at (column remains)");
+export const down: Migration["down"] = async (_db: Kysely<any>) => {
+  throw new Error(
+    "Migration add-match-voting-closed-at is intentionally non-reversible: SQLite cannot drop a column without rebuilding the matches table. Down migration aborted so callers do not assume the prior schema was restored.",
+  );
 };

--- a/packages/shared/src/database/schema.ts
+++ b/packages/shared/src/database/schema.ts
@@ -36,6 +36,7 @@ export interface MatchesTable {
   reminder_sent: Generated<number>;
   // Group scoping — nullable through Phase 0, backfilled and tightened to NOT NULL in Phase 1.
   group_id: string | null;
+  voting_closed_at: string | null;
   created_at: ColumnType<Date, string | undefined, never>;
   updated_at: ColumnType<Date, string | undefined, string>;
 }

--- a/packages/shared/src/domain/types.ts
+++ b/packages/shared/src/domain/types.ts
@@ -1,7 +1,12 @@
 // Domain types for the football match application
 
 // Player status types for match participation
-export const PLAYER_STATUSES = ["PAID", "PENDING", "CANCELLED", "SUBSTITUTE"] as const;
+export const PLAYER_STATUSES = [
+  "PAID",
+  "PENDING",
+  "CANCELLED",
+  "SUBSTITUTE",
+] as const;
 export type PlayerStatus = (typeof PLAYER_STATUSES)[number];
 
 // Signup types to track how a player was added
@@ -76,6 +81,7 @@ export interface Match {
   costPerPlayer?: string;
   sameDayCost?: string;
   createdByUserId: string;
+  votingClosedAt: string | null;
   createdAt: Date;
   updatedAt: Date;
 
@@ -242,8 +248,9 @@ export interface CreateLocationData {
   courtCount?: number;
 }
 
-export interface UpdateLocationData
-  extends Partial<Omit<CreateLocationData, "groupId">> {}
+export interface UpdateLocationData extends Partial<
+  Omit<CreateLocationData, "groupId">
+> {}
 
 export interface CreateCourtData {
   groupId: string;
@@ -253,8 +260,9 @@ export interface CreateCourtData {
   isActive?: boolean;
 }
 
-export interface UpdateCourtData
-  extends Partial<Omit<CreateCourtData, "groupId">> {}
+export interface UpdateCourtData extends Partial<
+  Omit<CreateCourtData, "groupId">
+> {}
 
 export interface CreateMatchData {
   groupId: string;
@@ -269,8 +277,9 @@ export interface CreateMatchData {
   createdByUserId: string;
 }
 
-export interface UpdateMatchData
-  extends Partial<Omit<CreateMatchData, "createdByUserId" | "groupId">> {
+export interface UpdateMatchData extends Partial<
+  Omit<CreateMatchData, "createdByUserId" | "groupId">
+> {
   status?: MatchStatus;
 }
 
@@ -287,8 +296,9 @@ export interface CreateSignupData {
   addedByUserId: string;
 }
 
-export interface UpdateSignupData
-  extends Partial<Omit<CreateSignupData, "matchId" | "addedByUserId" | "groupId">> {}
+export interface UpdateSignupData extends Partial<
+  Omit<CreateSignupData, "matchId" | "addedByUserId" | "groupId">
+> {}
 
 export interface CreateGuestSignupData {
   groupId: string;
@@ -435,6 +445,26 @@ export interface MatchVotingResults {
   matchId: string;
   totalVoters: number;
   results: CriteriaVoteResult[];
+}
+
+export interface MatchPlayerSocialStat {
+  userId: string;
+  userName: string;
+  thirdTimeAttended: boolean;
+  thirdTimeBeers: number;
+}
+
+// `results` and `playerStats` are empty arrays while voting is open, populated
+// once it closes (manually by an organizer or auto-closes 7 days after match.date).
+export interface MatchStats {
+  matchId: string;
+  isVotingClosed: boolean;
+  votingAutoCloseAt: string;
+  votingClosedAt: string | null;
+  totalVoters: number;
+  eligibleVoterCount: number;
+  results: CriteriaVoteResult[];
+  playerStats: MatchPlayerSocialStat[];
 }
 
 // Rich domain objects for API responses
@@ -608,7 +638,10 @@ export type NotificationPreferencesUpdate = Partial<NotificationPreferences>;
 
 export const NOTIFICATION_PREF_TO_COLUMN: Record<
   keyof NotificationPreferences,
-  "push_enabled" | "push_new_match" | "push_match_reminder" | "push_promo_to_confirmed"
+  | "push_enabled"
+  | "push_new_match"
+  | "push_match_reminder"
+  | "push_promo_to_confirmed"
 > = {
   pushEnabled: "push_enabled",
   pushNewMatch: "push_new_match",
@@ -682,10 +715,10 @@ export type MatchMedia = {
 
 export type MatchMediaFeedGroup = {
   matchId: string;
-  matchDate: string;     // ISO date
+  matchDate: string; // ISO date
   fieldName: string | null;
   items: MatchMedia[];
-  totalCount: number;    // total items in this match; can be > items.length
+  totalCount: number; // total items in this match; can be > items.length
 };
 
 // --- Groups (multi-tenant scoping) ---

--- a/packages/shared/src/repositories/turso-repositories.ts
+++ b/packages/shared/src/repositories/turso-repositories.ts
@@ -39,9 +39,6 @@ import type {
   MatchDetails,
   SignupWithDetails,
   PlayerStatus,
-  MatchMedia,
-  MatchMediaFeedGroup,
-  MatchMediaReactionSummary,
   MediaKind,
   ReactionEmoji,
 } from "../domain/types";
@@ -106,6 +103,7 @@ function dbMatchToMatch(row: any): Match {
     costPerPlayer: row.cost_per_player,
     sameDayCost: row.same_day_cost,
     createdByUserId: row.created_by_user_id,
+    votingClosedAt: row.voting_closed_at ?? null,
     createdAt: new Date(row.created_at),
     updatedAt: new Date(row.updated_at),
   };
@@ -131,7 +129,11 @@ function dbMatchWithCourtToMatch(row: any): Match {
   if (row.location_name) {
     match.location = {
       id: row.location_id,
-      groupId: assertGroupId(row.location_group_id, "locations", row.location_id),
+      groupId: assertGroupId(
+        row.location_group_id,
+        "locations",
+        row.location_id,
+      ),
       name: row.location_name,
       address: row.location_address || "",
       coordinates: row.location_coordinates || "",
@@ -267,7 +269,10 @@ export class TursoCourtRepository implements CourtRepository {
     return rows.map(dbCourtToCourt);
   }
 
-  async findByLocationId(groupId: string, locationId: string): Promise<Court[]> {
+  async findByLocationId(
+    groupId: string,
+    locationId: string,
+  ): Promise<Court[]> {
     const rows = await this.db
       .selectFrom("courts")
       .selectAll()
@@ -279,7 +284,10 @@ export class TursoCourtRepository implements CourtRepository {
     return rows.map(dbCourtToCourt);
   }
 
-  async findActiveByLocationId(groupId: string, locationId: string): Promise<Court[]> {
+  async findActiveByLocationId(
+    groupId: string,
+    locationId: string,
+  ): Promise<Court[]> {
     const rows = await this.db
       .selectFrom("courts")
       .selectAll()
@@ -432,7 +440,9 @@ export class TursoCourtRepository implements CourtRepository {
 export class TursoMatchRepository implements MatchRepository {
   private db = getDatabase();
 
-  async findAll(filters?: MatchFilters & { limit?: number; offset?: number }): Promise<{ matches: Match[]; total: number }> {
+  async findAll(
+    filters?: MatchFilters & { limit?: number; offset?: number },
+  ): Promise<{ matches: Match[]; total: number }> {
     // Build the base query for filtering and counting
     let baseQuery = this.db.selectFrom("matches");
 
@@ -461,7 +471,11 @@ export class TursoMatchRepository implements MatchRepository {
     }
 
     if (filters?.locationId) {
-      baseQuery = baseQuery.where("matches.location_id", "=", filters.locationId);
+      baseQuery = baseQuery.where(
+        "matches.location_id",
+        "=",
+        filters.locationId,
+      );
     }
 
     if (filters?.dateFrom) {
@@ -495,6 +509,7 @@ export class TursoMatchRepository implements MatchRepository {
         "matches.cost_per_player",
         "matches.same_day_cost",
         "matches.created_by_user_id",
+        "matches.voting_closed_at",
         "matches.created_at",
         "matches.updated_at",
         "courts.id as court_id",
@@ -543,7 +558,7 @@ export class TursoMatchRepository implements MatchRepository {
 
       // Create a map of matchId -> status
       const signupMap = new Map(
-        userSignups.map((s) => [s.match_id, s.status as PlayerStatus])
+        userSignups.map((s) => [s.match_id, s.status as PlayerStatus]),
       );
 
       // Attach user signup status to each match
@@ -605,11 +620,7 @@ export class TursoMatchRepository implements MatchRepository {
         "signups.guest_owner_id",
         "guest_owner.id",
       )
-      .leftJoin(
-        "user as player_user",
-        "signups.user_id",
-        "player_user.id",
-      )
+      .leftJoin("user as player_user", "signups.user_id", "player_user.id")
       .select([
         "signups.id",
         "signups.group_id",
@@ -987,7 +998,10 @@ export class TursoSignupRepository implements SignupRepository {
     });
   }
 
-  async removePlayerAsOrganizer(signupId: string, actorId: string): Promise<void> {
+  async removePlayerAsOrganizer(
+    signupId: string,
+    actorId: string,
+  ): Promise<void> {
     console.log(`Organizer ${actorId} removing signup ${signupId}`);
     await this.delete(signupId);
   }
@@ -1018,9 +1032,7 @@ export class TursoSignupRepository implements SignupRepository {
 }
 
 // Turso Match Invitation Repository
-export class TursoMatchInvitationRepository
-  implements MatchInvitationRepository
-{
+export class TursoMatchInvitationRepository implements MatchInvitationRepository {
   private db = getDatabase();
 
   async findByMatchId(matchId: string): Promise<MatchInvitation[]> {
@@ -1199,6 +1211,7 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
         "matches.cost_per_player as match_cost_per_player",
         "matches.same_day_cost as match_same_day_cost",
         "matches.created_by_user_id as match_created_by_user_id",
+        "matches.voting_closed_at as match_voting_closed_at",
         "matches.created_at as match_created_at",
         "matches.updated_at as match_updated_at",
       ])
@@ -1221,6 +1234,7 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
         costPerPlayer: row.match_cost_per_player,
         sameDayCost: row.match_same_day_cost,
         createdByUserId: row.match_created_by_user_id,
+        votingClosedAt: row.match_voting_closed_at ?? null,
         createdAt: new Date(row.match_created_at),
         updatedAt: new Date(row.match_updated_at),
       },
@@ -1372,7 +1386,10 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
     return rows.rows.map((row) => {
       const userName = row.user_name || row.user_email;
       const rawNick = row.display_username || row.username || null;
-      const userNickname = rawNick && !rawNick.includes("@") && rawNick !== userName ? rawNick : null;
+      const userNickname =
+        rawNick && !rawNick.includes("@") && rawNick !== userName
+          ? rawNick
+          : null;
       return {
         userId: row.user_id,
         userName,
@@ -1408,7 +1425,10 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
     };
   }
 
-  async getRankingsByMatches(groupId: string, limit: number): Promise<PlayerRanking[]> {
+  async getRankingsByMatches(
+    groupId: string,
+    limit: number,
+  ): Promise<PlayerRanking[]> {
     const rows = await sql<{
       user_id: string;
       user_name: string;
@@ -1440,7 +1460,10 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
     return rows.rows.map((row) => {
       const userName = row.user_name || row.user_email;
       const rawNick = row.display_username || row.username || null;
-      const userNickname = rawNick && !rawNick.includes("@") && rawNick !== userName ? rawNick : null;
+      const userNickname =
+        rawNick && !rawNick.includes("@") && rawNick !== userName
+          ? rawNick
+          : null;
       return {
         rank: Number(row.rank),
         userId: row.user_id,
@@ -1454,7 +1477,10 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
     });
   }
 
-  async getRankingsByThirdTimes(groupId: string, limit: number): Promise<PlayerRanking[]> {
+  async getRankingsByThirdTimes(
+    groupId: string,
+    limit: number,
+  ): Promise<PlayerRanking[]> {
     const rows = await sql<{
       user_id: string;
       user_name: string;
@@ -1488,7 +1514,10 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
     return rows.rows.map((row) => {
       const userName = row.user_name || row.user_email;
       const rawNick = row.display_username || row.username || null;
-      const userNickname = rawNick && !rawNick.includes("@") && rawNick !== userName ? rawNick : null;
+      const userNickname =
+        rawNick && !rawNick.includes("@") && rawNick !== userName
+          ? rawNick
+          : null;
       return {
         rank: Number(row.rank),
         userId: row.user_id,
@@ -1502,7 +1531,10 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
     });
   }
 
-  async getRankingsByBeers(groupId: string, limit: number): Promise<PlayerRanking[]> {
+  async getRankingsByBeers(
+    groupId: string,
+    limit: number,
+  ): Promise<PlayerRanking[]> {
     const rows = await sql<{
       user_id: string;
       user_name: string;
@@ -1536,7 +1568,10 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
     return rows.rows.map((row) => {
       const userName = row.user_name || row.user_email;
       const rawNick = row.display_username || row.username || null;
-      const userNickname = rawNick && !rawNick.includes("@") && rawNick !== userName ? rawNick : null;
+      const userNickname =
+        rawNick && !rawNick.includes("@") && rawNick !== userName
+          ? rawNick
+          : null;
       return {
         rank: Number(row.rank),
         userId: row.user_id,
@@ -1634,21 +1669,23 @@ export class TursoMatchMediaRepository {
    */
   async listByMatch(
     matchId: string,
-    callerUserId: string | null
-  ): Promise<Array<{
-    id: string;
-    matchId: string;
-    uploaderUserId: string;
-    uploaderName: string;
-    kind: MediaKind;
-    mimeType: string;
-    sizeBytes: number;
-    caption: string | null;
-    r2Key: string;
-    createdAt: Date;
-    reactionCounts: Record<string, number>;
-    ownReactions: Set<string>;
-  }>> {
+    callerUserId: string | null,
+  ): Promise<
+    Array<{
+      id: string;
+      matchId: string;
+      uploaderUserId: string;
+      uploaderName: string;
+      kind: MediaKind;
+      mimeType: string;
+      sizeBytes: number;
+      caption: string | null;
+      r2Key: string;
+      createdAt: Date;
+      reactionCounts: Record<string, number>;
+      ownReactions: Set<string>;
+    }>
+  > {
     const rows = await this.db
       .selectFrom("match_media as m")
       .innerJoin("user as u", "u.id", "m.uploader_user_id")
@@ -1716,21 +1753,23 @@ export class TursoMatchMediaRepository {
    */
   async listByIds(
     mediaIds: string[],
-    callerUserId: string | null
-  ): Promise<Array<{
-    id: string;
-    matchId: string;
-    uploaderUserId: string;
-    uploaderName: string;
-    kind: MediaKind;
-    mimeType: string;
-    sizeBytes: number;
-    caption: string | null;
-    r2Key: string;
-    createdAt: Date;
-    reactionCounts: Record<string, number>;
-    ownReactions: Set<string>;
-  }>> {
+    callerUserId: string | null,
+  ): Promise<
+    Array<{
+      id: string;
+      matchId: string;
+      uploaderUserId: string;
+      uploaderName: string;
+      kind: MediaKind;
+      mimeType: string;
+      sizeBytes: number;
+      caption: string | null;
+      r2Key: string;
+      createdAt: Date;
+      reactionCounts: Record<string, number>;
+      ownReactions: Set<string>;
+    }>
+  > {
     if (mediaIds.length === 0) return [];
 
     const rows = await this.db
@@ -1796,7 +1835,7 @@ export class TursoMatchMediaRepository {
   async toggleReaction(
     mediaId: string,
     userId: string,
-    emoji: ReactionEmoji
+    emoji: ReactionEmoji,
   ): Promise<{ didReact: boolean; newCount: number }> {
     // Race-safe toggle: try INSERT OR IGNORE first. If the insert reports 0
     // changes, the row already existed, so we DELETE it instead. This avoids
@@ -1868,11 +1907,7 @@ export class TursoMatchMediaRepository {
         eb.fn.countAll<number>().as("totalCount"),
       ])
       .where("mt.group_id", "=", groupId)
-      .groupBy((eb) => [
-        sql`m.match_id`,
-        sql`mt.date`,
-        sql`l.name`,
-      ])
+      .groupBy((eb) => [sql`m.match_id`, sql`mt.date`, sql`l.name`])
       .orderBy("lastUploadAt", "desc")
       .limit(matchesPerPage + 1); // fetch one extra to detect next page
 
@@ -1883,10 +1918,13 @@ export class TursoMatchMediaRepository {
     const matchRows = await matchQuery.execute();
 
     const hasMore = matchRows.length > matchesPerPage;
-    const pageMatches = hasMore ? matchRows.slice(0, matchesPerPage) : matchRows;
+    const pageMatches = hasMore
+      ? matchRows.slice(0, matchesPerPage)
+      : matchRows;
     const nextCursor =
       hasMore && pageMatches.length > 0
-        ? (pageMatches[pageMatches.length - 1]?.lastUploadAt as unknown as string) ?? null
+        ? ((pageMatches[pageMatches.length - 1]
+            ?.lastUploadAt as unknown as string) ?? null)
         : null;
 
     if (pageMatches.length === 0) {

--- a/packages/shared/src/repositories/voting-repository.ts
+++ b/packages/shared/src/repositories/voting-repository.ts
@@ -446,7 +446,7 @@ export class VotingRepository {
     return !!result;
   }
 
-  // Filters to user-linked stats only (skips guest rows that have no user_id).
+  // Inner-joins user to load user.name; rows whose user has been deleted drop out.
   async getMatchPlayerSocialStats(
     matchId: string,
   ): Promise<MatchPlayerSocialStat[]> {

--- a/packages/shared/src/repositories/voting-repository.ts
+++ b/packages/shared/src/repositories/voting-repository.ts
@@ -1,19 +1,21 @@
 // Voting Repository for match voting system
 
 import { sql } from "kysely";
-import { getDatabase } from "../database/connection";
+
 import type {
   VotingCriteria,
   MatchVote,
   CreateVoteData,
   LocalizedVotingCriteria,
   UserMatchVotes,
-  CriteriaVoteResult,
   MatchVotingResults,
+  MatchPlayerSocialStat,
   PlayerVotingStats,
   VotingLeaderboard,
   PlayerRanking,
 } from "../domain/types";
+
+import { getDatabase } from "../database/connection";
 
 const { nanoid } = require("nanoid");
 
@@ -49,7 +51,7 @@ function toMatchVote(row: any): MatchVote {
 // Get localized criteria based on language
 function toLocalizedCriteria(
   criteria: VotingCriteria,
-  language: "en" | "es"
+  language: "en" | "es",
 ): LocalizedVotingCriteria {
   return {
     id: criteria.id,
@@ -88,7 +90,7 @@ export class VotingRepository {
    */
   async findAllCriteriaLocalized(
     language: "en" | "es",
-    activeOnly = true
+    activeOnly = true,
   ): Promise<LocalizedVotingCriteria[]> {
     const criteria = await this.findAllCriteria(activeOnly);
     return criteria.map((c) => toLocalizedCriteria(c, language));
@@ -173,7 +175,7 @@ export class VotingRepository {
       descriptionEs?: string;
       isActive?: boolean;
       sortOrder?: number;
-    }
+    },
   ): Promise<VotingCriteria> {
     const db = getDatabase();
     const now = new Date().toISOString();
@@ -189,7 +191,8 @@ export class VotingRepository {
       updateData.description_en = data.descriptionEn;
     if (data.descriptionEs !== undefined)
       updateData.description_es = data.descriptionEs;
-    if (data.isActive !== undefined) updateData.is_active = data.isActive ? 1 : 0;
+    if (data.isActive !== undefined)
+      updateData.is_active = data.isActive ? 1 : 0;
     if (data.sortOrder !== undefined) updateData.sort_order = data.sortOrder;
 
     await db
@@ -210,10 +213,7 @@ export class VotingRepository {
    */
   async deleteCriteria(id: string): Promise<void> {
     const db = getDatabase();
-    await db
-      .deleteFrom("voting_criteria")
-      .where("id", "=", id)
-      .execute();
+    await db.deleteFrom("voting_criteria").where("id", "=", id).execute();
   }
 
   // ==================== MATCH VOTES ====================
@@ -234,7 +234,7 @@ export class VotingRepository {
 
     if (!votedForUser) {
       throw new Error(
-        `Cannot vote for user ${data.votedForUserId}: user does not exist. Guests cannot receive votes.`
+        `Cannot vote for user ${data.votedForUserId}: user does not exist. Guests cannot receive votes.`,
       );
     }
 
@@ -286,7 +286,7 @@ export class VotingRepository {
   async submitVotes(
     matchId: string,
     voterUserId: string,
-    votes: { criteriaId: string; votedForUserId: string }[]
+    votes: { criteriaId: string; votedForUserId: string }[],
   ): Promise<MatchVote[]> {
     const results: MatchVote[] = [];
 
@@ -322,7 +322,7 @@ export class VotingRepository {
    */
   async findUserVotesForMatch(
     matchId: string,
-    userId: string
+    userId: string,
   ): Promise<UserMatchVotes> {
     const db = getDatabase();
     const rows = await db
@@ -347,7 +347,7 @@ export class VotingRepository {
    */
   async getMatchVotingResults(
     matchId: string,
-    language: "en" | "es" = "en"
+    language: "en" | "es" = "en",
   ): Promise<MatchVotingResults> {
     const db = getDatabase();
 
@@ -364,7 +364,11 @@ export class VotingRepository {
     // Get vote counts per criteria and voted_for_user
     const results = await db
       .selectFrom("match_votes")
-      .innerJoin("voting_criteria", "voting_criteria.id", "match_votes.criteria_id")
+      .innerJoin(
+        "voting_criteria",
+        "voting_criteria.id",
+        "match_votes.criteria_id",
+      )
       .innerJoin("user", "user.id", "match_votes.voted_for_user_id")
       .select([
         "match_votes.criteria_id",
@@ -414,7 +418,7 @@ export class VotingRepository {
    */
   async deleteUserVotesForMatch(
     matchId: string,
-    userId: string
+    userId: string,
   ): Promise<void> {
     const db = getDatabase();
     await db
@@ -427,7 +431,10 @@ export class VotingRepository {
   /**
    * Check if a user has voted for a specific match
    */
-  async hasUserVotedForMatch(matchId: string, userId: string): Promise<boolean> {
+  async hasUserVotedForMatch(
+    matchId: string,
+    userId: string,
+  ): Promise<boolean> {
     const db = getDatabase();
     const result = await db
       .selectFrom("match_votes")
@@ -439,6 +446,60 @@ export class VotingRepository {
     return !!result;
   }
 
+  // Filters to user-linked stats only (skips guest rows that have no user_id).
+  async getMatchPlayerSocialStats(
+    matchId: string,
+  ): Promise<MatchPlayerSocialStat[]> {
+    const db = getDatabase();
+    const rows = await db
+      .selectFrom("match_player_stats")
+      .innerJoin("user", "user.id", "match_player_stats.user_id")
+      .select([
+        "match_player_stats.user_id as user_id",
+        "user.name as user_name",
+        "match_player_stats.third_time_attended as third_time_attended",
+        "match_player_stats.third_time_beers as third_time_beers",
+      ])
+      .where("match_player_stats.match_id", "=", matchId)
+      .orderBy("user.name", "asc")
+      .execute();
+
+    return rows.map((r) => ({
+      userId: r.user_id,
+      userName: r.user_name || "Unknown",
+      thirdTimeAttended: Number(r.third_time_attended) === 1,
+      thirdTimeBeers: Number(r.third_time_beers) || 0,
+    }));
+  }
+
+  // Excludes cancelled signups and guests (no user_id, can't vote).
+  async getEligibleVoterCount(matchId: string): Promise<number> {
+    const db = getDatabase();
+    const result = await db
+      .selectFrom("signups")
+      .select((eb) => eb.fn.countAll<number>().as("count"))
+      .where("match_id", "=", matchId)
+      .where("status", "!=", "CANCELLED")
+      .where("user_id", "is not", null)
+      .executeTakeFirst();
+    return Number(result?.count ?? 0);
+  }
+
+  async setMatchVotingClosedAt(
+    matchId: string,
+    isoTimestamp: string | null,
+  ): Promise<void> {
+    const db = getDatabase();
+    await db
+      .updateTable("matches")
+      .set({
+        voting_closed_at: isoTimestamp,
+        updated_at: new Date().toISOString(),
+      })
+      .where("id", "=", matchId)
+      .execute();
+  }
+
   // ==================== RANKING & LEADERBOARDS ====================
 
   /**
@@ -446,7 +507,7 @@ export class VotingRepository {
    */
   async getPlayerVotingStats(
     userId: string,
-    language: "en" | "es" = "en"
+    language: "en" | "es" = "en",
   ): Promise<PlayerVotingStats> {
     const db = getDatabase();
 
@@ -474,7 +535,7 @@ export class VotingRepository {
 
     const totalVotes = rows.rows.reduce(
       (sum, row) => sum + Number(row.vote_count),
-      0
+      0,
     );
 
     return {
@@ -496,12 +557,13 @@ export class VotingRepository {
   async getVotingLeaderboard(
     groupId: string,
     language: "en" | "es" = "en",
-    topN: number = 3
+    topN: number = 3,
   ): Promise<VotingLeaderboard> {
     const db = getDatabase();
 
     const nameColumn = language === "es" ? "vc.name_es" : "vc.name_en";
-    const descriptionColumn = language === "es" ? "vc.description_es" : "vc.description_en";
+    const descriptionColumn =
+      language === "es" ? "vc.description_es" : "vc.description_en";
 
     const rows = await sql<{
       criteria_id: string;
@@ -561,7 +623,12 @@ export class VotingRepository {
 
       const awardUserName = row.user_name || "Unknown";
       const awardRawNick = row.display_username || row.username || null;
-      const awardNickname = awardRawNick && !awardRawNick.includes("@") && awardRawNick !== awardUserName ? awardRawNick : null;
+      const awardNickname =
+        awardRawNick &&
+        !awardRawNick.includes("@") &&
+        awardRawNick !== awardUserName
+          ? awardRawNick
+          : null;
       criteriaMap.get(row.criteria_id)!.topPlayers.push({
         userId: row.voted_for_user_id,
         userName: awardUserName,
@@ -581,7 +648,10 @@ export class VotingRepository {
    * Get player rankings by total votes received across all criteria, scoped
    * to a group.
    */
-  async getRankingsByTotalVotes(groupId: string, limit: number): Promise<PlayerRanking[]> {
+  async getRankingsByTotalVotes(
+    groupId: string,
+    limit: number,
+  ): Promise<PlayerRanking[]> {
     const db = getDatabase();
 
     const rows = await sql<{
@@ -615,7 +685,10 @@ export class VotingRepository {
     return rows.rows.map((row) => {
       const userName = row.user_name || row.user_email;
       const rawNick = row.display_username || row.username || null;
-      const userNickname = rawNick && !rawNick.includes("@") && rawNick !== userName ? rawNick : null;
+      const userNickname =
+        rawNick && !rawNick.includes("@") && rawNick !== userName
+          ? rawNick
+          : null;
       return {
         rank: Number(row.rank),
         userId: row.user_id,

--- a/packages/shared/src/services/voting-service.ts
+++ b/packages/shared/src/services/voting-service.ts
@@ -1,13 +1,28 @@
 // Voting Service - Business logic for match voting system
 
-import { votingRepository, VotingRepository } from "../repositories/voting-repository";
+import { addDays } from "date-fns";
+
 import type {
   VotingCriteria,
   MatchVote,
   LocalizedVotingCriteria,
   UserMatchVotes,
   MatchVotingResults,
+  MatchStats,
 } from "../domain/types";
+import type { VotingRepository } from "../repositories/voting-repository";
+
+import { getRepositoryFactory } from "../repositories";
+import { votingRepository } from "../repositories/voting-repository";
+import { convertToAppTimezone } from "../utils/timezone";
+
+const VOTING_AUTO_CLOSE_DAYS = 7;
+
+// Auto-close moment = end-of-day in the app timezone of the match date, plus N days.
+function computeVotingAutoCloseAt(matchDate: string, days: number): string {
+  const endOfDay = convertToAppTimezone(`${matchDate} 23:59:59`);
+  return addDays(endOfDay, days).toISOString();
+}
 
 export class VotingService {
   private repository: VotingRepository;
@@ -22,7 +37,7 @@ export class VotingService {
    * Get all active voting criteria (localized)
    */
   async getActiveCriteria(
-    language: "en" | "es" = "en"
+    language: "en" | "es" = "en",
   ): Promise<LocalizedVotingCriteria[]> {
     return this.repository.findAllCriteriaLocalized(language, true);
   }
@@ -31,7 +46,7 @@ export class VotingService {
    * Get all voting criteria including inactive (admin only)
    */
   async getAllCriteria(
-    language: "en" | "es" = "en"
+    language: "en" | "es" = "en",
   ): Promise<LocalizedVotingCriteria[]> {
     return this.repository.findAllCriteriaLocalized(language, false);
   }
@@ -76,7 +91,7 @@ export class VotingService {
       descriptionEs?: string;
       isActive?: boolean;
       sortOrder?: number;
-    }
+    },
   ): Promise<VotingCriteria> {
     // Check criteria exists
     const existing = await this.repository.findCriteriaById(id);
@@ -119,7 +134,7 @@ export class VotingService {
   async submitVotes(
     matchId: string,
     voterUserId: string,
-    votes: { criteriaId: string; votedForUserId: string }[]
+    votes: { criteriaId: string; votedForUserId: string }[],
   ): Promise<MatchVote[]> {
     // Validate all criteria exist and are active
     const activeCriteria = await this.repository.findAllCriteria(true);
@@ -136,7 +151,7 @@ export class VotingService {
     for (const vote of votes) {
       if (votedForUsers.has(vote.votedForUserId)) {
         throw new Error(
-          "Each player can only be voted for one category per submission"
+          "Each player can only be voted for one category per submission",
         );
       }
       votedForUsers.add(vote.votedForUserId);
@@ -151,7 +166,7 @@ export class VotingService {
    */
   async getUserVotesForMatch(
     matchId: string,
-    userId: string
+    userId: string,
   ): Promise<UserMatchVotes> {
     return this.repository.findUserVotesForMatch(matchId, userId);
   }
@@ -161,7 +176,7 @@ export class VotingService {
    */
   async getMatchVotingResults(
     matchId: string,
-    language: "en" | "es" = "en"
+    language: "en" | "es" = "en",
   ): Promise<MatchVotingResults> {
     return this.repository.getMatchVotingResults(matchId, language);
   }
@@ -171,7 +186,7 @@ export class VotingService {
    */
   async hasUserVotedForMatch(
     matchId: string,
-    userId: string
+    userId: string,
   ): Promise<boolean> {
     return this.repository.hasUserVotedForMatch(matchId, userId);
   }
@@ -179,11 +194,63 @@ export class VotingService {
   /**
    * Clear user's votes for a match (allows re-voting)
    */
-  async clearUserVotesForMatch(
-    matchId: string,
-    userId: string
-  ): Promise<void> {
+  async clearUserVotesForMatch(matchId: string, userId: string): Promise<void> {
     return this.repository.deleteUserVotesForMatch(matchId, userId);
+  }
+
+  async getMatchStats(
+    matchId: string,
+    language: "en" | "es" = "en",
+  ): Promise<MatchStats> {
+    const match = await getRepositoryFactory().matches.findById(matchId);
+    if (!match) {
+      throw new Error("Match not found");
+    }
+
+    const votingAutoCloseAt = computeVotingAutoCloseAt(
+      match.date,
+      VOTING_AUTO_CLOSE_DAYS,
+    );
+    const votingClosedAt = match.votingClosedAt;
+    const isVotingClosed =
+      votingClosedAt !== null || new Date().toISOString() >= votingAutoCloseAt;
+
+    if (!isVotingClosed) {
+      return {
+        matchId,
+        isVotingClosed: false,
+        votingAutoCloseAt,
+        votingClosedAt,
+        totalVoters: 0,
+        eligibleVoterCount: 0,
+        results: [],
+        playerStats: [],
+      };
+    }
+
+    const [results, playerStats, eligibleVoterCount] = await Promise.all([
+      this.repository.getMatchVotingResults(matchId, language),
+      this.repository.getMatchPlayerSocialStats(matchId),
+      this.repository.getEligibleVoterCount(matchId),
+    ]);
+
+    return {
+      matchId,
+      isVotingClosed: true,
+      votingAutoCloseAt,
+      votingClosedAt,
+      totalVoters: results.totalVoters,
+      eligibleVoterCount,
+      results: results.results,
+      playerStats,
+    };
+  }
+
+  async setMatchVotingState(matchId: string, closed: boolean): Promise<void> {
+    await this.repository.setMatchVotingClosedAt(
+      matchId,
+      closed ? new Date().toISOString() : null,
+    );
   }
 }
 

--- a/packages/shared/src/services/voting-service.ts
+++ b/packages/shared/src/services/voting-service.ts
@@ -3,6 +3,7 @@
 import { addDays } from "date-fns";
 
 import type {
+  Match,
   VotingCriteria,
   MatchVote,
   LocalizedVotingCriteria,
@@ -12,7 +13,6 @@ import type {
 } from "../domain/types";
 import type { VotingRepository } from "../repositories/voting-repository";
 
-import { getRepositoryFactory } from "../repositories";
 import { votingRepository } from "../repositories/voting-repository";
 import { convertToAppTimezone } from "../utils/timezone";
 
@@ -20,7 +20,7 @@ const VOTING_AUTO_CLOSE_DAYS = 7;
 
 // Auto-close moment = end-of-day in the app timezone of the match date, plus N days.
 function computeVotingAutoCloseAt(matchDate: string, days: number): string {
-  const endOfDay = convertToAppTimezone(`${matchDate} 23:59:59`);
+  const endOfDay = convertToAppTimezone(`${matchDate}T23:59:59`);
   return addDays(endOfDay, days).toISOString();
 }
 
@@ -199,14 +199,10 @@ export class VotingService {
   }
 
   async getMatchStats(
-    matchId: string,
+    match: Match,
     language: "en" | "es" = "en",
   ): Promise<MatchStats> {
-    const match = await getRepositoryFactory().matches.findById(matchId);
-    if (!match) {
-      throw new Error("Match not found");
-    }
-
+    const matchId = match.id;
     const votingAutoCloseAt = computeVotingAutoCloseAt(
       match.date,
       VOTING_AUTO_CLOSE_DAYS,


### PR DESCRIPTION
## Summary
- New screen at `/matches/[matchId]/stats` showing per-criteria voting awards, post-match social stats (3rd time / beers), and participation count for a single match.
- Results are gated on a voting window: auto-closes 7 days after `match.date` (computed in app timezone), with organizer/admin manual close/reopen override via a new `voting_closed_at` column on `matches`.
- Adds `GET /voting/matches/:matchId/stats`, `POST .../close-voting`, `POST .../reopen-voting` (group-scoped via `assertMatchInCurrentGroup`; mutations require organizer or platform admin).
- Adds "View Match Stats" button on the match detail screen once `isPlayed`, visible to all group members.
- New `matchStats.*` namespace in en/es locales; new `a11y.viewMatchStats` label.

## Test plan
- [ ] `pnpm migrate:up` then `pnpm migrate:down` round-trip the new column cleanly.
- [ ] `GET /api/voting/matches/<id>/stats` before close → `isVotingClosed: false`, empty `results`/`playerStats`.
- [ ] `POST /api/voting/matches/<id>/close-voting` as organizer → 200; as non-organizer → 403; on cross-group `matchId` → 404.
- [ ] After close: `GET .../stats` returns populated `results`, `playerStats`, correct `eligibleVoterCount` and `totalVoters`.
- [ ] `POST .../reopen-voting` toggles the state back.
- [ ] Backdate a test match's `date` to >7 days ago → `isVotingClosed: true` without `voting_closed_at` set.
- [ ] Mobile/web: match detail for a played match shows "View Match Stats" button; stats screen renders status banner, awards, social stats sections; participation banner only shown when closed; ES locale renders correctly.
- [ ] Organizer sees "Close voting now" / "Reopen voting" buttons; non-organizer doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)