### PR TITLE
feat(matches): allow group members to invite friends

### DIFF
--- a/apps/api/src/routes/matches.ts
+++ b/apps/api/src/routes/matches.ts
@@ -306,8 +306,14 @@ app.post(
     const user = sessionUserToUser(sessionUser);
     const current = requireCurrentGroup(c);
 
+    // PAID/SUBSTITUTE are organizer-managed states — force PENDING for
+    // members so they can't fake-mark a guest as paid or pre-place them on
+    // the substitute list. Service still auto-promotes to SUBSTITUTE when
+    // the match is full, regardless of caller role.
+    const input = isCurrentOrganizer(c) ? body : { ...body, status: "PENDING" as const };
+
     try {
-      const signup = await getMatchService().addGuestPlayer(current.id, matchId, body, user);
+      const signup = await getMatchService().addGuestPlayer(current.id, matchId, input, user);
       return c.json({ signup }, 201);
     } catch (error) {
       if (error instanceof RosterMemberCollisionError) {

--- a/apps/api/src/routes/matches.ts
+++ b/apps/api/src/routes/matches.ts
@@ -297,13 +297,11 @@ app.post(
     const matchId = c.req.param("id");
     const body = c.req.valid("json");
 
-    // Organizer-only: the `rosterId` branch could be safely open to members,
-    // but the `guestName` branch writes to `group_roster`, which is an
-    // organizer-managed table. Gating the whole endpoint keeps roster
-    // authorship consistent with the rest of the roster CRUD.
-    const denied = requireOrganizer(c);
-    if (denied) return denied;
-
+    // Open to any group member: members can invite friends to a match. The
+    // inline `guestName` branch creates a roster entry tagged with
+    // `createdByUserId = inviter`, so authorship is preserved even though
+    // members can now write to `group_roster` via this path. Roster CRUD
+    // outside this endpoint remains organizer-only.
     const sessionUser = requireUser(c);
     const user = sessionUserToUser(sessionUser);
     const current = requireCurrentGroup(c);

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -487,7 +487,11 @@ export default function MatchDetailScreen() {
     if (isPlayed) return [];
 
     const isOwn = player.userId === userId;
-    const canAct = isAdmin || isOwn;
+    // Inviters can manage the guest signups they added (cancel/rejoin) —
+    // mirrors the backend authz at match-service.ts updateSignup, where
+    // `addedByUserId === updatedBy.id` grants update rights.
+    const isInviter = !!userId && player.addedByUserId === userId;
+    const canAct = isAdmin || isOwn || isInviter;
 
     if (!canAct) return [];
 
@@ -912,7 +916,6 @@ export default function MatchDetailScreen() {
 
                 <PlayersTable
                   players={buildPlayerRows()}
-                  isAdmin={isAdmin}
                   emptyMessage={t("players.noPlayers")}
                   statusLabels={statusLabels}
                   guestLabel={t("players.guest")}

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -883,8 +883,9 @@ export default function MatchDetailScreen() {
             </Pressable>
           )}
 
-          {/* View B: Participating or Played Match - Show Players Table */}
-          {(isParticipating || isPlayed || isAdmin) && (
+          {/* View B: Players table — visible to any logged-in group member,
+              plus anyone for played matches (preserves prior public behavior). */}
+          {(userId || isPlayed) && (
             <Card variant="elevated">
               <YStack gap="$2">
                 <XStack
@@ -896,7 +897,7 @@ export default function MatchDetailScreen() {
                   <Text fontSize="$6" fontWeight="bold">
                     {t("players.title")}
                   </Text>
-                  {!isPlayed && isOrganizer && match.availableSpots > 0 && (
+                  {!isPlayed && !isCancelled && userId && match.availableSpots > 0 && (
                     <Button
                       variant="outline"
                       size="$3"
@@ -1038,26 +1039,28 @@ export default function MatchDetailScreen() {
         showActions={false}
       >
         <YStack gap="$3" padding="$4" maxHeight={560}>
-          <XStack gap="$2">
-            <Button
-              flex={1}
-              variant={guestMode === "pick" ? "primary" : "outline"}
-              onPress={() => setGuestMode("pick")}
-              testID="guest-mode-pick"
-            >
-              {t("groups.roster.guestPickerTitle")}
-            </Button>
-            <Button
-              flex={1}
-              variant={guestMode === "quick" ? "primary" : "outline"}
-              onPress={() => setGuestMode("quick")}
-              testID="guest-mode-quick"
-            >
-              {t("groups.roster.quickAddTitle")}
-            </Button>
-          </XStack>
+          {isOrganizer && (
+            <XStack gap="$2">
+              <Button
+                flex={1}
+                variant={guestMode === "pick" ? "primary" : "outline"}
+                onPress={() => setGuestMode("pick")}
+                testID="guest-mode-pick"
+              >
+                {t("groups.roster.guestPickerTitle")}
+              </Button>
+              <Button
+                flex={1}
+                variant={guestMode === "quick" ? "primary" : "outline"}
+                onPress={() => setGuestMode("quick")}
+                testID="guest-mode-quick"
+              >
+                {t("groups.roster.quickAddTitle")}
+              </Button>
+            </XStack>
+          )}
 
-          {guestMode === "pick" ? (
+          {isOrganizer && guestMode === "pick" ? (
             <>
               <Input
                 placeholder={t("groups.roster.guestPickerSearch")}

--- a/packages/ui/src/components/PlayersTable.tsx
+++ b/packages/ui/src/components/PlayersTable.tsx
@@ -32,7 +32,6 @@ export interface PlayerRow {
 
 export interface PlayersTableProps {
   players: PlayerRow[];
-  isAdmin?: boolean;
   emptyMessage?: string;
   statusLabels?: Record<PlayerStatusType, string>;
   guestLabel?: string;
@@ -41,7 +40,6 @@ export interface PlayersTableProps {
 
 export function PlayersTable({
   players,
-  isAdmin = false,
   emptyMessage = "No players signed up yet",
   statusLabels,
   guestLabel = "Guest",
@@ -54,8 +52,6 @@ export function PlayersTable({
       </Text>
     );
   }
-
-  const canShowActions = (player: PlayerRow) => isAdmin || !!player.isCurrentUser;
 
   const getStatusLabel = (status: PlayerStatusType) => statusLabels?.[status] ?? status;
 
@@ -86,9 +82,7 @@ export function PlayersTable({
 
   const renderPlayerRow = (player: PlayerRow) => {
     const actions =
-      canShowActions(player) && player.actions && player.actions.length > 0
-        ? player.actions
-        : undefined;
+      player.actions && player.actions.length > 0 ? player.actions : undefined;
 
     const trailing = (
       <>


### PR DESCRIPTION
## Summary
- Open up the "Invite a friend" button on a match to any group member (previously organizer/admin only). The action is gated by `!isPlayed && !isCancelled && userId && match.availableSpots > 0`.
- Drop `requireOrganizer` from `POST /api/matches/:id/guest` only — all other guest/roster routes remain organizer-gated. Service-layer authorship is preserved (`group_roster.created_by_user_id`, `signups.guest_owner_id`, `signups.added_by_user_id` all carry the inviter id), and the match-status + member-collision checks still apply.
- Hide the pick-from-roster branch of the guest dialog for non-organizers — that branch depends on the organizer-only `GET /api/groups/:id/roster`. Members see the inline-create form directly.
- Widen the players-table card so any logged-in group member can see it on upcoming matches (it was previously gated to participants/organizers).

## Test plan
End-to-end verified locally as a non-organizer member of `grp_legacy` against `pnpm dev`:
- [x] Member sees the "Invite a friend" button on an upcoming match with available spots
- [x] Dialog opens with the inline-create form only (no pick/quick toggle, no roster list)
- [x] Submitting a guest name yields a 201 and the player row appears as "(Friend) — Pending"
- [x] DB authorship preserved: roster row's `created_by_user_id` and signup's `guest_owner_id` / `added_by_user_id` all match the inviter
- [x] Button is hidden when the match status is `cancelled`
- [x] No new typecheck or lint errors in the edited files

🤖 Generated with [Claude Code](https://claude.com/claude-code)