### PR TITLE
fix(matches): native crash on join confirmation + honest upload feedback

### DIFF
--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/gallery.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/gallery.tsx
@@ -44,6 +44,9 @@ export default function MatchGalleryScreen() {
   // Avoid touching state after the user navigates away mid-upload.
   const mountedRef = useRef(true);
   useEffect(() => {
+    // Reset on (re)mount so a StrictMode double-invoke doesn't leave the ref
+    // stuck false — otherwise the upload's finally would skip setUploading(false).
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
     };

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/gallery.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/gallery.tsx
@@ -19,12 +19,13 @@ import {
   YStack,
   XStack,
   Button,
+  Spinner,
 } from "@repo/ui";
 import { useLocalSearchParams } from "expo-router";
 import * as ImageManipulator from "expo-image-manipulator";
 import * as ImagePicker from "expo-image-picker";
 import * as VideoThumbnails from "expo-video-thumbnails";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { ActionSheetIOS, Alert, Platform, Pressable } from "react-native";
 import { Plus } from "@tamagui/lucide-icons-2";
@@ -39,6 +40,14 @@ export default function MatchGalleryScreen() {
   const qc = useQueryClient();
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
   const [uploading, setUploading] = useState(false);
+
+  // Avoid touching state after the user navigates away mid-upload.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const { data, refetch, isRefetching } = useQuery({
     queryKey: ["matchMedia", matchId],
@@ -202,7 +211,7 @@ export default function MatchGalleryScreen() {
       console.error("upload error", e);
       Alert.alert(t("multimedia.errors.uploadFailed"));
     } finally {
-      setUploading(false);
+      if (mountedRef.current) setUploading(false);
     }
   };
 
@@ -283,13 +292,13 @@ export default function MatchGalleryScreen() {
             {canUpload && (
               <Button
                 size="$3"
-                icon={<Plus size={16} />}
+                icon={uploading ? <Spinner size="small" /> : <Plus size={16} />}
                 onPress={openUpload}
                 disabled={uploading}
                 accessibilityLabel={t("a11y.uploadMedia")}
                 testID="gallery-upload-btn"
               >
-                {uploading ? t("multimedia.uploading", { percent: 0 }) : t("multimedia.upload")}
+                {uploading ? t("multimedia.uploading") : t("multimedia.upload")}
               </Button>
             )}
           </XStack>

--- a/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
+++ b/apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx
@@ -1150,7 +1150,16 @@ export default function MatchDetailScreen() {
         variant="default"
         showCancel={false}
       >
-        <Trans i18nKey="matchDetail.confirmationMessage" />
+        <Trans
+          i18nKey="matchDetail.confirmationMessage"
+          components={{
+            // Map to RN-safe Tamagui Text. Custom tag names (not basic HTML
+            // like <br>/<p>) so react-i18next renders them only via these
+            // components — never as native-invalid DOM nodes.
+            para: <Text fontSize="$4" color="$gray11" />,
+            bold: <Text fontSize="$4" color="$gray11" fontWeight="bold" />,
+          }}
+        />
       </AlertDialog>
 
       {/* Cancel Confirmation Alert */}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -75,7 +75,7 @@
     "cancelSpotMessage": "Are you sure you want to cancel your spot? You can rejoin later if you change your mind.",
     "confirmCancel": "Yes, cancel spot",
     "confirmation": "Confirmation",
-    "confirmationMessage": "Thank you for signing up! Remember that confirmation is done with payment.<br/><br/>Important: Payment on match day has a 2 Euro surcharge. Please don't forget.<br/><br/>For each day without paying after the match there will be a 1 Euro penalty!",
+    "confirmationMessage": "<para>Thank you for signing up! Remember that confirmation is done with payment.</para><para><bold>Important:</bold> Payment on match day has a 2 Euro surcharge. Please don't forget.</para><para>For each day without paying after the match there will be a 1 Euro penalty!</para>",
     "acceptConditions": "Accept conditions",
     "editName": "Edit Name",
     "playerName": "Player Name",
@@ -645,7 +645,7 @@
   "multimedia": {
     "title": "Multimedia",
     "upload": "Upload",
-    "uploading": "Uploading… {{percent}}%",
+    "uploading": "Uploading…",
     "captionPlaceholder": "Add a caption (optional)",
     "post": "Post",
     "cancel": "Cancel",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -76,7 +76,7 @@
     "cancelSpotMessage": "¿Estás seguro que querés cancelar tu lugar? Podés volver a anotarte más tarde si cambiás de opinión.",
     "confirmCancel": "Sí, cancelar lugar",
     "confirmation": "Confirmación",
-    "confirmationMessage": "¡Gracias por anotarte! Acordate que la confirmación se hace con el pago.<br/><br/>Importante: El pago el día del partido tiene un sobrecargo de 2 Euros. Por favor no te olvides.<br/><br/>Por cada día sin pagar posterior al partido habrá una penalización de 1 Euro!",
+    "confirmationMessage": "<para>¡Gracias por anotarte! Acordate que la confirmación se hace con el pago.</para><para><bold>Importante:</bold> El pago el día del partido tiene un sobrecargo de 2 Euros. Por favor no te olvides.</para><para>Por cada día sin pagar posterior al partido habrá una penalización de 1 Euro!</para>",
     "acceptConditions": "Aceptar condiciones",
     "editName": "Editar Nombre",
     "playerName": "Nombre del Jugador",
@@ -648,7 +648,7 @@
   "multimedia": {
     "title": "Multimedia",
     "upload": "Subir",
-    "uploading": "Subiendo… {{percent}}%",
+    "uploading": "Subiendo…",
     "captionPlaceholder": "Agregá un comentario (opcional)",
     "post": "Publicar",
     "cancel": "Cancelar",

--- a/packages/ui/src/components/AlertDialog.tsx
+++ b/packages/ui/src/components/AlertDialog.tsx
@@ -85,9 +85,11 @@ export function AlertDialog({
             )}
 
             {children && (
-              <TamaguiAlertDialog.Description fontSize="$4" color="$gray11" asChild>
-                <div>{children}</div>
-              </TamaguiAlertDialog.Description>
+              // Render arbitrary body content in a cross-platform container.
+              // A literal <div> crashes on React Native (unknown host component),
+              // and only the children path hit it — every other caller uses the
+              // `description` string prop above.
+              <YStack gap="$2">{children}</YStack>
             )}
           </YStack>
 

--- a/packages/ui/src/components/AlertDialog.tsx
+++ b/packages/ui/src/components/AlertDialog.tsx
@@ -86,10 +86,13 @@ export function AlertDialog({
 
             {children && (
               // Render arbitrary body content in a cross-platform container.
-              // A literal <div> crashes on React Native (unknown host component),
-              // and only the children path hit it — every other caller uses the
-              // `description` string prop above.
-              <YStack gap="$2">{children}</YStack>
+              // `asChild` keeps the dialog's accessible description association
+              // (aria-describedby on web) while delegating to a YStack — a
+              // literal <div> here crashes on React Native (unknown host
+              // component). Children supply their own text styling.
+              <TamaguiAlertDialog.Description asChild>
+                <YStack gap="$2">{children}</YStack>
+              </TamaguiAlertDialog.Description>
             )}
           </YStack>
 


### PR DESCRIPTION
## What & why

Two native-only bugs in the matches flow, reported by the user. Both were diagnosed via systematic debugging and verified end-to-end on the iOS simulator.

### 1. App crashes when joining a match
The signup succeeds server-side (you're registered when you re-open), but the app crashes immediately after.

**Root cause:** `AlertDialog` rendered its `children` inside a literal `<div>` (`AlertDialog.tsx`). `<div>` is not a registered React Native host component, so it hard-crashes on native (web tolerates it). The post-signup **confirmation modal is the only `AlertDialog` that passes `children`** — every other caller uses the `description` string prop — so it was the sole place hitting the crashing path, right after a successful signup.

**Fix:** replace the `<div>` with a cross-platform `YStack`. Also render the confirmation message via react-i18next `<Trans components={{…}}>` mapped to RN-safe `Text` (custom `<para>`/`<bold>` tags) instead of `<br/>` (also invalid on native) — this restores the paragraph breaks and bolds "Important:".

### 2. Photo upload stuck at "Uploading… 0%"
**Root cause:** the percent was hardcoded to `0` and `fetch()` emits no upload-progress events, so the label could never move — a misleading "stuck at 0%" during a genuinely slow upload.

**Fix:** honest indeterminate `Spinner` + "Uploading…" (removed the fake `{{percent}}` from the i18n strings), plus an unmount guard so navigating away mid-upload doesn't set state on an unmounted screen.

## Verification (iOS simulator, native)
- Join → `POST …/signup` `201`, signup persisted, **confirmation modal renders without crashing**.
- Confirmation shows three spaced paragraphs with **"Important:" bold**.
- Gallery renders with no regression; upload button shows the correct idle/loading states.
- `oxlint`: 0 errors on changed files.

## Files
- `packages/ui/src/components/AlertDialog.tsx` — `<div>` → `YStack`
- `apps/mobile-web/app/(tabs)/matches/[matchId]/index.tsx` — `<Trans>` with RN-safe components
- `apps/mobile-web/app/(tabs)/matches/[matchId]/gallery.tsx` — honest spinner + unmount guard
- `locales/en/common.json`, `locales/es/common.json` — `confirmationMessage` tags + drop fake percent

🤖 Generated with [Claude Code](https://claude.com/claude-code)