### PR TITLE
chore(mobile): bump version to 1.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ docs/superpowers/
 apps/mobile-web/build-*.ipa
 apps/mobile-web/build-*.aab
 apps/mobile-web/build-*.apk
+apps/mobile-web/builds/
 
 # Wrangler-generated Cloudflare Worker types (regenerate with `wrangler types`)
 apps/api/worker-configuration.d.ts

--- a/apps/api/src/config/app-versions.ts
+++ b/apps/api/src/config/app-versions.ts
@@ -5,13 +5,13 @@
 // `apps/mobile-web/app.config.ts`.
 export const APP_VERSIONS = {
   ios: {
-    version: "1.3.8",
-    buildNumber: 30,
+    version: "1.4.0",
+    buildNumber: 31,
     storeUrl: "https://apps.apple.com/us/app/fulbo-with-friends/id6759833737",
   },
   android: {
-    version: "1.3.8",
-    versionCode: 16,
+    version: "1.4.0",
+    versionCode: 17,
     storeUrl:
       "https://play.google.com/store/apps/details?id=com.pepegrillo.footballwithfriends",
   },

--- a/apps/mobile-web/app.config.ts
+++ b/apps/mobile-web/app.config.ts
@@ -5,7 +5,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Football with Friends",
   slug: "football-with-friends",
   owner: "pepegrillo",
-  version: "1.3.8",
+  version: "1.4.0",
   scheme: "football-with-friends",
   orientation: "portrait",
   icon: "./assets/icon.png",
@@ -76,7 +76,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     supportsTablet: false,
     bundleIdentifier: "com.pepegrillo.football-with-friends",
     usesAppleSignIn: true,
-    buildNumber: "30",
+    buildNumber: "31",
     infoPlist: {
       NSPhotoLibraryUsageDescription:
         "Football with Friends uses your photo library to update your profile picture.",
@@ -86,7 +86,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   },
   android: {
     package: "com.pepegrillo.footballwithfriends",
-    versionCode: 16,
+    versionCode: 17,
     adaptiveIcon: {
       foregroundImage: "./assets/adaptive-icon.png",
       backgroundColor: "#ffffff",


### PR DESCRIPTION
## Summary
- Bump app version **1.3.8 → 1.4.0** (minor release)
- iOS `buildNumber` 30 → 31, Android `versionCode` 16 → 17
- Keep `apps/api/src/config/app-versions.ts` (in-app "update available" banner) in sync with `app.config.ts` — both now point at 1.4.0
- Gitignore `apps/mobile-web/builds/` so the local `.aab`/`.ipa` artifacts stay out of git and the EAS upload archive

## Context
Production cloud builds for both platforms are already queued on EAS (iOS `e4fe8e90`, Android `60aa1fc5`) and will be submitted to the App Store + Play Store internal track once they finish.

> ⚠️ The `app-versions.ts` bump drives the in-app update banner. It only takes effect once the **API is redeployed to Cloudflare** — and points users at 1.4.0, so the store builds should be live before/around the API deploy.

## Test plan
- [ ] `pnpm check:app-versions` passes (enforced by pre-commit hook — green)
- [ ] EAS builds 1.4.0 (31 / 17) complete successfully
- [ ] Builds submitted and live on both stores
- [ ] API redeployed so the update banner reflects 1.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)