### PR TITLE
fix(admin): organizer tabs crash on mount + missing match info

### DIFF
--- a/apps/mobile-web/app/(tabs)/admin/index.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/index.tsx
@@ -28,35 +28,9 @@ import { router } from "expo-router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ScrollView, RefreshControl } from "react-native";
+import type { Match, Location, Court } from "@repo/shared/domain";
 
 type Tab = "matches" | "locations" | "courts" | "settings" | "voting";
-
-interface Match {
-  id: string;
-  date: string;
-  time: string;
-  status: string;
-  maxPlayers: number;
-  costPerPlayer?: string;
-  location?: { name: string } | null;
-  court?: { name: string } | null;
-}
-
-interface Location {
-  id: string;
-  name: string;
-  address?: string;
-  coordinates?: string;
-  courtCount?: number;
-}
-
-interface Court {
-  id: string;
-  name: string;
-  description?: string;
-  locationId: string;
-  isActive: boolean;
-}
 
 // Extract the actual error message from API errors.
 // The custom fetch in api-client throws Error("API error: 400 ...") with

--- a/apps/mobile-web/app/(tabs)/admin/index.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/index.tsx
@@ -36,10 +36,10 @@ interface Match {
   date: string;
   time: string;
   status: string;
-  max_players: number;
-  cost_per_player?: string;
-  location_name?: string;
-  court_name?: string;
+  maxPlayers: number;
+  costPerPlayer?: string;
+  location?: { name: string } | null;
+  court?: { name: string } | null;
 }
 
 interface Location {
@@ -314,9 +314,9 @@ function MatchesTab() {
   const getStatusBadge = (status: string) => {
     switch (status) {
       case "cancelled":
-        return <Badge variant="destructive">{t("status.cancelled")}</Badge>;
-      case "played":
-        return <Badge variant="secondary">{t("status.played")}</Badge>;
+        return <Badge variant="danger">{t("status.cancelled")}</Badge>;
+      case "completed":
+        return <Badge variant="info">{t("status.completed")}</Badge>;
       default:
         return null;
     }
@@ -381,17 +381,19 @@ function MatchesTab() {
                 <XStack gap="$3">
                   <Text color="$gray11">{match.time}</Text>
                   <Text color="$gray11">
-                    {match.max_players} {t("players.title").toLowerCase()}
+                    {match.maxPlayers} {t("players.title").toLowerCase()}
                   </Text>
-                  {match.cost_per_player && <Text color="$gray11">{match.cost_per_player}</Text>}
+                  {match.costPerPlayer ? (
+                    <Text color="$gray11">{match.costPerPlayer}</Text>
+                  ) : null}
                 </XStack>
 
-                {match.location_name && (
+                {match.location?.name ? (
                   <Text fontSize="$3" color="$gray10">
-                    {match.location_name}
-                    {match.court_name && ` - ${match.court_name}`}
+                    {match.location.name}
+                    {match.court?.name ? ` - ${match.court.name}` : ""}
                   </Text>
-                )}
+                ) : null}
 
                 <YStack gap="$2" marginTop="$2">
                   <XStack gap="$2">
@@ -695,7 +697,7 @@ function LocationsTab() {
                 <Text fontSize="$5" fontWeight="600">
                   {location.name}
                 </Text>
-                {location.address && <Text color="$gray11">{location.address}</Text>}
+                {location.address ? <Text color="$gray11">{location.address}</Text> : null}
                 <XStack gap="$2" marginTop="$2">
                   <Button
                     flex={1}
@@ -1040,14 +1042,14 @@ function CourtsTab() {
                   <Text fontSize="$5" fontWeight="600">
                     {court.name}
                   </Text>
-                  {!court.isActive && <Badge variant="secondary">{t("status.inactive")}</Badge>}
+                  {!court.isActive && <Badge variant="default">{t("status.inactive")}</Badge>}
                 </XStack>
                 <Text color="$gray11">{getLocationName(court.locationId)}</Text>
-                {court.description && (
+                {court.description ? (
                   <Text fontSize="$3" color="$gray10">
                     {court.description}
                   </Text>
-                )}
+                ) : null}
                 <XStack gap="$2" marginTop="$2">
                   <Button
                     flex={1}
@@ -1705,7 +1707,7 @@ function VotingCriteriaTab() {
                     {getName(c)}
                   </Text>
                   <XStack alignItems="center" gap="$2">
-                    <Badge variant={c.isActive ? "default" : "secondary"}>
+                    <Badge variant={c.isActive ? "success" : "default"}>
                       {c.isActive ? t("status.active") : t("status.inactive")}
                     </Badge>
                     <Text color="$gray10" fontSize="$2">

--- a/apps/mobile-web/app/(tabs)/admin/roster.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/roster.tsx
@@ -269,7 +269,7 @@ export default function AdminRosterScreen() {
                       </Text>
                     ) : null}
                   </YStack>
-                  <Badge variant={entry.claimedByUserId ? "success" : "secondary"}>
+                  <Badge variant={entry.claimedByUserId ? "success" : "default"}>
                     {entry.claimedByUserId
                       ? t("groups.roster.claimed")
                       : t("groups.roster.unclaimed")}

--- a/packages/ui/src/components/Badge.tsx
+++ b/packages/ui/src/components/Badge.tsx
@@ -29,7 +29,7 @@ export function Badge({ variant = "default", children, ...props }: BadgeProps) {
       color: "$blue11",
     },
   };
-  const { color, backgroundColor } = variantStyles[variant];
+  const { color, backgroundColor } = variantStyles[variant] ?? variantStyles.default;
 
   return (
     <XStack


### PR DESCRIPTION
## Summary
- **LocationsTab / CourtsTab crash**: Tamagui's dev-only `View` check called `console.error("Unexpected text node…", props)` when a child was a stray empty string. LogBox then `JSON.stringify`'d the props (which contain React fiber refs to live `HTMLDivElement`s) and threw a misleading `TypeError: Converting circular structure to JSON`, killing the screen. Trigger: `value && <Text>` patterns over nullable fields stored as `""` in the DB (`location.address`, `court.description`, `match.cost_per_player`, `match.location_name`). Replaced with `value ? … : null` so empty strings short-circuit cleanly.
- **Missing match metadata**: the local `Match` interface in `admin/index.tsx` used snake_case (`max_players`, `cost_per_player`, `location_name`, `court_name`) but the API returns camelCase plus nested `location`/`court` objects, so match cards silently rendered without player count, cost, or venue. Fixed the interface and JSX to read `match.maxPlayers`, `match.costPerPlayer`, `match.location?.name`, `match.court?.name`.
- **Badge runtime fallback** (`packages/ui/src/components/Badge.tsx`): defensive `?? variantStyles.default` so a stray variant string can't crash the screen — mobile-web has typecheck disabled (Tamagui type recursion), so this is the only line of defense.
- **Badge variant call sites**: replaced invalid `"destructive"` / `"secondary"` (and a dead `case "played"`) at every admin call site with the supported variants — sweep covers `admin/index.tsx` and `admin/roster.tsx`.

## Test plan
- [x] `pnpm dev:app` → log in as organizer → Organizer Dashboard
- [x] **Matches** tab renders with player count, cost, location/court names
- [x] **Locations** tab renders without crash; Edit dialog opens
- [x] **Courts** tab renders without crash; Add Court dialog with Location Select inside it works
- [x] **Match Voting** tab renders; Add Criteria dialog opens
- [x] **Settings** tab renders
- [x] **Roster** screen renders; unclaimed entries show neutral Badge
- [x] **Add Match** form: Location Select dropdown opens
- [x] **Edit Match**: Status select shows Upcoming/Cancelled/Completed
- [x] No console errors during the walkthrough
- [ ] Post-deploy: monitor Sentry issue `FOOTBALL-MOBILE-D` for 24h — expect zero new events

🤖 Generated with [Claude Code](https://claude.com/claude-code)