### PR TITLE
feat(stats): editable 3rd-time stats + badge dark-mode fix

### DIFF
--- a/apps/mobile-web/app.config.ts
+++ b/apps/mobile-web/app.config.ts
@@ -5,7 +5,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Football with Friends",
   slug: "football-with-friends",
   owner: "pepegrillo",
-  version: "1.3.1",
+  version: "1.3.2",
   scheme: "football-with-friends",
   orientation: "portrait",
   icon: "./assets/icon.png",
@@ -70,7 +70,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     supportsTablet: false,
     bundleIdentifier: "com.pepegrillo.football-with-friends",
     usesAppleSignIn: true,
-    buildNumber: "21",
+    buildNumber: "22",
     infoPlist: {
       NSPhotoLibraryUsageDescription:
         "Football with Friends uses your photo library to update your profile picture.",
@@ -81,7 +81,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   },
   android: {
     package: "com.pepegrillo.footballwithfriends",
-    versionCode: 7,
+    versionCode: 8,
     adaptiveIcon: {
       foregroundImage: "./assets/adaptive-icon.png",
       backgroundColor: "#ffffff",

--- a/apps/mobile-web/app/(tabs)/social/[userId].tsx
+++ b/apps/mobile-web/app/(tabs)/social/[userId].tsx
@@ -1,11 +1,5 @@
 // @ts-nocheck - Tamagui type recursion workaround
-import {
-  useQuery,
-  useMutation,
-  useQueryClient,
-  client,
-  useSession,
-} from "@repo/api-client";
+import { useQuery, client } from "@repo/api-client";
 import {
   Container,
   Card,
@@ -13,7 +7,6 @@ import {
   YStack,
   XStack,
   Spinner,
-  Button,
   StatsSummary,
   UserAvatar,
   H2,
@@ -58,13 +51,6 @@ interface PlayerProfile {
 export default function PlayerDetailScreen() {
   const { userId } = useLocalSearchParams<{ userId: string }>();
   const { t, i18n } = useTranslation();
-  const { data: session } = useSession();
-  const queryClient = useQueryClient();
-
-  const isAdmin = session?.user?.role === "admin";
-  const isSelf = session?.user?.id === userId;
-  const canEdit = isAdmin || isSelf;
-
   const {
     data: profile,
     isLoading,
@@ -82,19 +68,6 @@ export default function PlayerDetailScreen() {
     enabled: !!userId,
   });
 
-  // Also fetch all matches the user participated in (for stats entry on matches without stats yet)
-  const { data: userSignups } = useQuery({
-    queryKey: ["user-signups", userId],
-    queryFn: async () => {
-      // Get all matches to cross-reference with stats
-      const res = await client.api.matches.$get({
-        query: { type: "past" },
-      });
-      return res.json();
-    },
-    enabled: !!userId,
-  });
-
   // Fetch voting statistics for this player
   const { data: votingStats } = useQuery({
     queryKey: ["player-voting-stats", userId],
@@ -106,84 +79,6 @@ export default function PlayerDetailScreen() {
     },
     enabled: !!userId,
   });
-
-  const recordStatsMutation = useMutation({
-    mutationFn: async ({
-      matchId,
-      data,
-    }: {
-      matchId: string;
-      data: {
-        userId: string;
-        goals?: number;
-        thirdTimeAttended?: boolean;
-        thirdTimeBeers?: number;
-      };
-    }) => {
-      const res = await client.api.matches[":id"]["player-stats"].$post({
-        param: { id: matchId },
-        json: data,
-      });
-      return res.json();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["player-profile", userId] });
-    },
-  });
-
-  const updateStatsMutation = useMutation({
-    mutationFn: async ({
-      matchId,
-      targetUserId,
-      data,
-    }: {
-      matchId: string;
-      targetUserId: string;
-      data: {
-        goals?: number;
-        thirdTimeAttended?: boolean;
-        thirdTimeBeers?: number;
-        confirmed?: boolean;
-      };
-    }) => {
-      const res = await client.api.matches[":id"]["player-stats"][
-        ":userId"
-      ].$patch({
-        param: { id: matchId, userId: targetUserId },
-        json: data,
-      });
-      return res.json();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["player-profile", userId] });
-    },
-  });
-
-  const handleThirdTimeConfirm = (
-    matchId: string,
-    beers: number,
-    attended: boolean,
-  ) => {
-    const existingStat = profile?.matchStats?.find(
-      (s) => s.matchId === matchId,
-    );
-    if (existingStat) {
-      updateStatsMutation.mutate({
-        matchId,
-        targetUserId: userId!,
-        data: { thirdTimeBeers: beers, thirdTimeAttended: attended },
-      });
-    } else {
-      recordStatsMutation.mutate({
-        matchId,
-        data: {
-          userId: userId!,
-          thirdTimeBeers: beers,
-          thirdTimeAttended: attended,
-        },
-      });
-    }
-  };
 
   const language = i18n.language === "es" ? "es" : "en";
 
@@ -231,10 +126,7 @@ export default function PlayerDetailScreen() {
           {/* Player Header */}
           <Card variant="elevated">
             <YStack padding="$4" alignItems="center" gap="$3">
-              <UserAvatar
-                name={profile.user.name}
-                size={64}
-              />
+              <UserAvatar name={profile.user.name} size={64} />
               <XStack gap="$2" alignItems="center">
                 {profile.user.nationality && (
                   <Text fontSize="$7">
@@ -320,25 +212,10 @@ export default function PlayerDetailScreen() {
                           ? t("playerStats.attended")
                           : t("playerStats.notAttended")}
                       </Text>
-                      {stat.thirdTimeAttended && (
+                      {stat.thirdTimeAttended && stat.thirdTimeBeers > 0 && (
                         <Text fontSize="$4" fontWeight="700">
-                          {stat.thirdTimeBeers}
+                          🍺 {stat.thirdTimeBeers}
                         </Text>
-                      )}
-                      {canEdit && (
-                        <Button
-                          size="$2"
-                          variant="outline"
-                          onPress={() =>
-                            handleThirdTimeConfirm(
-                              stat.matchId,
-                              stat.thirdTimeBeers + 1,
-                              true,
-                            )
-                          }
-                        >
-                          +1
-                        </Button>
                       )}
                     </XStack>
                   </XStack>
@@ -357,13 +234,17 @@ export default function PlayerDetailScreen() {
                 <VotingStatsSection
                   stats={votingStats.criteriaBreakdown.map((stat: any) => ({
                     ...stat,
-                    criteriaName: t(`voting.criteria.${stat.criteriaCode}`, { defaultValue: stat.criteriaName }),
+                    criteriaName: t(`voting.criteria.${stat.criteriaCode}`, {
+                      defaultValue: stat.criteriaName,
+                    }),
                   }))}
                   totalVotes={votingStats.totalVotesReceived}
                   emptyTitle={t("awards.noAwardsYet")}
                   emptyDescription={t("awards.playMoreMatches")}
                   formatVotes={(count) => t("awards.votesCount", { count })}
-                  formatTotalVotes={(count) => t("awards.totalVotes", { count })}
+                  formatTotalVotes={(count) =>
+                    t("awards.totalVotes", { count })
+                  }
                   overallLabel={t("awards.rankOverall")}
                 />
               </YStack>

--- a/apps/mobile-web/app/stats-voting.tsx
+++ b/apps/mobile-web/app/stats-voting.tsx
@@ -155,6 +155,19 @@ export default function StatsVotingScreen() {
     enabled: !!selectedMatchId && !!userId,
   });
 
+  const { data: matchStatsView } = useQuery({
+    queryKey: ["match-stats", selectedMatchId],
+    queryFn: async () => {
+      const res = await client.api.voting.matches[":matchId"].stats.$get({
+        param: { matchId: selectedMatchId },
+      });
+      return res.json();
+    },
+    enabled: !!selectedMatchId && !!userId,
+  });
+
+  const isVotingClosed = !!matchStatsView?.isVotingClosed;
+
   // Submit votes mutation
   const submitVotesMutation = useMutation({
     mutationFn: async (
@@ -211,9 +224,8 @@ export default function StatsVotingScreen() {
     if (!data || !userId) return null;
     const stats = Array.isArray(data) ? data : data?.stats || [];
     return (
-      stats.find(
-        (s: any) => s.userId === userId || s.user_id === userId,
-      ) || null
+      stats.find((s: any) => s.userId === userId || s.user_id === userId) ||
+      null
     );
   };
 
@@ -232,12 +244,10 @@ export default function StatsVotingScreen() {
   useEffect(() => {
     const myStats = getMyStats(matchStatsData);
     if (myStats) {
-      const attended =
-        myStats.thirdTimeAttended ?? myStats.third_time_attended;
+      const attended = myStats.thirdTimeAttended ?? myStats.third_time_attended;
       if (attended !== undefined && attended !== null) {
         setAttendedThirdTime(Boolean(attended));
-        const beers =
-          myStats.thirdTimeBeers ?? myStats.third_time_beers ?? 0;
+        const beers = myStats.thirdTimeBeers ?? myStats.third_time_beers ?? 0;
         setBeersCount(Number(beers));
       }
     }
@@ -287,13 +297,29 @@ export default function StatsVotingScreen() {
   };
 
   const hasVoted = (userVotesData?.votes?.length ?? 0) > 0;
-  const hasSubmittedStats = !!getMyStats(matchStatsData);
+  const myStats = getMyStats(matchStatsData);
+  const hasSubmittedStats = !!myStats;
 
-  // Lock form only when both applicable parts are done:
-  // - If user has voted, votes are locked
-  // - If user has submitted stats, stats are locked
-  // - Full lock (hide submit) only when both are done (or one wasn't attempted)
-  const isLocked = hasVoted && hasSubmittedStats;
+  const serverAttended = myStats
+    ? Boolean(myStats.thirdTimeAttended ?? myStats.third_time_attended)
+    : null;
+  const serverBeers = Number(
+    myStats?.thirdTimeBeers ?? myStats?.third_time_beers ?? 0,
+  );
+  // Beer diff only matters when attendance is true (false → beers persisted as 0)
+  const statsDirty =
+    attendedThirdTime !== serverAttended ||
+    (attendedThirdTime === true && beersCount !== serverBeers);
+
+  // Votes are immutable after first submit; stats stay editable until voting closes.
+  const isLocked =
+    isVotingClosed || (hasVoted && hasSubmittedStats && !statsDirty);
+
+  const hasNewVotes =
+    !hasVoted && Object.values(voteSelections).some((v) => !!v);
+  const hasStatsToSubmit = hasSubmittedStats
+    ? statsDirty
+    : attendedThirdTime !== null;
 
   const handleSubmitVotes = async () => {
     const votes = Object.entries(voteSelections)
@@ -314,8 +340,7 @@ export default function StatsVotingScreen() {
       setSubmitError(null);
 
       try {
-        // Submit 3rd time stats if answered
-        if (attendedThirdTime !== null) {
+        if (attendedThirdTime !== null && hasStatsToSubmit) {
           await submitStatsMutation.mutateAsync({
             thirdTimeAttended: attendedThirdTime,
             thirdTimeBeers: attendedThirdTime ? beersCount : 0,
@@ -409,19 +434,18 @@ export default function StatsVotingScreen() {
               </YStack>
             </Card>
 
-            {/* Already voted banner */}
-            {!!selectedMatchId && hasVoted && (
+            {!!selectedMatchId && isVotingClosed && (
               <XStack
-                backgroundColor="$green3"
+                backgroundColor="$gray4"
                 padding="$3"
                 borderRadius="$3"
                 alignItems="center"
                 justifyContent="center"
                 gap="$2"
               >
-                <Lock size={16} color="$green10" />
-                <Text color="$green10" fontWeight="600">
-                  {t("voting.alreadyVoted")}
+                <Lock size={16} color="$gray11" />
+                <Text color="$gray11" fontWeight="600">
+                  {t("matchStats.votingClosed")}
                 </Text>
               </XStack>
             )}
@@ -442,8 +466,8 @@ export default function StatsVotingScreen() {
                           attendedThirdTime === true ? "primary" : "outline"
                         }
                         onPress={() => setAttendedThirdTime(true)}
-                        disabled={hasSubmittedStats}
-                        opacity={hasSubmittedStats ? 0.5 : 1}
+                        disabled={isVotingClosed}
+                        opacity={isVotingClosed ? 0.5 : 1}
                       >
                         {t("voting.yes")}
                       </Button>
@@ -453,8 +477,8 @@ export default function StatsVotingScreen() {
                           attendedThirdTime === false ? "primary" : "outline"
                         }
                         onPress={() => setAttendedThirdTime(false)}
-                        disabled={hasSubmittedStats}
-                        opacity={hasSubmittedStats ? 0.5 : 1}
+                        disabled={isVotingClosed}
+                        opacity={isVotingClosed ? 0.5 : 1}
                       >
                         {t("voting.no")}
                       </Button>
@@ -469,7 +493,7 @@ export default function StatsVotingScreen() {
                           circular
                           icon={Minus}
                           variant="outline"
-                          disabled={beersCount <= 0 || hasSubmittedStats}
+                          disabled={beersCount <= 0 || isVotingClosed}
                           onPress={() =>
                             setBeersCount(Math.max(0, beersCount - 1))
                           }
@@ -487,7 +511,7 @@ export default function StatsVotingScreen() {
                           circular
                           icon={Plus}
                           variant="outline"
-                          disabled={hasSubmittedStats}
+                          disabled={isVotingClosed}
                           onPress={() => setBeersCount(beersCount + 1)}
                         />
                       </XStack>
@@ -504,6 +528,21 @@ export default function StatsVotingScreen() {
                   <Text fontSize="$5" fontWeight="600">
                     {t("voting.matchAwards")}
                   </Text>
+                  {hasVoted && !isVotingClosed && (
+                    <XStack
+                      backgroundColor="$green3"
+                      padding="$3"
+                      borderRadius="$3"
+                      alignItems="center"
+                      justifyContent="center"
+                      gap="$2"
+                    >
+                      <Lock size={16} color="$green10" />
+                      <Text color="$green10" fontWeight="600">
+                        {t("voting.alreadyVoted")}
+                      </Text>
+                    </XStack>
+                  )}
                   {isLoadingCriteria || isLoadingPlayers ? (
                     <YStack alignItems="center" padding="$4">
                       <Spinner size="large" />
@@ -519,7 +558,7 @@ export default function StatsVotingScreen() {
                       selections={voteSelections}
                       onSelectionChange={handleSelectionChange}
                       placeholder={t("voting.selectPlayer")}
-                      disabled={hasVoted}
+                      disabled={hasVoted || isVotingClosed}
                     />
                   )}
 
@@ -550,11 +589,7 @@ export default function StatsVotingScreen() {
                       variant="primary"
                       onPress={handleSubmitVotes}
                       disabled={
-                        isSubmitting ||
-                        (Object.keys(voteSelections).filter(
-                          (k) => voteSelections[k],
-                        ).length === 0 &&
-                          attendedThirdTime === null)
+                        isSubmitting || (!hasNewVotes && !hasStatsToSubmit)
                       }
                     >
                       {isSubmitting ? (

--- a/apps/mobile-web/app/stats-voting.tsx
+++ b/apps/mobile-web/app/stats-voting.tsx
@@ -347,8 +347,9 @@ export default function StatsVotingScreen() {
           });
         }
 
-        // Submit votes if any
-        if (votes.length > 0) {
+        // Votes are immutable; voteSelections is pre-populated when hasVoted is true,
+        // so gate on hasNewVotes to avoid re-POSTing existing selections on stats edits.
+        if (hasNewVotes && votes.length > 0) {
           await submitVotesMutation.mutateAsync(votes);
         }
 

--- a/packages/ui/src/components/Badge.tsx
+++ b/packages/ui/src/components/Badge.tsx
@@ -28,6 +28,7 @@ export function Badge({ variant = "default", children, ...props }: BadgeProps) {
       color: "$blue11",
     },
   };
+  const { color, backgroundColor } = variantStyles[variant];
 
   return (
     <XStack
@@ -35,10 +36,10 @@ export function Badge({ variant = "default", children, ...props }: BadgeProps) {
       paddingVertical="$1.5"
       borderRadius="$2"
       alignItems="center"
-      {...variantStyles[variant]}
+      backgroundColor={backgroundColor}
       {...props}
     >
-      <Text fontSize="$2" fontWeight="600" color="inherit">
+      <Text fontSize="$2" fontWeight="600" color={color}>
         {children}
       </Text>
     </XStack>


### PR DESCRIPTION
## Summary
- **Editable 3rd-time stats** — unlock the attendance + beer-count controls until voting closes (manual close or 7-day auto-close). Votes remain immutable after first submit. The submit button only enables when there's actually something new to write (dirty tracking against the server snapshot).
- **Badge dark-mode contrast fix** — `<Text color="inherit">` doesn't propagate on RN, so non-default badges (info, warning, success, danger) rendered platform-default black on dark theme. Move the variant color directly to the `Text`.
- **Player profile cleanup** — remove the `+1` beer button (self-edits now go through the voting screen; organizers shouldn't be modifying other players' counts). Prefix the count with 🍺 so the number reads as a beer count. Drop the orphaned mutations and an unused `user-signups` query.

## Test plan
- [ ] On a past match where you've already submitted stats, change the beer count by ±1 → submit → reload → new count is pre-populated.
- [ ] Flip attendance Yes ↔ No → on No, beers persist as 0; toggling back to Yes shows the new count after a fresh submit.
- [ ] Confirm the awards selector stays locked after first vote; the "already voted" banner now sits inside the awards card.
- [ ] Trigger voting closed (organizer close or pick a >7-day-old match) → 3rd-time controls disabled, awards selector disabled, submit hidden, "voting closed" banner visible at the top.
- [ ] First-time voter on a fresh match: submit-only-stats and submit-only-votes paths both still work; submit button enables only when there's something new.
- [ ] Dark theme: Players tab + Awards section badges render legibly (light text on tinted background) for every variant.
- [ ] Player profile: no `+1` button anywhere; rows with attendance + ≥1 beer show "🍺 N"; rows with attendance + 0 beers show only the "Attended" label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)