### PR TITLE
fix(og): render emojis via twemoji loader

### DIFF
--- a/apps/api/src/routes/og.ts
+++ b/apps/api/src/routes/og.ts
@@ -31,6 +31,7 @@ app.get("/:matchId", async (c) => {
     return new ImageResponse(html, {
       width: 1200,
       height: 630,
+      emoji: "twemoji",
       headers: {
         "Cache-Control":
           "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",


### PR DESCRIPTION
## Summary
- The ⚽ emoji in the per-match OG image rendered as a "NO EMOJI" tofu because satori has no built-in emoji font.
- Enabled `workers-og`'s `emoji: "twemoji"` option, which loads the matching Twemoji SVG from the CDN at render time.

## Test plan
- [ ] After preview deploy, hit `https://<preview>/api/og/<match-id>` and confirm the ⚽ renders as a real soccer ball.
- [ ] Re-share a match link in WhatsApp; preview card shows the emoji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)