### PR TITLE
feat(ui): shared RefreshableScrollView for pull-to-refresh

### DIFF
--- a/apps/mobile-web/app/(tabs)/admin/index.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/index.tsx
@@ -21,13 +21,13 @@ import {
   Spinner,
   Dialog,
   AlertDialog,
+  RefreshableScrollView,
   useToastController,
   isValidPhoneNumber,
 } from "@repo/ui";
 import { router } from "expo-router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ScrollView, RefreshControl } from "react-native";
 import type { Match, Location, Court } from "@repo/shared/domain";
 
 type Tab = "matches" | "locations" | "courts" | "settings" | "voting";
@@ -305,10 +305,11 @@ function MatchesTab() {
   }
 
   return (
-    <ScrollView
+    <RefreshableScrollView
       backgroundColor="$background"
       style={{ flex: 1 }}
-      refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
+      refreshing={isRefetching}
+      onRefresh={refetch}
     >
       <YStack gap="$3" paddingBottom="$6">
         {/* Add Match Button */}
@@ -479,7 +480,7 @@ function MatchesTab() {
           }
         }}
       />
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }
 
@@ -629,10 +630,11 @@ function LocationsTab() {
   }
 
   return (
-    <ScrollView
+    <RefreshableScrollView
       backgroundColor="$background"
       style={{ flex: 1 }}
-      refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
+      refreshing={isRefetching}
+      onRefresh={refetch}
     >
       <YStack gap="$3" paddingBottom="$6">
         {/* Add Location Button */}
@@ -819,7 +821,7 @@ function LocationsTab() {
           </YStack>
         </Dialog>
       </YStack>
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }
 
@@ -986,10 +988,11 @@ function CourtsTab() {
   }
 
   return (
-    <ScrollView
+    <RefreshableScrollView
       backgroundColor="$background"
       style={{ flex: 1 }}
-      refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
+      refreshing={isRefetching}
+      onRefresh={refetch}
     >
       <YStack gap="$3" paddingBottom="$6">
         {/* Add Court Button */}
@@ -1134,7 +1137,7 @@ function CourtsTab() {
           }}
         />
       </YStack>
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }
 
@@ -1284,10 +1287,11 @@ function SettingsTab() {
   }
 
   return (
-    <ScrollView
+    <RefreshableScrollView
       backgroundColor="$background"
       style={{ flex: 1 }}
-      refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
+      refreshing={isRefetching}
+      onRefresh={refetch}
     >
       <YStack gap="$3" paddingBottom="$6">
         {/* Cost Settings */}
@@ -1362,7 +1366,7 @@ function SettingsTab() {
         {/* Password Reset Codes */}
         <ResetCodesSection />
       </YStack>
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }
 
@@ -1650,10 +1654,11 @@ function VotingCriteriaTab() {
   }
 
   return (
-    <ScrollView
+    <RefreshableScrollView
       backgroundColor="$background"
       style={{ flex: 1 }}
-      refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
+      refreshing={isRefetching}
+      onRefresh={refetch}
     >
       <YStack gap="$3" paddingBottom="$6">
         {/* Add Criteria Button */}
@@ -1868,6 +1873,6 @@ function VotingCriteriaTab() {
           }}
         />
       </YStack>
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }

--- a/apps/mobile-web/app/(tabs)/admin/roster.tsx
+++ b/apps/mobile-web/app/(tabs)/admin/roster.tsx
@@ -16,6 +16,7 @@ import {
   Container,
   Dialog,
   Input,
+  RefreshableScrollView,
   Spinner,
   Text,
   YStack,
@@ -195,7 +196,11 @@ export default function AdminRosterScreen() {
 
   return (
     <Container variant="padded">
-      <ScrollView>
+      <RefreshableScrollView
+        onRefresh={async () => {
+          await Promise.all([rosterQuery.refetch(), membersQuery.refetch()]);
+        }}
+      >
         <YStack gap="$4" paddingBottom="$6">
           <Card>
             <YStack padding="$4" gap="$3">
@@ -279,7 +284,7 @@ export default function AdminRosterScreen() {
             ))
           )}
         </YStack>
-      </ScrollView>
+      </RefreshableScrollView>
 
       {/* Edit dialog */}
       <Dialog

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/gallery.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/gallery.tsx
@@ -10,21 +10,23 @@ import {
   authFetchInit,
 } from "@repo/api-client";
 import type { MatchMedia, ReactionEmoji } from "@repo/shared/domain";
-import { Container, MediaGrid, MediaLightbox, Text, YStack, XStack, Button } from "@repo/ui";
+import {
+  Container,
+  MediaGrid,
+  MediaLightbox,
+  RefreshableScrollView,
+  Text,
+  YStack,
+  XStack,
+  Button,
+} from "@repo/ui";
 import { useLocalSearchParams } from "expo-router";
 import * as ImageManipulator from "expo-image-manipulator";
 import * as ImagePicker from "expo-image-picker";
 import * as VideoThumbnails from "expo-video-thumbnails";
 import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  ActionSheetIOS,
-  Alert,
-  Platform,
-  Pressable,
-  RefreshControl,
-  ScrollView,
-} from "react-native";
+import { ActionSheetIOS, Alert, Platform, Pressable } from "react-native";
 import { Plus } from "@tamagui/lucide-icons-2";
 
 const PHOTO_MAX_BYTES = 10 * 1024 * 1024;
@@ -276,9 +278,7 @@ export default function MatchGalleryScreen() {
   return (
     <>
       <Container variant="padded">
-        <ScrollView
-          refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
-        >
+        <RefreshableScrollView refreshing={isRefetching} onRefresh={refetch}>
           <XStack justifyContent="flex-end" marginBottom="$3">
             {canUpload && (
               <Button
@@ -300,7 +300,7 @@ export default function MatchGalleryScreen() {
           ) : (
             <MediaGrid items={items} onItemPress={(_, i) => setLightboxIndex(i)} />
           )}
-        </ScrollView>
+        </RefreshableScrollView>
       </Container>
       <MediaLightbox
         items={items}

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -25,6 +25,7 @@ import {
   StatusBadge,
   PlayersTable,
   List,
+  RefreshableScrollView,
   type PlayerRow,
   type PlayerAction,
   type PlayerStatusType,
@@ -46,7 +47,7 @@ import { Image } from "expo-image";
 import { useLocalSearchParams, router } from "expo-router";
 import { useMemo, useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
-import { Platform, Pressable, RefreshControl, ScrollView, Share, Linking } from "react-native";
+import { Platform, Pressable, ScrollView, Share, Linking } from "react-native";
 
 import {
   getGoogleCalendarUrl,
@@ -650,10 +651,11 @@ export default function MatchDetailScreen() {
 
   return (
     <Container variant="padded">
-      <ScrollView
+      <RefreshableScrollView
         style={{ flex: 1 }}
         showsVerticalScrollIndicator={false}
-        refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
+        refreshing={isRefetching}
+        onRefresh={refetch}
       >
         <YStack gap="$3" paddingBottom="$6">
           {/* Match Header Card */}
@@ -944,7 +946,7 @@ export default function MatchDetailScreen() {
             {t("matchDetail.viewRules")}
           </Button>
         </YStack>
-      </ScrollView>
+      </RefreshableScrollView>
 
       {/* Join Modal with Payment Info and Rules */}
       <Dialog

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/stats.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/stats.tsx
@@ -16,13 +16,14 @@ import {
   Button,
   Spinner,
   AwardCard,
+  RefreshableScrollView,
   useToastController,
 } from "@repo/ui";
 import { Beer, CheckCircle2, Lock, Unlock } from "@tamagui/lucide-icons-2";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Alert, RefreshControl, ScrollView } from "react-native";
+import { Alert } from "react-native";
 
 import type { MatchStats } from "@repo/shared/domain";
 
@@ -170,10 +171,7 @@ export default function MatchStatsScreen() {
       )}
 
       {stats && (
-        <ScrollView
-          style={{ flex: 1 }}
-          refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
-        >
+        <RefreshableScrollView style={{ flex: 1 }} refreshing={isRefetching} onRefresh={refetch}>
           <YStack gap="$3" paddingBottom="$6">
             {/* Status banner */}
             <Card variant="elevated">
@@ -318,7 +316,7 @@ export default function MatchStatsScreen() {
               </Card>
             )}
           </YStack>
-        </ScrollView>
+        </RefreshableScrollView>
       )}
     </Container>
   );

--- a/apps/mobile-web/app/(tabs)/matches/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/index.tsx
@@ -1,10 +1,19 @@
 import { useInfiniteQuery, client, useSession, useCurrentGroup } from "@repo/api-client";
-import { Container, Card, Text, YStack, XStack, Spinner, Tabs, Button } from "@repo/ui";
+import {
+  Container,
+  Card,
+  Text,
+  YStack,
+  XStack,
+  Spinner,
+  Tabs,
+  Button,
+  RefreshableScrollView,
+} from "@repo/ui";
 import { Plus, BookOpen } from "@tamagui/lucide-icons-2";
 import { router, Stack } from "expo-router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { RefreshControl, ScrollView } from "react-native";
 import { formatMatchDateTime } from "../../../lib/date-utils";
 
 type MatchType = "upcoming" | "past";
@@ -83,10 +92,11 @@ export default function MatchesListScreen() {
           />
         </YStack>
 
-        <ScrollView
+        <RefreshableScrollView
           style={{ flex: 1 }}
           showsVerticalScrollIndicator={false}
-          refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
+          refreshing={isRefetching}
+          onRefresh={refetch}
         >
           <YStack gap="$3" paddingBottom="$4">
             {isLoading && (
@@ -193,7 +203,7 @@ export default function MatchesListScreen() {
               </Button>
             )}
           </YStack>
-        </ScrollView>
+        </RefreshableScrollView>
 
         {/* Admin FAB — visible to platform admins and group organizers */}
         {canManage && (

--- a/apps/mobile-web/app/(tabs)/profile/groups/[groupId].tsx
+++ b/apps/mobile-web/app/(tabs)/profile/groups/[groupId].tsx
@@ -20,6 +20,7 @@ import {
   Card,
   Container,
   MembersTable,
+  RefreshableScrollView,
   type MemberRow,
   isValidPhoneNumber,
   useToastController,
@@ -372,7 +373,11 @@ export default function GroupDetailScreen() {
 
   return (
     <Container>
-      <ScrollView>
+      <RefreshableScrollView
+        onRefresh={async () => {
+          await Promise.all([refetch(), invitesQuery.refetch()]);
+        }}
+      >
         <YStack padding="$4" gap="$4">
           <YStack gap="$1">
             <Text fontSize="$7" fontWeight="700">
@@ -589,7 +594,7 @@ export default function GroupDetailScreen() {
             </Button>
           )}
         </YStack>
-      </ScrollView>
+      </RefreshableScrollView>
 
       {/* Delete-group confirm */}
       <AlertDialog

--- a/apps/mobile-web/app/(tabs)/profile/groups/index.tsx
+++ b/apps/mobile-web/app/(tabs)/profile/groups/index.tsx
@@ -1,14 +1,15 @@
 // @ts-nocheck - Tamagui type recursion workaround
-import { useCurrentGroup } from "@repo/api-client";
-import { Container } from "@repo/ui";
+import { groupQueryKeys, useCurrentGroup, useQueryClient } from "@repo/api-client";
+import { Container, RefreshableScrollView } from "@repo/ui";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
-import { Pressable, ScrollView } from "react-native";
+import { Pressable } from "react-native";
 import { Spinner, Text, XStack, YStack } from "tamagui";
 
 export default function MyGroupsScreen() {
   const { t } = useTranslation();
   const { myGroups: groups, groupId, switchGroup, isLoading } = useCurrentGroup();
+  const queryClient = useQueryClient();
 
   if (isLoading) {
     return (
@@ -28,7 +29,9 @@ export default function MyGroupsScreen() {
 
   return (
     <Container>
-      <ScrollView>
+      <RefreshableScrollView
+        onRefresh={() => queryClient.invalidateQueries({ queryKey: groupQueryKeys.me() })}
+      >
         <YStack padding="$4" gap="$3">
           {groups.map((g) => {
             const badge = g.amIOwner
@@ -72,7 +75,7 @@ export default function MyGroupsScreen() {
             );
           })}
         </YStack>
-      </ScrollView>
+      </RefreshableScrollView>
     </Container>
   );
 }

--- a/apps/mobile-web/app/(tabs)/profile/index.tsx
+++ b/apps/mobile-web/app/(tabs)/profile/index.tsx
@@ -25,6 +25,7 @@ import {
   COUNTRIES,
   PhoneInput,
   AlertDialog,
+  RefreshableScrollView,
   getCountryFlag,
   getCountryName,
 } from "@repo/ui";
@@ -33,7 +34,7 @@ import * as ImagePicker from "expo-image-picker";
 import { Link, router, Stack } from "expo-router";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { ScrollView, RefreshControl, Pressable, Platform, Alert, Linking } from "react-native";
+import { ScrollView, Pressable, Platform, Alert, Linking } from "react-native";
 import Constants from "expo-constants";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -57,7 +58,6 @@ export default function ProfileScreen() {
   const [isSaving, setIsSaving] = useState(false);
   const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isRefreshing, setIsRefreshing] = useState(false);
 
   // Password change state
   const [currentPassword, setCurrentPassword] = useState("");
@@ -94,12 +94,6 @@ export default function ProfileScreen() {
   const handleLanguageChange = async (lang: "en" | "es") => {
     await changeLanguage(lang);
     setCurrentLanguage(lang);
-  };
-
-  const handleRefresh = async () => {
-    setIsRefreshing(true);
-    await refetchSession();
-    setIsRefreshing(false);
   };
 
   const handleSaveProfile = async () => {
@@ -384,10 +378,10 @@ export default function ProfileScreen() {
         }}
       />
       <Container variant="padded" paddingTop={insets.top + 16}>
-        <ScrollView
+        <RefreshableScrollView
           showsVerticalScrollIndicator={false}
           contentContainerStyle={{ paddingBottom: 24 }}
-          refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
+          onRefresh={refetchSession}
         >
           <YStack gap="$4">
             {/* Profile Card with Inline Editing */}
@@ -715,7 +709,7 @@ export default function ProfileScreen() {
               </YStack>
             </Card>
           </YStack>
-        </ScrollView>
+        </RefreshableScrollView>
 
         {/* Password Change Confirmation Dialog */}
         <AlertDialog

--- a/apps/mobile-web/app/(tabs)/profile/notifications.tsx
+++ b/apps/mobile-web/app/(tabs)/profile/notifications.tsx
@@ -1,10 +1,11 @@
 // @ts-nocheck - Tamagui type recursion workaround
 
-import { Card, Container, Text } from "@repo/ui";
+import { notificationPreferencesQueryKeys, useQueryClient } from "@repo/api-client";
+import { Card, Container, RefreshableScrollView, Text } from "@repo/ui";
 import { Settings } from "@tamagui/lucide-icons-2";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Linking, Platform, ScrollView } from "react-native";
+import { Linking, Platform } from "react-native";
 import { Spinner, Switch, XStack, YStack } from "tamagui";
 
 import { NotificationPermissionPrompt } from "../../../components/notifications/notification-permission-prompt";
@@ -38,6 +39,7 @@ const CATEGORIES: {
 export default function NotificationsScreen() {
   const { t } = useTranslation();
   const notif = useNotificationPreferencesContext();
+  const queryClient = useQueryClient();
   const [promptOpen, setPromptOpen] = useState(false);
 
   if (Platform.OS === "web") {
@@ -78,7 +80,14 @@ export default function NotificationsScreen() {
 
   return (
     <Container>
-      <ScrollView>
+      <RefreshableScrollView
+        onRefresh={async () => {
+          await Promise.all([
+            queryClient.invalidateQueries({ queryKey: notificationPreferencesQueryKeys.all }),
+            notif.refreshOsStatus(),
+          ]);
+        }}
+      >
         <YStack padding="$4" gap="$4">
           <Card variant="outlined">
             <YStack gap="$3">
@@ -155,7 +164,7 @@ export default function NotificationsScreen() {
             </YStack>
           </Card>
         </YStack>
-      </ScrollView>
+      </RefreshableScrollView>
 
       <NotificationPermissionPrompt open={promptOpen} onClose={() => setPromptOpen(false)} />
     </Container>

--- a/apps/mobile-web/app/(tabs)/social/[userId].tsx
+++ b/apps/mobile-web/app/(tabs)/social/[userId].tsx
@@ -12,10 +12,10 @@ import {
   H2,
   VotingStatsSection,
   getCountryFlag,
+  RefreshableScrollView,
 } from "@repo/ui";
 import { useLocalSearchParams } from "expo-router";
 import { useTranslation } from "react-i18next";
-import { RefreshControl, ScrollView } from "react-native";
 
 interface MatchPlayerStat {
   id: string;
@@ -116,10 +116,7 @@ export default function PlayerDetailScreen() {
 
   return (
     <Container variant="padded">
-      <ScrollView
-        style={{ flex: 1 }}
-        refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
-      >
+      <RefreshableScrollView style={{ flex: 1 }} refreshing={isRefetching} onRefresh={refetch}>
         <YStack gap="$4" paddingBottom="$6">
           {/* Player Header */}
           <Card variant="elevated">
@@ -245,7 +242,7 @@ export default function PlayerDetailScreen() {
             </Card>
           )}
         </YStack>
-      </ScrollView>
+      </RefreshableScrollView>
     </Container>
   );
 }

--- a/apps/mobile-web/app/(tabs)/social/multimedia/index.tsx
+++ b/apps/mobile-web/app/(tabs)/social/multimedia/index.tsx
@@ -3,9 +3,9 @@ import { api, useInfiniteQuery } from "@repo/api-client";
 import { router, Stack } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { ChevronRight, Play } from "@tamagui/lucide-icons-2";
-import { Pressable, RefreshControl, ScrollView, View } from "react-native";
+import { Pressable, View } from "react-native";
 import { Image } from "expo-image";
-import { Container, Text, YStack, XStack, Card } from "@repo/ui";
+import { Container, Text, YStack, XStack, Card, RefreshableScrollView } from "@repo/ui";
 import { formatDisplayDate } from "@repo/shared/utils";
 import type { MatchMedia, MatchMediaFeedGroup } from "@repo/shared/domain";
 
@@ -86,8 +86,9 @@ export default function MultimediaFeedScreen() {
     <>
       <Stack.Screen options={{ title: t("multimedia.title") }} />
       <Container variant="padded">
-        <ScrollView
-          refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
+        <RefreshableScrollView
+          refreshing={isRefetching}
+          onRefresh={refetch}
           onScroll={({ nativeEvent }) => {
             const { layoutMeasurement, contentOffset, contentSize } = nativeEvent;
             const atBottom = layoutMeasurement.height + contentOffset.y >= contentSize.height - 80;
@@ -150,7 +151,7 @@ export default function MultimediaFeedScreen() {
               )}
             </YStack>
           )}
-        </ScrollView>
+        </RefreshableScrollView>
       </Container>
     </>
   );

--- a/apps/mobile-web/app/(tabs)/social/stats.tsx
+++ b/apps/mobile-web/app/(tabs)/social/stats.tsx
@@ -13,11 +13,11 @@ import {
   RankingCard,
   PodiumDisplay,
   AwardCard,
+  RefreshableScrollView,
 } from "@repo/ui";
 import { router } from "expo-router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { RefreshControl, ScrollView } from "react-native";
 
 export default function PlayersStatsScreen() {
   const { t } = useTranslation();
@@ -110,9 +110,10 @@ export default function PlayersStatsScreen() {
             />
           </YStack>
 
-          <ScrollView
+          <RefreshableScrollView
             style={{ flex: 1 }}
-            refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
+            refreshing={isRefetching}
+            onRefresh={refetch}
           >
             <YStack gap="$3" paddingBottom="$4">
               {isLoading && (
@@ -160,7 +161,7 @@ export default function PlayersStatsScreen() {
                   />
                 ))}
             </YStack>
-          </ScrollView>
+          </RefreshableScrollView>
         </>
       )}
 
@@ -177,11 +178,10 @@ export default function PlayersStatsScreen() {
             />
           </YStack>
 
-          <ScrollView
+          <RefreshableScrollView
             style={{ flex: 1 }}
-            refreshControl={
-              <RefreshControl refreshing={isRefetchingRankings} onRefresh={refetchRankings} />
-            }
+            refreshing={isRefetchingRankings}
+            onRefresh={refetchRankings}
           >
             <YStack gap="$3" paddingBottom="$4">
               {isLoadingRankings && (
@@ -250,17 +250,16 @@ export default function PlayersStatsScreen() {
                 </>
               )}
             </YStack>
-          </ScrollView>
+          </RefreshableScrollView>
         </>
       )}
 
       {/* Awards Tab */}
       {activeTab === "awards" && (
-        <ScrollView
+        <RefreshableScrollView
           style={{ flex: 1 }}
-          refreshControl={
-            <RefreshControl refreshing={isRefetchingLeaderboard} onRefresh={refetchLeaderboard} />
-          }
+          refreshing={isRefetchingLeaderboard}
+          onRefresh={refetchLeaderboard}
         >
           <YStack gap="$3" paddingBottom="$4">
             {isLoadingLeaderboard && (
@@ -318,7 +317,7 @@ export default function PlayersStatsScreen() {
                 />
               ))}
           </YStack>
-        </ScrollView>
+        </RefreshableScrollView>
       )}
     </Container>
   );

--- a/apps/mobile-web/components/notifications/notification-inbox.tsx
+++ b/apps/mobile-web/components/notifications/notification-inbox.tsx
@@ -4,6 +4,7 @@ import { Spinner, Text, YStack } from "@repo/ui";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { FlatList, RefreshControl } from "react-native";
+import { useTheme } from "tamagui";
 
 import { InboxEmpty } from "./inbox-empty";
 import { InboxRow } from "./inbox-row";
@@ -14,6 +15,7 @@ interface NotificationInboxProps {
 
 export function NotificationInbox({ onItemPress }: NotificationInboxProps) {
   const { t } = useTranslation();
+  const theme = useTheme();
   const { data, isLoading, isRefetching, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useNotifications();
 
@@ -34,7 +36,7 @@ export function NotificationInbox({ onItemPress }: NotificationInboxProps) {
 
   if (isLoading && items.length === 0) {
     return (
-      <YStack flex={1} alignItems="center" justifyContent="center">
+      <YStack flex={1} backgroundColor="$background" alignItems="center" justifyContent="center">
         <Spinner size="large" />
       </YStack>
     );
@@ -60,6 +62,7 @@ export function NotificationInbox({ onItemPress }: NotificationInboxProps) {
       renderItem={renderItem}
       onEndReached={onEndReached}
       onEndReachedThreshold={0.3}
+      style={{ flex: 1, backgroundColor: theme.background?.val }}
       refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
       ListFooterComponent={
         isFetchingNextPage ? (

--- a/packages/ui/src/components/RefreshableScrollView.tsx
+++ b/packages/ui/src/components/RefreshableScrollView.tsx
@@ -1,0 +1,43 @@
+import { forwardRef, useCallback, useState } from "react";
+import type { ScrollView as RNScrollView, ScrollViewProps } from "react-native";
+import { RefreshControl, ScrollView } from "react-native";
+
+export type RefreshableScrollViewProps = ScrollViewProps & {
+  onRefresh?: () => Promise<unknown> | unknown;
+  refreshing?: boolean;
+};
+
+export const RefreshableScrollView = forwardRef<RNScrollView, RefreshableScrollViewProps>(
+  function RefreshableScrollView(
+    { onRefresh, refreshing, children, ...rest }: RefreshableScrollViewProps,
+    ref,
+  ) {
+    const [internalRefreshing, setInternalRefreshing] = useState(false);
+    const isControlled = refreshing !== undefined;
+    const isRefreshing = isControlled ? refreshing : internalRefreshing;
+
+    const handleRefresh = useCallback(async () => {
+      if (!onRefresh) return;
+      if (!isControlled) setInternalRefreshing(true);
+      try {
+        await onRefresh();
+      } finally {
+        if (!isControlled) setInternalRefreshing(false);
+      }
+    }, [onRefresh, isControlled]);
+
+    return (
+      <ScrollView
+        ref={ref}
+        refreshControl={
+          onRefresh ? (
+            <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />
+          ) : undefined
+        }
+        {...rest}
+      >
+        {children}
+      </ScrollView>
+    );
+  },
+);

--- a/packages/ui/src/components/RefreshableScrollView.tsx
+++ b/packages/ui/src/components/RefreshableScrollView.tsx
@@ -2,7 +2,7 @@ import { forwardRef, useCallback, useState } from "react";
 import type { ScrollView as RNScrollView, ScrollViewProps } from "react-native";
 import { RefreshControl, ScrollView } from "react-native";
 
-export type RefreshableScrollViewProps = ScrollViewProps & {
+export type RefreshableScrollViewProps = Omit<ScrollViewProps, "refreshControl"> & {
   onRefresh?: () => Promise<unknown> | unknown;
   refreshing?: boolean;
 };
@@ -29,12 +29,12 @@ export const RefreshableScrollView = forwardRef<RNScrollView, RefreshableScrollV
     return (
       <ScrollView
         ref={ref}
+        {...rest}
         refreshControl={
           onRefresh ? (
             <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />
           ) : undefined
         }
-        {...rest}
       >
         {children}
       </ScrollView>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -18,6 +18,9 @@ export type { CustomCardProps } from "./components/Card";
 export { Container } from "./components/Container";
 export type { ContainerProps } from "./components/Container";
 
+export { RefreshableScrollView } from "./components/RefreshableScrollView";
+export type { RefreshableScrollViewProps } from "./components/RefreshableScrollView";
+
 // Feedback Components
 export { Dialog } from "./components/Dialog";
 export type { CustomDialogProps } from "./components/Dialog";


### PR DESCRIPTION
## Summary
- New `RefreshableScrollView` in `@repo/ui` wraps RN's `ScrollView` + `RefreshControl`. Supports controlled mode (pass `refreshing` from `useQuery.isRefetching`) and uncontrolled mode (wrapper manages its own state, awaits the `onRefresh` promise).
- Migrated 9 screens off copy-pasted inline `RefreshControl` blocks: matches list/detail/gallery/stats, admin tabs (5 panes), social stats/[userId]/multimedia, profile.
- Added pull-to-refresh to 4 screens that previously lacked it: `admin/roster`, `profile/notifications`, `profile/groups` (list + detail).
- Home page intentionally excluded per requirement.
- Dropped the manual `isRefreshing`/`handleRefresh` state in `profile/index.tsx` — wrapper owns it now.

## Test plan
- [ ] Pull down on each migrated screen on iOS — spinner appears and clears once data resolves.
- [ ] Pull down on home — no spinner appears (excluded).
- [ ] Verify multi-query screens (admin/roster, profile/groups/[groupId], profile/notifications) refetch all relevant queries in parallel.
- [ ] Spot-check admin tabs — each of the 5 panes refreshes independently.
- [ ] Web smoke check — no console errors, scroll behaves normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)