### PR TITLE
chore(release): bump to 1.3.3

### DIFF
--- a/apps/mobile-web/app.config.ts
+++ b/apps/mobile-web/app.config.ts
@@ -5,7 +5,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Football with Friends",
   slug: "football-with-friends",
   owner: "pepegrillo",
-  version: "1.3.2",
+  version: "1.3.3",
   scheme: "football-with-friends",
   orientation: "portrait",
   icon: "./assets/icon.png",
@@ -69,7 +69,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     supportsTablet: false,
     bundleIdentifier: "com.pepegrillo.football-with-friends",
     usesAppleSignIn: true,
-    buildNumber: "23",
+    buildNumber: "24",
     infoPlist: {
       NSPhotoLibraryUsageDescription:
         "Football with Friends uses your photo library to update your profile picture.",
@@ -79,7 +79,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   },
   android: {
     package: "com.pepegrillo.footballwithfriends",
-    versionCode: 9,
+    versionCode: 10,
     adaptiveIcon: {
       foregroundImage: "./assets/adaptive-icon.png",
       backgroundColor: "#ffffff",


### PR DESCRIPTION
## Summary
- Bumps `version` 1.3.2 → 1.3.3, iOS `buildNumber` 23 → 24, Android `versionCode` 9 → 10.
- Ships the match-card tap regression fix from #54 to alpha-track testers — 1.3.2 currently on TestFlight and Play alpha has the broken Tamagui rc.41 match-tap behavior.

## Test plan
- [ ] Local build iOS prod profile, submit to App Store Connect (TestFlight)
- [ ] Local build Android prod AAB, submit to Play alpha track
- [ ] Smoke-test on installed device: tap a match card from upcoming + past tabs and confirm detail screen opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)