### PR TITLE
fix(cron): complete matches 1h after kickoff, reminders 24h before

### DIFF
--- a/apps/api/src/cron/send-match-reminders.ts
+++ b/apps/api/src/cron/send-match-reminders.ts
@@ -1,4 +1,4 @@
-import { addDays } from "date-fns";
+import { sql } from "kysely";
 import { getDatabase } from "@repo/shared/database";
 import { NOTIFICATION_TYPES } from "@repo/shared/domain";
 import { getRepositoryFactory } from "@repo/shared/repositories";
@@ -8,26 +8,41 @@ import { formatDateInAppTimezone } from "@repo/shared/utils";
 
 import { recordForRecipients } from "../lib/notification-inbox";
 
+const REMINDER_LEAD_MS = 24 * 60 * 60 * 1000; // fire ~24h before kickoff
+
 /**
- * Send match reminders for matches happening tomorrow.
- * Only sends once per match (tracked via reminder_sent column).
+ * Send match reminders 24h before kickoff (e.g. an 18:00 match on day D
+ * triggers a reminder at 18:00 on day D-1, Europe/Berlin).
+ *
+ * Cron ticks every 30 min, so the actual fire time is the first tick at
+ * or after `kickoff - 24h`. Each match is reminded at most once
+ * (tracked via the `reminder_sent` column).
  */
 export async function sendMatchReminders() {
   const db = getDatabase();
 
-  // Get tomorrow's date in Europe/Berlin timezone
-  const tomorrowDate = formatDateInAppTimezone(addDays(new Date(), 1), "yyyy-MM-dd");
+  const now = new Date();
+  // Upper bound: matches kicking off at or before "now + 24h".
+  // Lower bound: matches that haven't started yet — guards against firing
+  // a stale reminder for a match still flagged "upcoming" past its kickoff.
+  const horizon = new Date(now.getTime() + REMINDER_LEAD_MS);
+  const horizonBerlin = formatDateInAppTimezone(horizon, "yyyy-MM-dd HH:mm");
+  const nowBerlin = formatDateInAppTimezone(now, "yyyy-MM-dd HH:mm");
 
-  console.log(`[CRON] Checking for matches on ${tomorrowDate} to send reminders`);
+  console.log(
+    `[CRON] Checking for matches kicking off in (${nowBerlin}, ${horizonBerlin}] (Berlin) for 24h reminders`,
+  );
 
   try {
-    // Find upcoming matches tomorrow that haven't had reminders sent
+    // Find upcoming matches whose kickoff falls in the 24h reminder window
+    // and that haven't been reminded yet.
     const matches = await db
       .selectFrom("matches")
       .selectAll()
       .where("status", "=", "upcoming")
-      .where("date", "=", tomorrowDate)
       .where("reminder_sent", "=", 0)
+      .where(sql<string>`(${sql.ref("date")} || ' ' || ${sql.ref("time")})`, ">", nowBerlin)
+      .where(sql<string>`(${sql.ref("date")} || ' ' || ${sql.ref("time")})`, "<=", horizonBerlin)
       .execute();
 
     if (matches.length === 0) {

--- a/apps/api/src/cron/update-match-statuses.ts
+++ b/apps/api/src/cron/update-match-statuses.ts
@@ -1,28 +1,33 @@
+import { sql } from "kysely";
 import { getDatabase } from "@repo/shared/database";
 import { NOTIFICATION_TYPES } from "@repo/shared/domain";
 import { getServiceFactory, NotificationTemplates } from "@repo/shared/services";
+import { formatDateInAppTimezone } from "@repo/shared/utils";
 
 import { recordForRecipients } from "../lib/notification-inbox";
+
+// Mark a match as completed once it has been underway for at least this long.
+// Stored `date` + `time` are Europe/Berlin local; cutoff is computed in the same
+// frame, so a lexicographic compare on `date || ' ' || time` is correct.
+const COMPLETION_BUFFER_MS = 60 * 60 * 1000; // 1 hour after kickoff
 
 /**
  * Update match statuses from "upcoming" to "completed"
  * and send voting reminders to participants.
  * Runs every 30 minutes via Cloudflare Cron Triggers.
  *
- * Uses native Date/Intl to stay within CF Workers CPU limits.
+ * A match is completed once `match_start + 1h <= now` in Europe/Berlin local
+ * time (i.e. ~1 hour after kickoff), independent of the calendar date.
  */
 export async function updateMatchStatuses() {
   const db = getDatabase();
 
-  // Get today's date in Europe/Berlin timezone using native Intl
-  const berlinDate = new Intl.DateTimeFormat("en-CA", {
-    timeZone: "Europe/Berlin",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(new Date()); // returns "YYYY-MM-DD"
+  // "now - 1h" formatted in Berlin local — directly comparable to stored
+  // `date` + `time` strings, which are also Berlin local.
+  const cutoff = new Date(Date.now() - COMPLETION_BUFFER_MS);
+  const cutoffBerlin = formatDateInAppTimezone(cutoff, "yyyy-MM-dd HH:mm");
 
-  console.log(`[CRON] Updating upcoming matches before ${berlinDate}`);
+  console.log(`[CRON] Completing matches with kickoff <= ${cutoffBerlin} (Berlin)`);
 
   try {
     // Find matches that will transition (for voting reminders)
@@ -30,7 +35,7 @@ export async function updateMatchStatuses() {
       .selectFrom("matches")
       .select(["id", "date", "time", "location_id", "group_id"])
       .where("status", "=", "upcoming")
-      .where("date", "<", berlinDate)
+      .where(sql<string>`(${sql.ref("date")} || ' ' || ${sql.ref("time")})`, "<=", cutoffBerlin)
       .execute();
 
     // Update statuses
@@ -41,7 +46,7 @@ export async function updateMatchStatuses() {
         updated_at: new Date().toISOString(),
       })
       .where("status", "=", "upcoming")
-      .where("date", "<", berlinDate)
+      .where(sql<string>`(${sql.ref("date")} || ' ' || ${sql.ref("time")})`, "<=", cutoffBerlin)
       .execute();
 
     const updated = Number(result[0]?.numUpdatedRows ?? 0);


### PR DESCRIPTION
## Summary
- **Match completion** (`update-match-statuses.ts`): previously compared only the match `date` against today (Berlin), so a 17:30 kickoff stayed `upcoming` until the next calendar day. Now compares `(date || ' ' || time)` against `now − 1h` in Berlin local — a 17:30 match transitions to `completed` at the next `*/30` tick at or after 18:30.
- **24h reminders** (`send-match-reminders.ts`): previously fired the instant `now + 24h` rolled into the match's date, i.e. at midnight Berlin. Now fires when kickoff falls in `(now, now + 24h]` Berlin local — an 18:00 kickoff on day D triggers its reminder at the 18:00 tick on day D−1, exactly as users expect.
- Both compares use a lexicographic string compare against `formatDateInAppTimezone(..., "yyyy-MM-dd HH:mm")`. Stored `time` is zero-padded `HH:MM` (validated in `match-service.ts`), so the compare is chronologically correct and DST-safe.
- The lower bound (`now <`) on the reminder query also guards against firing a stale reminder for a match still flagged `upcoming` past its kickoff.
- `reminder_sent` still ensures one push per match.

## Test plan
- [ ] `pnpm --filter api typecheck` (already green locally)
- [ ] Deploy to preview (`pnpm cf:deploy:preview` from `apps/api`) and tail Workers logs for the next `*/30` cron tick — confirm the new log lines:
  - `[CRON] Completing matches with kickoff <= YYYY-MM-DD HH:MM (Berlin)`
  - `[CRON] Checking for matches kicking off in (..., ...] (Berlin) for 24h reminders`
- [ ] Seed a test match with a kickoff ~5 min in the past and confirm it is marked `completed` at the next cron tick (not at midnight).
- [ ] Seed a test match with a kickoff ~24h in the future and confirm the reminder is sent on the next tick where `kickoff − now ≤ 24h` (and not earlier).
- [ ] Verify already-completed matches and already-reminded matches are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)