### PR TITLE
fix(profile): send bearer token on picture upload + bump version

### DIFF
--- a/apps/mobile-web/app.config.ts
+++ b/apps/mobile-web/app.config.ts
@@ -5,7 +5,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Football with Friends",
   slug: "football-with-friends",
   owner: "pepegrillo",
-  version: "1.3.3",
+  version: "1.3.4",
   scheme: "football-with-friends",
   orientation: "portrait",
   icon: "./assets/icon.png",
@@ -69,7 +69,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     supportsTablet: false,
     bundleIdentifier: "com.pepegrillo.football-with-friends",
     usesAppleSignIn: true,
-    buildNumber: "24",
+    buildNumber: "25",
     infoPlist: {
       NSPhotoLibraryUsageDescription:
         "Football with Friends uses your photo library to update your profile picture.",
@@ -79,7 +79,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   },
   android: {
     package: "com.pepegrillo.footballwithfriends",
-    versionCode: 10,
+    versionCode: 11,
     adaptiveIcon: {
       foregroundImage: "./assets/adaptive-icon.png",
       backgroundColor: "#ffffff",

--- a/apps/mobile-web/app/(tabs)/profile/index.tsx
+++ b/apps/mobile-web/app/(tabs)/profile/index.tsx
@@ -228,6 +228,7 @@ export default function ProfileScreen() {
   const handleUploadPhoto = async () => {
     if (!session?.user) return;
 
+    const token = getBearerToken();
     try {
       const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
       if (!permissionResult.granted) {
@@ -264,7 +265,6 @@ export default function ProfileScreen() {
       }
       const apiUrl = getConfiguredApiUrl();
       const headers = new Headers();
-      const token = getBearerToken();
       if (token) headers.set("Authorization", `Bearer ${token}`);
 
       const uploadRes = await fetch(`${apiUrl}/api/profile/upload-picture`, {
@@ -301,7 +301,11 @@ export default function ProfileScreen() {
     } catch (err) {
       Sentry.captureException(err, {
         tags: { source: "profile-upload" },
-        extra: { platform: Platform.OS },
+        extra: {
+          platform: Platform.OS,
+          hasBearerToken: Boolean(token),
+          errorMessage: err instanceof Error ? err.message : String(err),
+        },
       });
       setError(t("profile.uploadFailed"));
       console.error("Upload photo error:", err);

--- a/apps/mobile-web/app/(tabs)/profile/index.tsx
+++ b/apps/mobile-web/app/(tabs)/profile/index.tsx
@@ -1,5 +1,13 @@
 // @ts-nocheck - Tamagui type recursion workaround
-import { useSession, signOut, client, getConfiguredApiUrl, getWebAppUrl } from "@repo/api-client";
+import {
+  useSession,
+  signOut,
+  client,
+  getConfiguredApiUrl,
+  getWebAppUrl,
+  getBearerToken,
+} from "@repo/api-client";
+import * as Sentry from "@sentry/react-native";
 import {
   Container,
   Card,
@@ -255,15 +263,30 @@ export default function ProfileScreen() {
         } as any);
       }
       const apiUrl = getConfiguredApiUrl();
+      const headers = new Headers();
+      const token = getBearerToken();
+      if (token) headers.set("Authorization", `Bearer ${token}`);
+
       const uploadRes = await fetch(`${apiUrl}/api/profile/upload-picture`, {
         method: "POST",
         body: formData,
-        credentials: "include",
+        headers,
+        credentials: token ? "omit" : "include",
       });
 
       const data = await uploadRes.json();
 
       if (!uploadRes.ok) {
+        Sentry.captureMessage("Profile picture upload failed", {
+          level: "error",
+          tags: { source: "profile-upload" },
+          extra: {
+            status: uploadRes.status,
+            error: data?.error,
+            hasBearerToken: Boolean(token),
+            platform: Platform.OS,
+          },
+        });
         setError(data.error || t("profile.uploadFailed"));
         return;
       }
@@ -276,6 +299,10 @@ export default function ProfileScreen() {
 
       await refetchSession();
     } catch (err) {
+      Sentry.captureException(err, {
+        tags: { source: "profile-upload" },
+        extra: { platform: Platform.OS },
+      });
       setError(t("profile.uploadFailed"));
       console.error("Upload photo error:", err);
     } finally {


### PR DESCRIPTION
## Summary
- Profile-picture upload relied on cookie credentials, which fail on native (auth uses bearer tokens). Attach the `Authorization` header when a bearer token is present and switch `credentials` to `"omit"` in that case.
- Capture upload failures and exceptions to Sentry (`source=profile-upload`) with `status`, `error`, `hasBearerToken`, and `platform` so recurrences are diagnosable.
- Bump app version to **1.3.4** (iOS build 25, Android versionCode 11).

## Test plan
- [ ] Native (iOS / Android) build with the new version: open Profile → change profile picture → upload succeeds
- [ ] Web: profile-picture upload still works (cookie path)
- [ ] Force a failure (e.g. revoke token) and confirm Sentry receives an event under tag `source=profile-upload` with `hasBearerToken` and `platform` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)