### PR TITLE
fix(matches): correct share URL + render per-match OG image

### DIFF
--- a/api/og/[matchId].tsx
+++ b/api/og/[matchId].tsx
@@ -1,5 +1,7 @@
-import { formatDisplayDate } from "@repo/shared/utils";
 import { ImageResponse } from "@vercel/og";
+import { formatInTimeZone } from "date-fns-tz";
+
+const APP_TIMEZONE = process.env.DEFAULT_TIMEZONE || "Europe/Berlin";
 
 export const config = { runtime: "edge" };
 
@@ -36,7 +38,11 @@ export default async function handler(request: Request) {
     return new Response("Upstream error", { status: 502 });
   }
 
-  const dateLine = formatDisplayDate(match.date, "EEEE, MMMM d, yyyy");
+  const dateLine = formatInTimeZone(
+    match.date,
+    APP_TIMEZONE,
+    "EEEE, MMMM d, yyyy",
+  );
   const subtitle = `${match.time}hs · ${match.location?.name ?? "TBD"} · ${match.maxPlayers} players`;
 
   return new ImageResponse(

--- a/api/og/[matchId].tsx
+++ b/api/og/[matchId].tsx
@@ -1,0 +1,91 @@
+import { formatDisplayDate } from "@repo/shared/utils";
+import { ImageResponse } from "@vercel/og";
+
+export const config = { runtime: "edge" };
+
+interface MatchPreview {
+  date: string;
+  time: string;
+  maxPlayers: number;
+  location?: { name: string } | null;
+}
+
+export default async function handler(request: Request) {
+  const apiBase = process.env.EXPO_PUBLIC_API_URL;
+  if (!apiBase) return new Response("Misconfigured", { status: 500 });
+
+  const url = new URL(request.url);
+  const rawMatchId = url.pathname.split("/og/")[1]?.split(/[/?#]/)[0];
+  if (!rawMatchId) return new Response("Bad request", { status: 400 });
+
+  let matchId: string;
+  try {
+    matchId = decodeURIComponent(rawMatchId);
+  } catch {
+    return new Response("Bad request", { status: 400 });
+  }
+
+  let match: MatchPreview;
+  try {
+    const res = await fetch(
+      `${apiBase}/api/matches/${encodeURIComponent(matchId)}/preview`,
+    );
+    if (!res.ok) return new Response("Not found", { status: 404 });
+    match = (await res.json()) as MatchPreview;
+  } catch {
+    return new Response("Upstream error", { status: 502 });
+  }
+
+  const dateLine = formatDisplayDate(match.date, "EEEE, MMMM d, yyyy");
+  const subtitle = `${match.time}hs · ${match.location?.name ?? "TBD"} · ${match.maxPlayers} players`;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "linear-gradient(135deg, #0a3d2c 0%, #1a7a55 100%)",
+          color: "white",
+          padding: 80,
+        }}
+      >
+        <div style={{ fontSize: 36, opacity: 0.85, marginBottom: 16 }}>
+          ⚽ Fútbol con los pibes
+        </div>
+        <div
+          style={{
+            fontSize: 80,
+            fontWeight: 700,
+            textAlign: "center",
+            lineHeight: 1.1,
+          }}
+        >
+          {dateLine}
+        </div>
+        <div
+          style={{
+            fontSize: 44,
+            opacity: 0.95,
+            marginTop: 32,
+            textAlign: "center",
+          }}
+        >
+          {subtitle}
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+      headers: {
+        "Cache-Control":
+          "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    },
+  );
+}

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -468,7 +468,7 @@ export default function MatchDetailScreen() {
     if (!match) return;
     const baseUrl =
       (typeof process !== "undefined" && process.env?.EXPO_PUBLIC_WEB_BASE_URL) ||
-      "https://footballwithfriends.vercel.app";
+      "https://football-with-friends.vercel.app";
     const matchUrl =
       Platform.OS === "web" && typeof window !== "undefined"
         ? window.location.href

--- a/apps/mobile-web/eas.json
+++ b/apps/mobile-web/eas.json
@@ -22,6 +22,7 @@
       "channel": "preview",
       "env": {
         "EXPO_PUBLIC_API_URL": "https://football-api-staging.pepe-grillo-parlante.workers.dev",
+        "EXPO_PUBLIC_WEB_BASE_URL": "https://football-with-friends.vercel.app",
         "EXPO_PUBLIC_ENV": "preview",
         "EXPO_PUBLIC_GOOGLE_CLIENT_ID": "114959048918-po7fdnktjj37nsflujuflfdd9vcsgut9.apps.googleusercontent.com",
         "EXPO_PUBLIC_SENTRY_DSN": "https://f6e2bd957d49ba8f9bf064a314c3fe5e@o4507997605527552.ingest.de.sentry.io/4511172311056464"
@@ -44,6 +45,7 @@
       "channel": "production",
       "env": {
         "EXPO_PUBLIC_API_URL": "https://football-api.pepe-grillo-parlante.workers.dev",
+        "EXPO_PUBLIC_WEB_BASE_URL": "https://football-with-friends.vercel.app",
         "EXPO_PUBLIC_ENV": "production",
         "EXPO_PUBLIC_GOOGLE_CLIENT_ID": "114959048918-po7fdnktjj37nsflujuflfdd9vcsgut9.apps.googleusercontent.com",
         "EXPO_PUBLIC_SENTRY_DSN": "https://f6e2bd957d49ba8f9bf064a314c3fe5e@o4507997605527552.ingest.de.sentry.io/4511172311056464",

--- a/middleware.ts
+++ b/middleware.ts
@@ -89,11 +89,7 @@ export default async function middleware(request: Request) {
     if (!res.ok) return next();
     const match = (await res.json()) as MatchResponse;
     return new Response(buildOgHtml(match, request.url, matchId), {
-      headers: {
-        "Content-Type": "text/html; charset=utf-8",
-        "Cache-Control":
-          "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
-      },
+      headers: { "Content-Type": "text/html; charset=utf-8" },
     });
   } catch {
     return next();

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,7 @@
-import { formatDisplayDate } from "@repo/shared/utils";
 import { next } from "@vercel/functions";
+import { formatInTimeZone } from "date-fns-tz";
+
+const APP_TIMEZONE = process.env.DEFAULT_TIMEZONE || "Europe/Berlin";
 
 export const config = {
   matcher: "/matches/:matchId*",
@@ -29,7 +31,9 @@ function buildOgHtml(
   matchId: string,
 ): string {
   const locationName = escapeHtml(match.location?.name || "TBD");
-  const date = escapeHtml(formatDisplayDate(match.date, "EEEE, MMMM d, yyyy"));
+  const date = escapeHtml(
+    formatInTimeZone(match.date, APP_TIMEZONE, "EEEE, MMMM d, yyyy"),
+  );
   const time = escapeHtml(match.time);
   const title = `Football Match - ${date}`;
   const description = `${time}hs | ${locationName} | ${match.maxPlayers} players`;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,3 +1,4 @@
+import { formatDisplayDate } from "@repo/shared/utils";
 import { next } from "@vercel/functions";
 
 export const config = {
@@ -15,17 +16,6 @@ function escapeHtml(str: string): string {
     .replace(/"/g, "&quot;");
 }
 
-function formatDate(dateStr: string): string {
-  const [y, m, d] = dateStr.split("-");
-  const date = new Date(Number(y), Number(m) - 1, Number(d));
-  return date.toLocaleDateString("en-US", {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
-}
-
 interface MatchResponse {
   date: string;
   time: string;
@@ -33,14 +23,20 @@ interface MatchResponse {
   location?: { name: string } | null;
 }
 
-function buildOgHtml(match: MatchResponse, pageUrl: string): string {
+function buildOgHtml(
+  match: MatchResponse,
+  pageUrl: string,
+  matchId: string,
+): string {
   const locationName = escapeHtml(match.location?.name || "TBD");
-  const date = escapeHtml(formatDate(match.date));
+  const date = escapeHtml(formatDisplayDate(match.date, "EEEE, MMMM d, yyyy"));
   const time = escapeHtml(match.time);
   const title = `Football Match - ${date}`;
   const description = `${time}hs | ${locationName} | ${match.maxPlayers} players`;
   const safeUrl = escapeHtml(pageUrl);
-  const ogImage = escapeHtml(new URL("/icons/icon-512x512.png", pageUrl).toString());
+  const ogImage = escapeHtml(
+    new URL(`/api/og/${encodeURIComponent(matchId)}`, pageUrl).toString(),
+  );
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -52,8 +48,10 @@ function buildOgHtml(match: MatchResponse, pageUrl: string): string {
   <meta property="og:description" content="${description}">
   <meta property="og:url" content="${safeUrl}">
   <meta property="og:image" content="${ogImage}">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
   <meta property="og:site_name" content="Football with Friends">
-  <meta name="twitter:card" content="summary">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="${title}">
   <meta name="twitter:description" content="${description}">
   <meta name="twitter:image" content="${ogImage}">
@@ -86,8 +84,12 @@ export default async function middleware(request: Request) {
     const res = await fetch(`${apiBase}/api/matches/${encodeURIComponent(matchId)}/preview`);
     if (!res.ok) return next();
     const match = (await res.json()) as MatchResponse;
-    return new Response(buildOgHtml(match, request.url), {
-      headers: { "Content-Type": "text/html; charset=utf-8" },
+    return new Response(buildOgHtml(match, request.url, matchId), {
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        "Cache-Control":
+          "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+      },
     });
   } catch {
     return next();

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "@libsql/client": "^0.17.3",
     "@libsql/kysely-libsql": "^0.4.1",
-    "@repo/shared": "workspace:*",
     "@tanstack/react-query": "^5.100.8",
     "@vercel/functions": "^3.5.0",
     "@vercel/og": "^0.11.1",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,10 @@
   "dependencies": {
     "@libsql/client": "^0.17.3",
     "@libsql/kysely-libsql": "^0.4.1",
+    "@repo/shared": "workspace:*",
     "@tanstack/react-query": "^5.100.8",
     "@vercel/functions": "^3.5.0",
+    "@vercel/og": "^0.11.1",
     "better-auth": "^1.6.9",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,9 +22,6 @@ importers:
       '@libsql/kysely-libsql':
         specifier: ^0.4.1
         version: 0.4.1(kysely@0.28.16)
-      '@repo/shared':
-        specifier: workspace:*
-        version: link:packages/shared
       '@tanstack/react-query':
         specifier: ^5.100.8
         version: 5.100.8(react@19.2.5)
@@ -10560,7 +10557,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-color@2.1.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,12 +22,18 @@ importers:
       '@libsql/kysely-libsql':
         specifier: ^0.4.1
         version: 0.4.1(kysely@0.28.16)
+      '@repo/shared':
+        specifier: workspace:*
+        version: link:packages/shared
       '@tanstack/react-query':
         specifier: ^5.100.8
         version: 5.100.8(react@19.2.5)
       '@vercel/functions':
         specifier: ^3.5.0
         version: 3.5.0
+      '@vercel/og':
+        specifier: ^0.11.1
+        version: 0.11.1
       better-auth:
         specifier: ^1.6.9
         version: 1.6.9(@cloudflare/workers-types@4.20260502.1)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -2919,6 +2925,10 @@ packages:
   '@react-navigation/routers@7.5.3':
     resolution: {integrity: sha512-1tJHg4KKRJuQ1/EvJxatrMef3NZXEPzwUIUZ3n1yJ2t7Q97siwRtbynRpQG9/69ebbtiZ8W3ScOZF/OmhvM4Rg==}
 
+  '@resvg/resvg-wasm@2.4.0':
+    resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
+    engines: {node: '>= 10'}
+
   '@rollup/plugin-babel@5.3.1':
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
@@ -3090,6 +3100,11 @@ packages:
   '@sentry/types@10.51.0':
     resolution: {integrity: sha512-/0nTcXk82RKtGGv0mxmY56o+BE85lBuSWG9chtSEfeypvxHFyWn3D7td9rPmjboDMtytC24cYbUzx55jb2OjQA==}
     engines: {node: '>=18'}
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
 
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
@@ -3909,6 +3924,10 @@ packages:
       '@aws-sdk/credential-provider-web-identity':
         optional: true
 
+  '@vercel/og@0.11.1':
+    resolution: {integrity: sha512-02rXXRABFq1B03w3aNhcVfxkY+8Ba5QFi4ax0zS0oOiD/LL9WUd/LA7BjVPakrQmVhIBjuo2oBM5U25R9IuXMg==}
+    engines: {node: '>=16'}
+
   '@vercel/oidc@3.4.0':
     resolution: {integrity: sha512-p0sKfHkfRmMaqqDwNL4tjnX9TgRrLMlEtUjIxfrEns8pOxz1R9ztqOVI+ehqiq93/2/HnfPe/UBZkfAZwnx0UA==}
     engines: {node: '>= 20'}
@@ -4143,6 +4162,10 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -4327,6 +4350,9 @@ packages:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
 
+  camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
+
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
@@ -4506,11 +4532,28 @@ packages:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
 
+  css-background-parser@0.1.0:
+    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
+
+  css-box-shadow@1.0.0-3:
+    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
+
+  css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+
+  css-gradient-parser@0.0.17:
+    resolution: {integrity: sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==}
+    engines: {node: '>=16'}
+
   css-in-js-utils@3.1.0:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   css-tree@1.1.3:
     resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
@@ -4674,6 +4717,10 @@ packages:
 
   electron-to-chromium@1.5.349:
     resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
+
+  emoji-regex-xs@2.0.1:
+    resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
+    engines: {node: '>=10.0.0'}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -5129,6 +5176,9 @@ packages:
   fetch-nodeshim@0.4.10:
     resolution: {integrity: sha512-m6I8ALe4L4XpdETy7MJZWs6L1IVMbjs99bwbpIKphxX+0CTns4IKDWJY0LWfr4YsFjfg+z1TjzTMU8lKl8rG0w==}
 
+  fflate@0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -5374,6 +5424,10 @@ packages:
 
   hermes-parser@0.35.0:
     resolution: {integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==}
+
+  hex-rgb@4.3.0:
+    resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
+    engines: {node: '>=6'}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -5888,6 +5942,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -6398,6 +6455,12 @@ packages:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
     engines: {node: '>=18'}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
+  parse-css-color@0.2.1:
+    resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
+
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -6862,6 +6925,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  satori@0.25.0:
+    resolution: {integrity: sha512-utINfLxrYrmSnLvxFT4ZwgwWa8KOjrz7ans32V5wItgHVmzESl/9i33nE38uG0miycab8hUqQtDlOpqrIpB/iw==}
+    engines: {node: '>=16'}
+
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -7113,6 +7180,9 @@ packages:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
 
+  string.prototype.codepointat@0.2.1:
+    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
     engines: {node: '>= 0.4'}
@@ -7244,6 +7314,9 @@ packages:
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
@@ -7398,6 +7471,9 @@ packages:
   unicode-property-aliases-ecmascript@2.2.0:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
@@ -7719,6 +7795,9 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
@@ -10481,9 +10560,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-color@2.1.0': {}
 
@@ -10626,6 +10703,8 @@ snapshots:
   '@react-navigation/routers@7.5.3':
     dependencies:
       nanoid: 3.3.12
+
+  '@resvg/resvg-wasm@2.4.0': {}
 
   '@rollup/plugin-babel@5.3.1(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@2.80.0)':
     dependencies:
@@ -10787,6 +10866,11 @@ snapshots:
   '@sentry/types@10.51.0':
     dependencies:
       '@sentry/core': 10.51.0
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    dependencies:
+      fflate: 0.7.4
+      string.prototype.codepointat: 0.2.1
 
   '@sinclair/typebox@0.27.10': {}
 
@@ -14910,6 +14994,13 @@ snapshots:
     dependencies:
       '@vercel/oidc': 3.4.0
 
+  '@vercel/og@0.11.1':
+    dependencies:
+      '@resvg/resvg-wasm': 2.4.0
+      satori: 0.25.0
+    optionalDependencies:
+      sharp: 0.34.5
+
   '@vercel/oidc@3.4.0': {}
 
   '@xmldom/xmldom@0.8.13': {}
@@ -15193,6 +15284,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@0.0.8: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.25: {}
@@ -15364,6 +15457,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   camelcase@8.0.0: {}
+
+  camelize@1.0.1: {}
 
   caniuse-lite@1.0.30001791: {}
 
@@ -15574,6 +15669,14 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
+  css-background-parser@0.1.0: {}
+
+  css-box-shadow@1.0.0-3: {}
+
+  css-color-keywords@1.0.0: {}
+
+  css-gradient-parser@0.0.17: {}
+
   css-in-js-utils@3.1.0:
     dependencies:
       hyphenate-style-name: 1.1.0
@@ -15585,6 +15688,12 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       nth-check: 2.1.1
+
+  css-to-react-native@3.2.0:
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
 
   css-tree@1.1.3:
     dependencies:
@@ -15727,6 +15836,8 @@ snapshots:
       jake: 10.9.4
 
   electron-to-chromium@1.5.349: {}
+
+  emoji-regex-xs@2.0.1: {}
 
   emoji-regex@10.6.0: {}
 
@@ -16495,6 +16606,8 @@ snapshots:
 
   fetch-nodeshim@0.4.10: {}
 
+  fflate@0.7.4: {}
+
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -16743,6 +16856,8 @@ snapshots:
   hermes-parser@0.35.0:
     dependencies:
       hermes-estree: 0.35.0
+
+  hex-rgb@4.3.0: {}
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -17245,6 +17360,11 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
 
   lines-and-columns@1.2.4: {}
 
@@ -17998,6 +18118,13 @@ snapshots:
       registry-url: 6.0.1
       semver: 7.7.4
 
+  pako@0.2.9: {}
+
+  parse-css-color@0.2.1:
+    dependencies:
+      color-name: 1.1.4
+      hex-rgb: 4.3.0
+
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -18603,6 +18730,20 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  satori@0.25.0:
+    dependencies:
+      '@shuding/opentype.js': 1.4.0-beta.0
+      css-background-parser: 0.1.0
+      css-box-shadow: 1.0.0-3
+      css-gradient-parser: 0.0.17
+      css-to-react-native: 3.2.0
+      emoji-regex-xs: 2.0.1
+      escape-html: 1.0.3
+      linebreak: 1.1.0
+      parse-css-color: 0.2.1
+      postcss-value-parser: 4.2.0
+      yoga-layout: 3.2.1
+
   sax@1.6.0: {}
 
   scheduler@0.27.0: {}
@@ -18877,6 +19018,8 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
+
+  string.prototype.codepointat@0.2.1: {}
 
   string.prototype.matchall@4.0.12:
     dependencies:
@@ -19190,6 +19333,8 @@ snapshots:
 
   through@2.3.8: {}
 
+  tiny-inflate@1.0.3: {}
+
   tinyexec@1.1.2: {}
 
   tinyglobby@0.2.16:
@@ -19327,6 +19472,11 @@ snapshots:
   unicode-match-property-value-ecmascript@2.2.1: {}
 
   unicode-property-aliases-ecmascript@2.2.0: {}
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   unique-string@2.0.0:
     dependencies:
@@ -19714,6 +19864,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yoga-layout@3.2.1: {}
 
   youch-core@0.3.3:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes two regressions when sharing match links from the native app:

1. **Wrong share URL domain.** Native builds were producing `https://footballwithfriends.vercel.app/...` (no hyphens) instead of the real `https://football-with-friends.vercel.app/...`. Caused by a typo in the fallback used when `EXPO_PUBLIC_WEB_BASE_URL` is unset — and that env var was never set in `eas.json`, so every native build hit the typo. Web was unaffected because it uses `window.location.href`.
2. **No rich link preview in chat apps.** Side effect of #1 — bots scraped a non-existent domain so `middleware.ts` never ran. Also, the previous `og:image` pointed at the static PWA icon `/icons/icon-512x512.png` (512×512, wrong aspect ratio for social cards).

### Changes

- Fix the URL fallback in `apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx`.
- Add `EXPO_PUBLIC_WEB_BASE_URL` to `preview` and `production` EAS profiles so the fallback isn't load-bearing.
- New Vercel Edge function `api/og/[matchId].tsx` (using `@vercel/og`) that renders a 1200×630 PNG with date / time / location / players, fetched from the existing public `/api/matches/:id/preview` endpoint (already auth-exempt in `apps/api/src/middleware/security.ts`).
- `middleware.ts` now points `og:image` at the new endpoint, declares `og:image:width/height`, upgrades `twitter:card` to `summary_large_image`, and serves its HTML with `Cache-Control` so repeat WhatsApp/Telegram scrapes hit Vercel's CDN instead of round-tripping to the CF Worker.
- Date formatting uses `formatDisplayDate` from `@repo/shared/utils` (timezone-aware via `date-fns-tz`) instead of a hand-rolled formatter.

## Test plan

- [ ] Vercel preview deploys successfully (function build + middleware build).
- [ ] `curl -o /tmp/og.png "https://<preview-url>/api/og/<real-match-id>"` returns a 1200×630 PNG with the match details rendered.
- [ ] `curl -A "WhatsApp/2.0" "https://<preview-url>/matches/<real-match-id>"` returns HTML with `<meta property="og:image" content="https://<preview-url>/api/og/<id>">` and `twitter:card="summary_large_image"`.
- [ ] After a new EAS preview build, share a match from the native app → URL pasted into WhatsApp must be `https://football-with-friends.vercel.app/matches/<id>` and a wide rich preview card must render.
- [ ] Web sharing still works (uses `window.location.href`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)