### PR TITLE
fix(stats): drop signups fan-out from third-time, beer, and summary queries

### DIFF
--- a/packages/shared/src/repositories/turso-repositories.ts
+++ b/packages/shared/src/repositories/turso-repositories.ts
@@ -1277,7 +1277,10 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
   }
 
   async getAllPlayerSummaries(): Promise<PlayerSummary[]> {
-    // Get all users who have at least one non-cancelled signup
+    // Aggregate signups and match_player_stats independently in CTEs, then
+    // join. Joining the raw tables and grouping by user multiplies every
+    // signup row by every stats row (and vice versa), which inflates
+    // total_goals and total_third_times by the user's signup count.
     const rows = await sql<{
       user_id: string;
       user_name: string;
@@ -1290,6 +1293,20 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
       total_goals: number;
       total_third_times: number;
     }>`
+      WITH user_match_counts AS (
+        SELECT user_id, COUNT(DISTINCT match_id) AS total_matches
+        FROM signups
+        WHERE status = 'PAID'
+        GROUP BY user_id
+      ),
+      user_stats AS (
+        SELECT
+          user_id,
+          SUM(goals) AS total_goals,
+          SUM(third_time_attended) AS total_third_times
+        FROM match_player_stats
+        GROUP BY user_id
+      )
       SELECT
         u.id as user_id,
         u.name as user_name,
@@ -1298,14 +1315,13 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
         u.displayUsername as display_username,
         u.nationality,
         u.profilePicture as profile_picture,
-        COUNT(DISTINCT s.match_id) as total_matches,
-        COALESCE(SUM(mps.goals), 0) as total_goals,
-        COALESCE(SUM(mps.third_time_attended), 0) as total_third_times
+        umc.total_matches,
+        COALESCE(us.total_goals, 0) as total_goals,
+        COALESCE(us.total_third_times, 0) as total_third_times
       FROM user u
-      INNER JOIN signups s ON u.id = s.user_id AND s.status = 'PAID'
-      LEFT JOIN match_player_stats mps ON u.id = mps.user_id
-      GROUP BY u.id
-      ORDER BY total_matches DESC, u.name ASC
+      INNER JOIN user_match_counts umc ON u.id = umc.user_id
+      LEFT JOIN user_stats us ON u.id = us.user_id
+      ORDER BY umc.total_matches DESC, u.name ASC
     `.execute(this.db);
 
     return rows.rows.map((row) => {
@@ -1396,6 +1412,10 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
   }
 
   async getRankingsByThirdTimes(groupId: string, limit: number): Promise<PlayerRanking[]> {
+    // Restrict to users who have at least one PAID signup in the group via
+    // EXISTS (semi-join). Joining `signups` directly would multiply each
+    // `match_player_stats` row by the user's paid-signup count and inflate
+    // the SUM.
     const rows = await sql<{
       user_id: string;
       user_name: string;
@@ -1415,11 +1435,14 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
         u.displayUsername as display_username,
         u.nationality,
         u.profilePicture as profile_picture,
-        COALESCE(SUM(mps.third_time_attended), 0) as value,
-        ROW_NUMBER() OVER (ORDER BY COALESCE(SUM(mps.third_time_attended), 0) DESC, u.name ASC) as rank
+        SUM(mps.third_time_attended) as value,
+        ROW_NUMBER() OVER (ORDER BY SUM(mps.third_time_attended) DESC, u.name ASC) as rank
       FROM user u
-      INNER JOIN signups s ON u.id = s.user_id AND s.status = 'PAID' AND s.group_id = ${groupId}
-      LEFT JOIN match_player_stats mps ON u.id = mps.user_id AND mps.group_id = ${groupId}
+      INNER JOIN match_player_stats mps ON u.id = mps.user_id AND mps.group_id = ${groupId}
+      WHERE EXISTS (
+        SELECT 1 FROM signups s
+        WHERE s.user_id = u.id AND s.status = 'PAID' AND s.group_id = ${groupId}
+      )
       GROUP BY u.id
       HAVING value > 0
       ORDER BY rank ASC
@@ -1445,6 +1468,8 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
   }
 
   async getRankingsByBeers(groupId: string, limit: number): Promise<PlayerRanking[]> {
+    // See note in getRankingsByThirdTimes: EXISTS instead of joining signups
+    // to avoid fanning out match_player_stats rows.
     const rows = await sql<{
       user_id: string;
       user_name: string;
@@ -1464,11 +1489,14 @@ export class TursoPlayerStatsRepository implements PlayerStatsRepository {
         u.displayUsername as display_username,
         u.nationality,
         u.profilePicture as profile_picture,
-        COALESCE(SUM(mps.third_time_beers), 0) as value,
-        ROW_NUMBER() OVER (ORDER BY COALESCE(SUM(mps.third_time_beers), 0) DESC, u.name ASC) as rank
+        SUM(mps.third_time_beers) as value,
+        ROW_NUMBER() OVER (ORDER BY SUM(mps.third_time_beers) DESC, u.name ASC) as rank
       FROM user u
-      INNER JOIN signups s ON u.id = s.user_id AND s.status = 'PAID' AND s.group_id = ${groupId}
-      LEFT JOIN match_player_stats mps ON u.id = mps.user_id AND mps.group_id = ${groupId}
+      INNER JOIN match_player_stats mps ON u.id = mps.user_id AND mps.group_id = ${groupId}
+      WHERE EXISTS (
+        SELECT 1 FROM signups s
+        WHERE s.user_id = u.id AND s.status = 'PAID' AND s.group_id = ${groupId}
+      )
       GROUP BY u.id
       HAVING value > 0
       ORDER BY rank ASC


### PR DESCRIPTION
## Summary

The Tercer Tiempo and Cervezas Consumidas rankings — and the totals on the all-player summary screen — were inflated by the user's paid-signup count. A player with 6 paid matches and 4 attended tercer tiempos / 8 beers was showing up as 24 third times / 48 beers.

**Root cause.** Three queries joined \`signups\` and \`match_player_stats\` in the same \`FROM\` clause and grouped by \`user.id\`. Each \`signups\` row created a copy of every \`match_player_stats\` row for that user, so any \`SUM\` over a \`match_player_stats\` column was multiplied by N = user's paid-signup count.

**Fixes.**

- \`getRankingsByThirdTimes\` / \`getRankingsByBeers\` — replace the multiplying \`INNER JOIN signups\` with a \`WHERE EXISTS\` semi-join. Same filter intent (only rank users with at least one PAID signup in the group), no row fan-out. Drops the now-redundant \`LEFT JOIN\` + \`COALESCE\` since \`HAVING value > 0\` already excludes users without \`match_player_stats\` rows.
- \`getAllPlayerSummaries\` — pre-aggregate \`signups\` (paid match counts) and \`match_player_stats\` (goals, third-time attendances) in CTEs, then join by \`user_id\`. Each side groups itself before the join, so neither can fan out the other.

\`getRankingsByMatches\` was already correct (\`COUNT(DISTINCT s.match_id)\` deduplicates), as are \`getRankingsByTotalVotes\` (no \`signups\` join) and the per-user \`getPlayerSummary\` (separate \`WHERE\`-only queries on each table).

## Test plan

- [ ] \`pnpm --filter @repo/shared typecheck\` and \`pnpm --filter api typecheck\` (both green locally)
- [ ] Pick a known active player and compare in the DB:
  - [ ] \`SELECT SUM(third_time_attended), SUM(third_time_beers) FROM match_player_stats WHERE user_id = '<id>' AND group_id = '<gid>'\` should match what the rankings UI shows.
  - [ ] Same player's PAID signup count (\`SELECT COUNT(DISTINCT match_id) FROM signups WHERE user_id = '<id>' AND status = 'PAID'\`) should equal the "matches played" cell on the all-player summary screen.
- [ ] In the mobile app, open the Tercer Tiempo and Cervezas rankings and confirm the numbers shrank to plausible per-match values.
- [ ] Confirm a user with multiple PAID signups but no \`match_player_stats\` rows is excluded from the third-time / beer rankings (HAVING value > 0).
- [ ] Confirm a user with PAID signups but never went to the tercer tiempo still appears on the all-player summary with \`total_third_times = 0\`, \`total_goals = 0\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)