### PR TITLE
feat(matches): polish finished-match action buttons

### DIFF
--- a/apps/mobile-web/app.config.ts
+++ b/apps/mobile-web/app.config.ts
@@ -5,7 +5,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Football with Friends",
   slug: "football-with-friends",
   owner: "pepegrillo",
-  version: "1.3.0",
+  version: "1.3.1",
   scheme: "football-with-friends",
   orientation: "portrait",
   icon: "./assets/icon.png",
@@ -70,7 +70,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     supportsTablet: false,
     bundleIdentifier: "com.pepegrillo.football-with-friends",
     usesAppleSignIn: true,
-    buildNumber: "20",
+    buildNumber: "21",
     infoPlist: {
       NSPhotoLibraryUsageDescription:
         "Football with Friends uses your photo library to update your profile picture.",
@@ -81,7 +81,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   },
   android: {
     package: "com.pepegrillo.footballwithfriends",
-    versionCode: 6,
+    versionCode: 7,
     adaptiveIcon: {
       foregroundImage: "./assets/adaptive-icon.png",
       backgroundColor: "#ffffff",

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -207,6 +207,19 @@ export default function MatchDetailScreen() {
   });
   const mediaCount = mediaCountData?.count ?? 0;
 
+  const { data: matchStats } = useQuery({
+    queryKey: ["match-stats", matchId],
+    queryFn: async () => {
+      const res = await client.api.voting.matches[":matchId"].stats.$get({
+        param: { matchId: matchId! },
+      });
+      if (!res.ok) return null;
+      return res.json();
+    },
+    enabled: !!matchId,
+  });
+  const isVotingClosed = matchStats?.isVotingClosed ?? false;
+
   const signupMutation = useMutation({
     mutationFn: async () => {
       const res = await client.api.matches[":id"].signup.$post({
@@ -859,7 +872,9 @@ export default function MatchDetailScreen() {
                 })
               }
             >
-              {t("voting.voteForMatch")}
+              {isVotingClosed
+                ? t("voting.seeMyVotes")
+                : t("voting.voteForMatch")}
             </Button>
           )}
 
@@ -879,6 +894,41 @@ export default function MatchDetailScreen() {
             >
               {t("matchStats.viewStats")}
             </Button>
+          )}
+
+          {/* Multimedia Gallery — only for finished matches, placed under match stats */}
+          {isPlayed && userId && (mediaCount > 0 || isParticipating || isAdmin) && (
+            <Pressable
+              onPress={() => router.push(`/(tabs)/matches/${matchId}/gallery`)}
+              accessibilityRole="button"
+              accessibilityLabel={t("multimedia.viewGallery")}
+            >
+              <Card variant="elevated" padding="$4">
+                <XStack alignItems="center" gap="$3">
+                  <YStack
+                    width={40}
+                    height={40}
+                    borderRadius={10}
+                    backgroundColor="$purple4"
+                    alignItems="center"
+                    justifyContent="center"
+                  >
+                    <ImageIcon size={20} color="$purple10" />
+                  </YStack>
+                  <YStack flex={1}>
+                    <Text fontSize="$5" fontWeight="bold">
+                      {t("multimedia.title")}
+                    </Text>
+                    <Text fontSize="$3" color="$gray11">
+                      {mediaCount === 0
+                        ? t("multimedia.addFirstPhoto")
+                        : t("multimedia.galleryCount", { count: mediaCount })}
+                    </Text>
+                  </YStack>
+                  <ChevronRight size={20} color="$gray10" />
+                </XStack>
+              </Card>
+            </Pressable>
           )}
 
           {/* View B: Participating or Played Match - Show Players Table */}
@@ -917,43 +967,6 @@ export default function MatchDetailScreen() {
                 />
               </YStack>
             </Card>
-          )}
-
-          {/* Multimedia Gallery Card */}
-          {userId && (mediaCount > 0 || isParticipating || isAdmin) && (
-            <Pressable
-              onPress={() => router.push(`/(tabs)/matches/${matchId}/gallery`)}
-              accessibilityRole="button"
-              accessibilityLabel={t("multimedia.viewGallery")}
-            >
-              <Card variant="elevated" padding="$4">
-                <XStack alignItems="center" gap="$3">
-                  <YStack
-                    width={40}
-                    height={40}
-                    borderRadius={10}
-                    backgroundColor="$purple4"
-                    alignItems="center"
-                    justifyContent="center"
-                  >
-                    <ImageIcon size={20} color="$purple10" />
-                  </YStack>
-                  <YStack flex={1}>
-                    <Text fontSize="$5" fontWeight="bold">
-                      {t("multimedia.title")}
-                    </Text>
-                    <Text fontSize="$3" color="$gray11">
-                      {mediaCount === 0
-                        ? t("multimedia.addFirstPhoto")
-                        : t("multimedia.galleryCount", { count: mediaCount })}
-                    </Text>
-                    {/* Note: addFirstPhoto is only shown to participants/admin since
-                        the card is hidden for non-participants when count === 0. */}
-                  </YStack>
-                  <ChevronRight size={20} color="$gray10" />
-                </XStack>
-              </Card>
-            </Pressable>
           )}
 
           {/* Not logged in prompt */}

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -9,6 +9,7 @@ import {
   useGroupRoster,
   type GroupRosterEntry,
 } from "@repo/api-client";
+import type { MatchStats } from "@repo/shared/domain";
 import { formatMatchDate } from "@repo/shared/utils";
 import {
   Container,
@@ -207,18 +208,24 @@ export default function MatchDetailScreen() {
   });
   const mediaCount = mediaCountData?.count ?? 0;
 
-  const { data: matchStats } = useQuery({
+  const isCancelled = match?.status === "cancelled";
+  const isPlayed = match?.status === "completed";
+  const isParticipating = match?.isUserSignedUp;
+  const userWasParticipant =
+    match?.userSignup?.status === "PAID" ||
+    match?.userSignup?.status === "PENDING";
+
+  const { data: isVotingClosed = false } = useQuery<MatchStats, Error, boolean>({
     queryKey: ["match-stats", matchId],
     queryFn: async () => {
       const res = await client.api.voting.matches[":matchId"].stats.$get({
         param: { matchId: matchId! },
       });
-      if (!res.ok) return null;
-      return res.json();
+      return res.json() as Promise<MatchStats>;
     },
-    enabled: !!matchId,
+    select: (data) => data.isVotingClosed,
+    enabled: !!matchId && isPlayed && userWasParticipant,
   });
-  const isVotingClosed = matchStats?.isVotingClosed ?? false;
 
   const signupMutation = useMutation({
     mutationFn: async () => {
@@ -634,15 +641,6 @@ export default function MatchDetailScreen() {
       testID: `match-detail-player-row-${signup.id}`,
     }));
   };
-
-  const isCancelled = match?.status === "cancelled";
-  const isPlayed = match?.status === "completed" || match?.status === "played";
-  const isParticipating = match?.isUserSignedUp;
-
-  // Check if user was a participant (PAID or PENDING, not CANCELLED)
-  const userWasParticipant =
-    match?.userSignup?.status === "PAID" ||
-    match?.userSignup?.status === "PENDING";
 
   // Check if match is today (in app timezone, not device timezone)
   const isMatchToday = match

--- a/apps/mobile-web/app/stats-voting.tsx
+++ b/apps/mobile-web/app/stats-voting.tsx
@@ -366,6 +366,8 @@ export default function StatsVotingScreen() {
       <Stack.Screen
         options={{
           title: t("voting.title"),
+          headerStyle: { backgroundColor: theme.background?.val },
+          headerTintColor: theme.color?.val,
           headerBackVisible: false,
           headerLeft: () => (
             <Pressable onPress={() => router.back()} style={{ marginLeft: 8 }}>

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -738,6 +738,7 @@
     "title": "Match Voting",
     "selectMatch": "Select Match",
     "voteForMatch": "Vote for this Match",
+    "seeMyVotes": "See what I voted",
     "thirdTimeSection": "3rd Half Stats",
     "didYouGo": "Did you go to the 3rd half?",
     "yes": "Yes",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -741,6 +741,7 @@
     "title": "Votación del Partido",
     "selectMatch": "Seleccionar Partido",
     "voteForMatch": "Votar por este Partido",
+    "seeMyVotes": "Ver lo que voté",
     "thirdTimeSection": "Estadísticas del 3er Tiempo",
     "didYouGo": "¿Fuiste al 3er tiempo?",
     "yes": "Sí",


### PR DESCRIPTION
## Summary
- Move the multimedia gallery card up to sit right under "View Match Stats" and gate it on finished matches.
- Vote CTA on the match detail screen now reads "See what I voted" once the voting window has closed (driven by `/api/voting/matches/:id/stats`); still reads "Vote for this Match" while the window is open.
- Add themed `headerStyle` background + `headerTintColor` to the stats-voting screen so the header follows light/dark mode instead of staying white.
